### PR TITLE
Add a basic index for the documentation tree.

### DIFF
--- a/fusion/src/index.md
+++ b/fusion/src/index.md
@@ -1,0 +1,12 @@
+<!-- Copyright Ion Fusion contributors. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Ion Fusion Reference Documentation
+
+This documentation consists of two parts:
+
+* The [Language Reference](fusion.html) documents the modules and features available to Fusion code.
+    * The [index](binding-index.html) lists all available bindings. The
+      [permuted index](permuted-index.html) may help you discover related features.
+* The [Java API Reference](javadoc/index.html) describes how to embed the Ion Fusion runtime in your
+  Java application.


### PR DESCRIPTION

Note that this (inherited) documentation layout is wonky, as it has the `javadoc` tree "inside" the Fusion module hierarchy, rather than as a sibling.  This is largely because we want to render this index from Markdown using the magic `fusion document` command, and that currently requires everything to be under `fusion/src` alongside module code.

We should eventually rework this so that the Fusion and Java references are sibling directories.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
