### PR TITLE
Split workflows to avoid uploading dependency graphs from PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,17 +5,18 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
-name: Java CI with Gradle
+name: Java Build with Gradle
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - 'main'
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - 'main'
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,25 +39,3 @@ jobs:
       uses: gradle/actions/setup-gradle@v4
     - name: Build with Gradle Wrapper
       run: ./gradlew release
-
-
-  dependency-submission:
-    if: github.repository == 'ion-fusion/fusion-java'
-
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: 17
-        distribution: corretto
-
-    # Generates and submits a dependency graph, enabling Dependabot Alerts.
-    # https://github.com/gradle/actions/blob/main/dependency-submission
-    # https://github.com/gradle/github-dependency-submission-demo
-    - name: Generate and submit dependency graph
-      uses: gradle/actions/dependency-submission@v4

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,34 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will generate and upload a dependency graph of a Java project with Gradle for Dependabot to consume
+
+name: Java Dependency Graph with Gradle
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  dependency-submission:
+    if: github.repository == 'ion-fusion/fusion-java'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: corretto
+
+    # Generates and submits a dependency graph, enabling Dependabot Alerts.
+    # https://github.com/gradle/actions/blob/main/dependency-submission
+    # https://github.com/gradle/github-dependency-submission-demo
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@v4


### PR DESCRIPTION
## Description

Breaks out the dependency graph/build steps into two separate workflows, so that PRs don't upload a dependency graph.


## Related Issues

https://github.com/ion-fusion/fusion-java/issues/10
---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
