### PR TITLE
Align the distro docs and the docs website.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,8 +21,6 @@ build:
             - java --version
         build:
             html:
-                - ./gradlew fusiondoc javadoc
-                # TODO Perform this work in Gradle
-                - mkdir -p "${READTHEDOCS_OUTPUT}/html"
-                - mv build/docs/fusiondoc/* "${READTHEDOCS_OUTPUT}/html"
-                - mv build/docs/javadoc "${READTHEDOCS_OUTPUT}/html"
+                - ./gradlew installDist
+                - mkdir -p "${READTHEDOCS_OUTPUT}"
+                - mv build/install/fusion/docs "${READTHEDOCS_OUTPUT}/html"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -279,8 +279,13 @@ distributions {
                 dependsOn("fusiondoc", "javadoc")
             }
 
+            // TODO JavaDocs should be beside, not inside, the Fusion docs.
+            //  https://github.com/ion-fusion/fusion-java/issues/204
             into("docs") {
-                from(docsDir)
+                from(fusiondocDir)
+            }
+            into("docs") {
+                from(docsDir).include("javadoc/**")
             }
         }
     }


### PR DESCRIPTION
Lifts the `fusiondoc` (our generated content) to `docs` and moves `javadoc` inside it.

This isn't ideal -- the Fusion and Java references should be siblings (#204) -- but we cannot yet generate pages outside of the module hierarchy.

## Description

This makes the SDK `docs` directory match what's on `docs.ion-fusion.dev`.

## Related Issues

Makes a bit of progress on #204 by moving all the relevant logic into Gradle.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
