### PR TITLE
Upload latest build on main to a release

### DIFF
--- a/.github/workflows/push-gradle-ci.yml
+++ b/.github/workflows/push-gradle-ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
 
     steps:
     # https://github.com/actions/checkout
@@ -39,6 +39,36 @@ jobs:
     - name: Build with Gradle Wrapper
       run: ./gradlew release
 
+    - name: Upload release
+      if: github.repository == 'ion-fusion/fusion-java'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # Define release tag and name.
+        RELEASE_TAG="latest"
+        RELEASE_TITLE="Latest build"
+
+        # Pick the target branch. Otherwise, this would default to main (which would be OK, but doesn't adapt to
+        # running or testing this script elsewhere).
+        CURRENT_BRANCH=$(git branch --show-current)
+
+        # Delete the existing release if it exists.
+        EXISTING_RELEASE=$(gh release list --repo ${{ github.repository }} --json tagName --jq ".[] | select(.tagName==\"$RELEASE_TAG\")")
+        if [ -n "$EXISTING_RELEASE" ]; then
+          gh release delete --repo ${{ github.repository }} \
+            "$RELEASE_TAG" \
+            --yes \
+            --cleanup-tag
+        fi
+
+        # Create the release and upload the distribution files (this will include a zip and a tarball).
+        gh release create --repo ${{ github.repository }} \
+          "$RELEASE_TAG" \
+          --title "$RELEASE_TITLE" \
+          --notes "Latest build" \
+          --prerelease \
+          --target "$CURRENT_BRANCH" \
+          build/distributions/*
 
   dependency-submission:
     if: github.repository == 'ion-fusion/fusion-java'


### PR DESCRIPTION
Solution for #207. Or at least, initial solution. There are some improvements we could make -- see #207 for discussion.

## Description

This adds a step after build in our main CI action that:
- Only runs on the main branch in the ion-fusion/fusion-java repo (not forks)
- Tags and uploads the `distributions` build output as a Release called "latest build" (and tagged `latest`)
- Deletes and re-creates the same Release every time

The release includes the two distributions bundles (zip and tar), and Github seems to automatically include download links for the source code in .zip and .tar.gz formats as well. 

You can see a sample Release in my fork: https://github.com/rationull/fusion-java/releases

## Potential changes/improvements/feedback areas

- The naming is not something I'm tied to. Any other suggestions? In particular I think I like "snapshot" better than "latest" -- then we could reserve "latest" for real tagged releases.
- We could modify the existing release instead of deleting and re-creating it. This is marginally harder since we'd want to list and delete all artifacts associated with the release first. The benefit would be that if for some reason the new release upload fails for a build, the previous release would still exist. The downside would be that if the release gets partially uploaded somehow, we could end up with mixed content. We could achieve the same thing by timestamping the names and keeping the latest or something.
- (Maybe there's a pre-existing step script from an authoritative source we can use -- but I figured we'll work out what result we want before coupling to anything like that given how simple this is with the gh CLI)

Refactors that can come after the basic functionality is merged
- We could split the upload out into a separate workflow job (not just a separate step) -- or even a separate workflow if they support dependencies. This seems a bit nicer, but would require us to upload and re-download artifacts between the build job and the upload job -- file systems are shared between steps but not between jobs.
- Then, tie building and publishing a container to the same artifacts to start to establish a multi-target CI release workflow.
- Rename/rearrange the workflows accordingly.  The current workflow does stuff that runs in forks too, and may have been named for the gradle dependency graph push.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
