### PR TITLE
Update .editorconfig for Markdown.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -423,15 +423,22 @@ ij_html_text_wrap = normal
 
 [{*.markdown,*.md}]
 max_line_length = 100
-ij_visual_guides = 79,100
+ij_continuation_indent_size = 4
+ij_visual_guides = 100
+ij_wrap_on_typing = true
 ij_markdown_force_one_space_after_blockquote_symbol = true
 ij_markdown_force_one_space_after_header_symbol = true
 ij_markdown_force_one_space_after_list_bullet = true
 ij_markdown_force_one_space_between_words = true
+ij_markdown_format_tables = true
+ij_markdown_insert_quote_arrows_on_wrap = true
 ij_markdown_keep_indents_on_empty_lines = false
+ij_markdown_keep_line_breaks_inside_text_blocks = false
 ij_markdown_max_lines_around_block_elements = 1
 ij_markdown_max_lines_around_header = 1
 ij_markdown_max_lines_between_paragraphs = 1
 ij_markdown_min_lines_around_block_elements = 1
-ij_markdown_min_lines_around_header = 1
+ij_markdown_min_lines_around_header = 2
 ij_markdown_min_lines_between_paragraphs = 1
+ij_markdown_wrap_text_if_long = true
+ij_markdown_wrap_text_inside_blockquotes = true


### PR DESCRIPTION
This makes it tolerable to auto-format Markdown files.  The notable exception is that it can mangle code-fenced blocks, which requires some manual undo-ing.

Note that the min/max lines around things are reversed due to an IDEA bug. https://youtrack.jetbrains.com/issue/IJPL-96536/markdown-code-style-blank-line-configs-are-mixed-up

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
