### PR TITLE
Remove Amazon-specific documentation in `/fusion/module` docs

### DIFF
--- a/fusion/src/fusion/module.fusion
+++ b/fusion/src/fusion/module.fusion
@@ -219,7 +219,7 @@ That hierarchy is reserved for exclusive use by the Fusion platform.
 We recommend that all user code be placed in modules that follow a naming
 convention similar to Java packages. For example, code that in Java would be
 under the package `org.example.company.project` would be in the module
-`/org/example/company/project` in a fusion package.
+`/org/example/company/project` in a Fusion package.
 
 [fusion]:  fusion.html
 [module]:  fusion/module.html#module


### PR DESCRIPTION
## Description

Cleans out Amazon-specific recommendations and internal links from the `/fusion/module` documentation.


## Related Issues

https://github.com/ion-fusion/fusion-java/issues/23

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
