### PR TITLE
Remove obsolete uses of JUnit `@AfterEach`.

### DIFF
--- a/tst/dev/ionfusion/fusion/CoreTestCase.java
+++ b/tst/dev/ionfusion/fusion/CoreTestCase.java
@@ -3,6 +3,7 @@
 
 package dev.ionfusion.fusion;
 
+import static com.amazon.ion.util.IonTextUtils.printString;
 import static dev.ionfusion.fusion.FusionNumber.isDecimal;
 import static dev.ionfusion.fusion.FusionNumber.isFloat;
 import static dev.ionfusion.fusion.FusionNumber.isInt;
@@ -12,11 +13,10 @@ import static dev.ionfusion.fusion.FusionString.isString;
 import static dev.ionfusion.fusion.FusionString.unsafeStringToJavaString;
 import static dev.ionfusion.fusion.FusionValue.isAnyNull;
 import static dev.ionfusion.fusion.FusionVoid.isVoid;
-import static com.amazon.ion.util.IonTextUtils.printString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
-import dev.ionfusion.fusion.junit.StdioTestCase;
+
 import com.amazon.ion.IonContainer;
 import com.amazon.ion.IonInt;
 import com.amazon.ion.IonList;
@@ -26,6 +26,7 @@ import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonText;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.system.IonSystemBuilder;
+import dev.ionfusion.fusion.junit.StdioTestCase;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.file.Path;
@@ -33,7 +34,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 public class CoreTestCase
@@ -100,16 +100,6 @@ public class CoreTestCase
         throws Exception
     {
         mySystem = IonSystemBuilder.standard().build();
-    }
-
-    @AfterEach
-    public void tearDown()
-        throws Exception
-    {
-        mySystem = null;
-        myRuntimeBuilder = null;
-        myRuntime = null;
-        myTopLevel = null;
     }
 
 

--- a/tst/dev/ionfusion/fusion/DocumentationTest.java
+++ b/tst/dev/ionfusion/fusion/DocumentationTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.net.URL;
 import org.htmlunit.IncorrectnessListener;
@@ -17,7 +18,6 @@ import org.htmlunit.html.HtmlHeading1;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.html.HtmlParagraph;
 import org.htmlunit.html.parser.HTMLParserListener;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -58,11 +58,6 @@ public class DocumentationTest
         });
     }
 
-    @AfterEach
-    public void tearDown()
-    {
-        myWebClient = null;
-    }
 
     private HtmlPage loadModule(String modulePath)
         throws IOException

--- a/tst/dev/ionfusion/fusion/cli/CliTestCase.java
+++ b/tst/dev/ionfusion/fusion/cli/CliTestCase.java
@@ -4,24 +4,16 @@
 package dev.ionfusion.fusion.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import dev.ionfusion.fusion.junit.StdioTestCase;
 import java.util.ArrayList;
 import java.util.Arrays;
-import org.junit.jupiter.api.AfterEach;
 
 public class CliTestCase
     extends StdioTestCase
 {
     protected String stdoutText;
     protected String stderrText;
-
-
-    @AfterEach
-    public void tearDownCli()
-    {
-        stdoutText = null;
-        stderrText = null;
-    }
 
 
     void run(String... commandLine)

--- a/tst/dev/ionfusion/fusion/junit/StdioTestCase.java
+++ b/tst/dev/ionfusion/fusion/junit/StdioTestCase.java
@@ -5,6 +5,7 @@ package dev.ionfusion.fusion.junit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.enumeration;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -12,7 +13,6 @@ import java.io.PrintStream;
 import java.io.SequenceInputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.LinkedList;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 
@@ -36,18 +36,6 @@ public class StdioTestCase
 
         myStdout = new PrintStream(myStdoutBytes);
         myStderr = new PrintStream(myStderrBytes);
-    }
-
-    @AfterEach
-    public void tearDownStdio()
-    {
-        myStdinData = null;
-        myStdin     = null;
-
-        myStdoutBytes = null;
-        myStderrBytes = null;
-        myStdout = null;
-        myStderr = null;
     }
 
 


### PR DESCRIPTION
In all these cases, we were just nulling-out fields.  That's an obsolete idiom that reduced memory leakage on earlier versions of JUnit that retained test instances through the entire test run.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
