### PR TITLE
Remove unnecessary uses of `@BeforeEach`.

### DIFF
--- a/tst/dev/ionfusion/fusion/CoreTestCase.java
+++ b/tst/dev/ionfusion/fusion/CoreTestCase.java
@@ -34,7 +34,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 
 public class CoreTestCase
     extends StdioTestCase
@@ -90,17 +89,10 @@ public class CoreTestCase
         Paths.get("").toAbsolutePath();
 
 
-    private IonSystem mySystem;
-    private FusionRuntimeBuilder myRuntimeBuilder;
-    private FusionRuntime myRuntime;
-    private TopLevel myTopLevel;
-
-    @BeforeEach
-    public void setUp()
-        throws Exception
-    {
-        mySystem = IonSystemBuilder.standard().build();
-    }
+    private final IonSystem            mySystem = IonSystemBuilder.standard().build();
+    private       FusionRuntimeBuilder myRuntimeBuilder;
+    private       FusionRuntime        myRuntime;
+    private       TopLevel             myTopLevel;
 
 
     public static Path fusionBootstrapDirectory()

--- a/tst/dev/ionfusion/fusion/junit/StdioTestCase.java
+++ b/tst/dev/ionfusion/fusion/junit/StdioTestCase.java
@@ -13,38 +13,22 @@ import java.io.PrintStream;
 import java.io.SequenceInputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.LinkedList;
-import org.junit.jupiter.api.BeforeEach;
 
 
 public class StdioTestCase
 {
-    private LinkedList<InputStream> myStdinData;
-    private InputStream             myStdin;
+    private final LinkedList<InputStream> myStdinData = new LinkedList<>();
+    private       InputStream             myStdin;
 
-    private ByteArrayOutputStream myStdoutBytes;
-    private ByteArrayOutputStream myStderrBytes;
+    private final ByteArrayOutputStream myStdoutBytes = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream myStderrBytes = new ByteArrayOutputStream();
 
-    private PrintStream myStdout;
-    private PrintStream myStderr;
-
-
-    @BeforeEach
-    public void setUpStdio()
-    {
-        myStdoutBytes = new ByteArrayOutputStream();
-        myStderrBytes = new ByteArrayOutputStream();
-
-        myStdout = new PrintStream(myStdoutBytes);
-        myStderr = new PrintStream(myStderrBytes);
-    }
+    private final PrintStream myStdout = new PrintStream(myStdoutBytes);
+    private final PrintStream myStderr = new PrintStream(myStderrBytes);
 
 
     protected void supplyInput(InputStream data)
     {
-        if (myStdinData == null)
-        {
-            myStdinData = new LinkedList<>();
-        }
         myStdinData.push(data);
     }
 
@@ -68,14 +52,7 @@ public class StdioTestCase
     {
         if (myStdin == null)
         {
-            if (myStdinData != null)
-            {
-                myStdin = new SequenceInputStream(enumeration(myStdinData));
-            }
-            else
-            {
-                myStdin = new ByteArrayInputStream(new byte[0]);
-            }
+            myStdin = new SequenceInputStream(enumeration(myStdinData));
         }
         return myStdin;
     }


### PR DESCRIPTION
## Description

A similarly obsolete memory-management idiom.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
