### PR TITLE
Remove `ModuleIdentity` helpers for "local" names.

### DIFF
--- a/ftst/module_invalid_name.test.fusion
+++ b/ftst/module_invalid_name.test.fusion
@@ -1,0 +1,14 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+(require "/fusion/experimental/check")
+
+
+// Not a symbol
+(expect_syntax_exn (module null  "/fusion" "body"))
+(expect_syntax_exn (module 12    "/fusion" "body"))
+
+// Symbol with invalid content
+(expect_syntax_exn (module null.symbol "/fusion" "body"))
+(expect_syntax_exn (module ''          "/fusion" "body"))
+(expect_syntax_exn (module $name       "/fusion" "body"))


### PR DESCRIPTION
There was no difference from other modules names, and I no longer remember what distinction was intended.

## Description

This starts a (probably long) set of changes preparing to tease apart the public APIs and the implementation details into separate packages.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
