### PR TITLE
Ramp up HTMLUnit strictness and fix a warning.

### DIFF
--- a/src/dev/ionfusion/fusion/HtmlWriter.java
+++ b/src/dev/ionfusion/fusion/HtmlWriter.java
@@ -4,6 +4,7 @@
 package dev.ionfusion.fusion;
 
 import static com.amazon.ion.system.IonTextWriterBuilder.UTF8;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -105,11 +106,23 @@ class HtmlWriter
     }
 
 
-    private void openHead(String title, String baseUrl)
+    void openHtml()
         throws IOException
     {
         myOut.append("<!DOCTYPE html>\n" +
-                     "<head>" +
+                     "<html>\n");
+    }
+
+    void closeHtml()
+        throws IOException
+    {
+        myOut.append("</html>\n");
+    }
+
+    private void openHead(String title, String baseUrl)
+        throws IOException
+    {
+        myOut.append("<head>" +
                      "<meta http-equiv='Content-Type'" +
                      " content='text/html; charset=utf-8'>");
 
@@ -155,6 +168,19 @@ class HtmlWriter
         }
         
         myOut.append("</head>\n");
+    }
+
+
+    void openBody()
+        throws IOException
+    {
+        myOut.append("<body>\n");
+    }
+
+    void closeBody()
+        throws IOException
+    {
+        myOut.append("</body>\n");
     }
 
 

--- a/src/dev/ionfusion/fusion/_Private_ModuleDocumenter.java
+++ b/src/dev/ionfusion/fusion/_Private_ModuleDocumenter.java
@@ -3,13 +3,14 @@
 
 package dev.ionfusion.fusion;
 
+import static com.amazon.ion.system.IonTextWriterBuilder.UTF8;
 import static dev.ionfusion.fusion.DocIndex.buildDocIndex;
 import static dev.ionfusion.fusion.FusionUtils.EMPTY_STRING_ARRAY;
 import static dev.ionfusion.fusion.ModuleDoc.buildDocTree;
-import static com.amazon.ion.system.IonTextWriterBuilder.UTF8;
-import dev.ionfusion.fusion.ModuleDoc.Filter;
+
 import com.amazon.ion.Timestamp;
 import com.petebevin.markdown.MarkdownProcessor;
+import dev.ionfusion.fusion.ModuleDoc.Filter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -220,13 +221,21 @@ public final class _Private_ModuleDocumenter
         void renderModule()
             throws IOException
         {
-            String modulePath = myModuleId.absolutePath();
-            renderHead(modulePath, myBaseUrl, "module.css");
+            openHtml();
+            {
+                String modulePath = myModuleId.absolutePath();
+                renderHead(modulePath, myBaseUrl, "module.css");
 
-            renderHeader();
-            renderModuleIntro();
-            renderSubmoduleLinks();
-            renderBindings();
+                openBody();
+                {
+                    renderHeader();
+                    renderModuleIntro();
+                    renderSubmoduleLinks();
+                    renderBindings();
+                }
+                closeBody();
+            }
+            closeHtml();
         }
 
 

--- a/tst/dev/ionfusion/fusion/DocumentationTest.java
+++ b/tst/dev/ionfusion/fusion/DocumentationTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.URL;
-import org.htmlunit.IncorrectnessListener;
 import org.htmlunit.WebClient;
 import org.htmlunit.html.HtmlBody;
 import org.htmlunit.html.HtmlHeading1;
@@ -31,14 +30,7 @@ public class DocumentationTest
     @BeforeEach
     public void initWebClient()
     {
-        myWebClient.setIncorrectnessListener(new IncorrectnessListener()
-        {
-            @Override
-            public void notify(String s, Object o)
-            {
-                fail("Incorrectness: " + s);
-            }
-        });
+        myWebClient.setIncorrectnessListener((s, o) -> fail("Incorrectness: " + s));
 
         myWebClient.setHTMLParserListener(new HTMLParserListener()
         {
@@ -53,8 +45,7 @@ public class DocumentationTest
             public void warning(String message, URL url, String html,
                                 int line, int column, String key)
             {
-                // TODO Enable this and fix warnings.
-//              fail("HTML warning at line " + line + ": " + message);
+                fail("HTML warning at line " + line + ": " + message);
             }
         });
     }


### PR DESCRIPTION
## Description

This had been lurking in my local clone for a while.

Interestingly, this is the only problem HTMLUnit reports, but IDEA's HTML editor reports a _lot_ more issues.  Perhaps there's a way to make HTMLUnit more strict.  We definitely need to scan more than one file. 🫠

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
