### PR TITLE
Remove `ModuleIdentity.reIntern()`.

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/ModuleForm.java
+++ b/src/main/java/dev/ionfusion/fusion/ModuleForm.java
@@ -447,10 +447,10 @@ final class ModuleForm
         }
 
         ModuleIdentity id;
-        String current = myCurrentModuleDeclareName.asString(eval);
-        if (current != null)
+        Object current = myCurrentModuleDeclareName.currentValue(eval);
+        if (current instanceof ModuleIdentity)
         {
-            id = ModuleIdentity.reIntern(current);
+            id = (ModuleIdentity) current;
         }
         else
         {

--- a/src/main/java/dev/ionfusion/fusion/ModuleIdentity.java
+++ b/src/main/java/dev/ionfusion/fusion/ModuleIdentity.java
@@ -133,24 +133,6 @@ class ModuleIdentity
 
 
     /**
-     * WORKAROUND for not being able to put ModuleIdentity as the value of
-     * current_module_declare_name or as a syntax property on `module` forms.
-     *
-     * @param path must be the result of {@link #absolutePath()}.
-     * @return not null.
-     */
-    static ModuleIdentity reIntern(String path)
-    {
-        synchronized (ourInternedIdentities)
-        {
-            ModuleIdentity interned = ourInternedIdentities.get(path);
-            assert interned != null;
-            return interned;
-        }
-    }
-
-
-    /**
      * Creates a <em>non-interned</em> identity for a top-level namespace.
      *
      * @return a fresh, non-interned identity.

--- a/src/main/java/dev/ionfusion/fusion/ModuleNameResolver.java
+++ b/src/main/java/dev/ionfusion/fusion/ModuleNameResolver.java
@@ -3,14 +3,14 @@
 
 package dev.ionfusion.fusion;
 
+import static com.amazon.ion.util.IonTextUtils.printString;
 import static dev.ionfusion.fusion.FusionSexp.unsafePairHead;
 import static dev.ionfusion.fusion.FusionSexp.unsafePairTail;
 import static dev.ionfusion.fusion.FusionSexp.unsafeSexpToJavaList;
-import static dev.ionfusion.fusion.FusionString.makeString;
 import static dev.ionfusion.fusion.FusionText.isText;
 import static dev.ionfusion.fusion.FusionText.unsafeTextToJavaString;
 import static dev.ionfusion.fusion.ModuleIdentity.isValidModulePath;
-import static com.amazon.ion.util.IonTextUtils.printString;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -282,12 +282,10 @@ final class ModuleNameResolver
             {
                 checkForCycles(eval, id);
 
-                Object idString = makeString(eval, id.absolutePath());
-
                 Evaluator loadEval =
                     eval.markedContinuation(new Object[]{ myCurrentModuleDeclareName,
                                                           MODULE_LOADING_MARK },
-                                            new Object[]{ idString, id });
+                                            new Object[]{ id, id });
                 myLoadHandler.loadModule(loadEval, id, loc);
                 // Evaluation of 'module' declares it, but doesn't instantiate.
                 // It also calls-back to registerDeclaredModule().


### PR DESCRIPTION
It was a private helper that's no longer needed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
