### PR TITLE
Declare the `ftst` directory as input to unit tests.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,9 @@ tasks.test {
 
     // Collect Fusion coverage data IFF a report is being generated.
     mustRunAfter(fcovConfigure)
+
+    inputs.dir(layout.projectDirectory.dir("ftst"))
+
     jvmArgumentProviders.add {
         if (fcovRunning) {
             logger.lifecycle("Enabling Fusion code coverage instrumentation")


### PR DESCRIPTION
Otherwise, Gradle won't reliably run tests when a script changes, since it's not watching for changes.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
