### PR TITLE
Java package/namespace change

### DIFF
--- a/benchmarks/dev/ionfusion/fusion/FoldBenchmarks.java
+++ b/benchmarks/dev/ionfusion/fusion/FoldBenchmarks.java
@@ -1,7 +1,7 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.amazon.fusion;
+package dev.ionfusion.fusion;
 
 import java.util.Random;
 import java.util.concurrent.TimeUnit;

--- a/benchmarks/dev/ionfusion/fusion/FusionState.java
+++ b/benchmarks/dev/ionfusion/fusion/FusionState.java
@@ -1,7 +1,7 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.amazon.fusion;
+package dev.ionfusion.fusion;
 
 import static java.util.UUID.randomUUID;
 import org.openjdk.jmh.annotations.Level;

--- a/benchmarks/dev/ionfusion/fusion/StructBenchmarks.java
+++ b/benchmarks/dev/ionfusion/fusion/StructBenchmarks.java
@@ -1,7 +1,7 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.amazon.fusion;
+package dev.ionfusion.fusion;
 
 import static java.util.UUID.randomUUID;
 import com.amazon.ion.util.IonTextUtils;


### PR DESCRIPTION
Move `com.amazon` to `dev.ionfusion`

Applying the same package/namespace change on this branch as was previously applied to `main`.

Keeping the extra `fusion` level to match `main`, knowing that we may end up removing it.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
