### PR TITLE
Add build configuration for Read the Docs.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,28 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+    os: ubuntu-24.04
+
+    # We don't need this, but RtD requires at least one tool.
+    tools:
+        python: "3.10"
+
+    apt_packages:
+        - openjdk-8-jdk-headless
+
+    jobs:
+        # This is just here to log the shell environment.
+        post_system_dependencies:
+            - env
+            - which -a java
+            - java --version
+        build:
+            html:
+                - ./gradlew fusiondoc javadoc
+                # TODO Perform this work in Gradle
+                - mkdir -p "${READTHEDOCS_OUTPUT}/html"
+                - mv build/docs/fusiondoc/* "${READTHEDOCS_OUTPUT}/html"
+                - mv build/docs/javadoc "${READTHEDOCS_OUTPUT}/html"


### PR DESCRIPTION
https://readthedocs.org/

## Description

To see the results of this commit  on my fork, browse to https://toddjonker-fusion-java.readthedocs.io/en/latest/

Next step is to get this content hosted at a custom domain like https://docs.ionfusion.dev/ which appears [fairly straightforward](https://docs.readthedocs.com/platform/stable/guides/custom-domains.html).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
