### PR TITLE
Update .editorconfig re line length and indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,18 +4,17 @@ end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = true
-max_line_length = 120
+max_line_length = 100
 tab_width = 4
 ij_continuation_indent_size = 8
 ij_formatter_off_tag = @formatter:off
 ij_formatter_on_tag = @formatter:on
-ij_formatter_tags_enabled = false
+ij_formatter_tags_enabled = true
 ij_smart_tabs = false
-ij_visual_guides = 80,100,120
+ij_visual_guides = 79,100
 ij_wrap_on_typing = false
 
 [*.css]
-ij_visual_guides = none
 ij_css_align_closing_brace_with_properties = false
 ij_css_blank_lines_around_nested_selector = 1
 ij_css_blank_lines_between_blocks = 1
@@ -35,9 +34,6 @@ ij_css_use_double_quotes = true
 ij_css_value_alignment = do_not_align
 
 [*.java]
-max_line_length = 100
-ij_continuation_indent_size = 4
-ij_visual_guides = 80,100,120
 ij_java_align_consecutive_assignments = true
 ij_java_align_consecutive_variable_declarations = true
 ij_java_align_group_field_declarations = true
@@ -289,14 +285,12 @@ ij_java_wrap_first_method_in_call_chain = false
 ij_java_wrap_long_lines = false
 
 [*.properties]
-ij_visual_guides = none
 ij_properties_align_group_field_declarations = false
 ij_properties_keep_blank_lines = false
 ij_properties_key_value_delimiter = equals
 ij_properties_spaces_around_key_value_delimiter = false
 
 [.editorconfig]
-ij_visual_guides = none
 ij_editorconfig_align_group_field_declarations = false
 ij_editorconfig_space_after_colon = false
 ij_editorconfig_space_after_comma = true
@@ -305,7 +299,6 @@ ij_editorconfig_space_before_comma = false
 ij_editorconfig_spaces_around_assignment_operators = true
 
 [{*.ant,*.fxml,*.jhm,*.jnlp,*.jrxml,*.pom,*.rng,*.tld,*.wsdl,*.xml,*.xsd,*.xsl,*.xslt,*.xul}]
-ij_visual_guides = none
 ij_xml_align_attributes = true
 ij_xml_align_text = false
 ij_xml_attribute_wrap = normal
@@ -326,7 +319,6 @@ ij_xml_text_wrap = normal
 [{*.bash,*.sh,*.zsh,build,current_platform,guard,rspec}]
 indent_size = 2
 tab_width = 2
-ij_visual_guides = none
 ij_shell_binary_ops_start_line = false
 ij_shell_keep_column_alignment_padding = false
 ij_shell_minify_program = false
@@ -335,14 +327,14 @@ ij_shell_switch_cases_indented = false
 ij_shell_use_unix_line_separator = true
 
 [{*.fusion,*.ion}]
-ij_visual_guides = none
+indent_size = 2
+tab_width = 2
 ij_ion_keep_indents_on_empty_lines = false
 ij_ion_label_indent_absolute = false
 ij_ion_label_indent_size = 0
 ij_ion_use_relative_indents = false
 
 [{*.htm,*.html,*.sht,*.shtm,*.shtml}]
-ij_visual_guides = none
 ij_html_add_new_line_before_tags = body,div,p,form,h1,h2,h3
 ij_html_align_attributes = true
 ij_html_align_text = false
@@ -370,7 +362,8 @@ ij_html_space_inside_empty_tag = false
 ij_html_text_wrap = normal
 
 [{*.markdown,*.md}]
-ij_visual_guides = none
+max_line_length = 100
+ij_visual_guides = 79,100
 ij_markdown_force_one_space_after_blockquote_symbol = true
 ij_markdown_force_one_space_after_header_symbol = true
 ij_markdown_force_one_space_after_list_bullet = true


### PR DESCRIPTION
* The first guide is at 79: if text goes to 80, the newline falls on column 81 and there's a bogus blank line on an 80-column terminal.
* Try as I might, I find 120 columns too wide for side-by-side diffs or editor tabs. Even 100 is too wide for my 14" laptop, but for now I'll see how bad that is in practice.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
