### PR TITLE
[build] Make `fusion` dir an input to fusiondoc task.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -244,6 +244,7 @@ tasks.register<JavaExec>("fusiondocGen") {
 
     enableAssertions = true
 
+    inputs.dir(layout.projectDirectory.dir("fusion"))
     outputs.dir(fusiondocDir)
 }
 


### PR DESCRIPTION
This ensures Gradle will rebuild the Fusion docs when the source changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
