### PR TITLE
Refine names and docs on PR-triggered workflows.

### DIFF
--- a/.github/workflows/pr-build-dependency-graph.yml
+++ b/.github/workflows/pr-build-dependency-graph.yml
@@ -3,12 +3,13 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 #
-# This workflow will build a Java project with Gradle and upload its dependency graph
-# for another workflow to download and submit for processing. This split is needed because
-# PR-triggered workflows from forked repositories cannot have 'write' permissions.
+# This workflow will:
+#   * build the project with Gradle
+#   * upload its dependency graph to workflow artifact storage
 #
-# See: https://github.com/gradle/actions/blob/main/docs/dependency-submission.md#usage-with-pull-requests-from-public-forked-repositories
-name: PR Build and Generate Dependency Graph
+# The "PR Submit Dependency Graph" workflow triggers when this one completes.
+
+name: PR Build and Record Dependencies
 
 on:
   pull_request:
@@ -33,26 +34,28 @@ jobs:
         java-version: 17
         distribution: corretto
 
-    # Configure Gradle for optimal use in GitHub Actions, 
+    # Configure Gradle for optimal use in GitHub Actions,
     # including caching of downloaded dependencies.
     # https://github.com/gradle/actions/blob/main/setup-gradle
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
+
     - name: Build with Gradle Wrapper
       run: ./gradlew release
 
-  dependency-submission:
+  generate-dependency-graph:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
         java-version: 17
         distribution: corretto
 
-    - name: Generate and submit dependency graph
+    - name: Generate dependency graph
       uses: gradle/actions/dependency-submission@v4
       with:
         dependency-graph: generate-and-upload

--- a/.github/workflows/pr-dependency-review.yml
+++ b/.github/workflows/pr-dependency-review.yml
@@ -1,9 +1,17 @@
-# Generates a dependency review on a pull request based on the result
-# of the uploaded dependency graph. Idle waits for secondary workflows
-# triggered by the PR to generate, and then submit the graph.
+# Performs a GitHub dependency review on a pull request, based on data inferred by GitHub and/or
+# submitted by the "PR Submit Dependency Graph" workflow.
 #
-# See: https://github.com/gradle/actions/blob/main/docs/dependency-submission.md#usage-with-pull-requests-from-public-forked-repositories
-name: PR Review Dependency Graph
+# This workflow will:
+#   * wait for other workflows triggered by the PR to submit a graph snapshot
+#   * analyze the graph using GitHub's Dependency Review API
+#
+# By default, the dependency review will fail if it discovers any vulnerable packages.
+#
+# See:
+#   * https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review
+#   * https://github.com/gradle/actions/blob/main/docs/dependency-submission.md#usage-with-pull-requests-from-public-forked-repositories
+
+name: PR Dependency Review
 
 on:
   pull_request:

--- a/.github/workflows/pr-dependency-submit.yml
+++ b/.github/workflows/pr-dependency-submit.yml
@@ -3,16 +3,22 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 #
-# This workflow will download and submit a dependency graph of a Java project with Gradle
-# for another workflow to use to verify dependency safety. This split is needed because
-# PR-triggered workflows from forked repositories cannot have 'write' permissions.
+# This workflow will:
+#   * download a Gradle dependency graph file from workflow artifact storage
+#   * submit it to GitHub's Dependency Graph API for review
 #
-# See: https://github.com/gradle/actions/blob/main/docs/dependency-submission.md#usage-with-pull-requests-from-public-forked-repositories
+# We must generate and submit dependencies in separate workflows because PR workflows from forked
+# repositories do not have 'write' permission to submit the dependency graph.
+#
+# See:
+#   * https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflows-in-forked-repositories
+#   * https://github.com/gradle/actions/blob/main/docs/dependency-submission.md#usage-with-pull-requests-from-public-forked-repositories
+
 name: PR Submit Dependency Graph
 
 on:
   workflow_run:
-    workflows: ['PR Build and Generate Dependency Graph']
+    workflows: ['PR Build and Record Dependencies']
     types: [completed]
 
 permissions:
@@ -23,7 +29,7 @@ jobs:
   submit-dependency-graph:
     runs-on: ubuntu-latest
     steps:
-    - name: Download and submit dependency graph
+    - name: Submit dependency graph
       uses: gradle/actions/dependency-submission@v4
       with:
         dependency-graph: download-and-submit


### PR DESCRIPTION
I found the existing names confusing when poking throw the workflow results, particularly the distinction between "upload" and "submit".

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
