### PR TITLE
Remove JavaDoc exclusion for util/function package.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -219,7 +219,6 @@ gradle.taskGraph.whenReady {
 tasks.javadoc {
     exclude("**/_Private_*",
             "dev/ionfusion/fusion/cli",
-            "dev/ionfusion/fusion/util/function/**",
             "dev/ionfusion/fusion/util/hamt/**")
 
     title = "FusionJava API Reference"


### PR DESCRIPTION
That package was removed by #172

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
