### PR TITLE
[CI] Don't run dependency-submission workflow on forks

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,6 +41,7 @@ jobs:
 
 
   dependency-submission:
+    if: github.repository == 'ion-fusion/fusion-java'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
It's unnecessary and likely to fail.

GitHub's "Dependency Graph" is not enabled by default, and there's really no point in spending user minutes on this.

See, for example: https://github.com/toddjonker/fusion-java/actions/runs/12284446454

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
