### PR TITLE
Ensure that the first Gradle build succeeds.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -259,6 +259,8 @@ tasks.register<JavaExec>("fusiondocGen") {
     args = listOf("document", fusiondocDir.asFile.path, "fusion")
 
     enableAssertions = true
+
+    outputs.dir(fusiondocDir)
 }
 
 val fusiondoc by tasks.register<Copy>("fusiondoc") {


### PR DESCRIPTION
This lets Gradle know where the Fusion docs are generated.  When it doesn't know about them, Gradle may consider them "stale" and remove them, causing a unit test to fail.