### PR TITLE
Add files to bootstrap the all-contributors bot.

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,24 @@
+{
+  "projectName": "fusion-java",
+  "projectOwner": "ion-fusion",
+  "repoType": "github",
+  "files": [
+    "CONTRIBUTORS.md"
+  ],
+  "commitType": "docs",
+  "commitConvention": "angular",
+  "contributorsPerLine": 7,
+  "contributors": [
+    {
+      "login": "toddjonker",
+      "name": "Todd V. Jonker",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2058215?v=4",
+      "profile": "https://github.com/toddjonker",
+      "contributions": [
+        "code",
+        "doc",
+        "design"
+      ]
+    }
+  ]
+}

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,3 +35,19 @@ chronological order:
 * Marco Torres
 * Matt Goertzen
 * Zachary Luckabaugh
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/toddjonker"><img src="https://avatars.githubusercontent.com/u/2058215?v=4?s=100" width="100px;" alt="Todd V. Jonker"/><br /><sub><b>Todd V. Jonker</b></sub></a><br /><a href="#code-toddjonker" title="Code">💻</a> <a href="#doc-toddjonker" title="Documentation">📖</a> <a href="#design-toddjonker" title="Design">🎨</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,7 +6,24 @@ Our core team:
 * Jonathan Little drove the externalization process within Amazon.
 * Isaac M. Good has long provided critical community leadership and technical reviews.
 
-In addition, we thank the following individuals for their code contributions to this project. In 
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/toddjonker"><img src="https://avatars.githubusercontent.com/u/2058215?v=4?s=100" width="100px;" alt="Todd V. Jonker"/><br /><sub><b>Todd V. Jonker</b></sub></a><br /><a href="#code-toddjonker" title="Code">💻</a> <a href="#doc-toddjonker" title="Documentation">📖</a> <a href="#design-toddjonker" title="Design">🎨</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+
+In addition, we thank the following individuals for their code contributions to this project. In
 chronological order:
 
 * Jason Lee
@@ -35,19 +52,3 @@ chronological order:
 * Marco Torres
 * Matt Goertzen
 * Zachary Luckabaugh
-
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
-<table>
-  <tbody>
-    <tr>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/toddjonker"><img src="https://avatars.githubusercontent.com/u/2058215?v=4?s=100" width="100px;" alt="Todd V. Jonker"/><br /><sub><b>Todd V. Jonker</b></sub></a><br /><a href="#code-toddjonker" title="Code">💻</a> <a href="#doc-toddjonker" title="Documentation">📖</a> <a href="#design-toddjonker" title="Design">🎨</a></td>
-    </tr>
-  </tbody>
-</table>
-
-<!-- markdownlint-restore -->
-<!-- prettier-ignore-end -->
-
-<!-- ALL-CONTRIBUTORS-LIST:END -->


### PR DESCRIPTION
https://allcontributors.org/docs/en/bot/overview

## Description

This bot helps generate and maintain a table of contributors, making it easy to add entries for a broad variety of contributions, including non-code.

I got the bot working on my personal fork. It's a bit persnickety (must manually delete branches the bot creates for its PRs) but gets the job done.

Later, I'll add historical committers in bulk using the CLI, which will avoid a lot of PR spam.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
