### PR TITLE
Use a more Ion-y example to demo Ion-ness.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ That should print `3`.  What's not obvious is that the evaluator is printing the
 Amazon Ion format.  We can use a more interesting expression to demonstrate:
 
 ```shell
-fusion eval '[null, (+ 1 2)]'
+fusion eval '[null, (timestamp_at_day 2025-03-28T02:09-07:00)]'
 ```
 
-That should print `[null, 3]` using Ion's notation for a list. You can see that the list in the 
-input expression evaluates to list, and each element of the list is likewise evaluated as an 
-expression. Fusion makes it easy to construct data very directly. This applies to Ion structs 
+That should print `[null, 2025-03-28]`, using Ion's notation for a timestamp. You can see that the
+list in the input expression evaluates to list, and each element of the list is likewise evaluated
+as an expression. Fusion makes it easy to construct data very directly. This applies to Ion structs
 (JSON objects) as well:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ As our last example for now, we'll demonstrate a nontrivial Fusion script: gener
 authors to this repository, in chronological order. This real-world example was used to generate the
 list in our [CONTRIBUTORS page](CONTRIBUTORS.md).
 
-First, copy this content into a file named `authers.fusion`:
+First, copy this content into a file named `authors.fusion`:
 
 ```
 (define all_names


### PR DESCRIPTION
## Description

Using timestamps instead of ints makes for a more Ion-rich demonstration.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
