### PR TITLE
Use repo variables to control Actions with side effects

### DIFF
--- a/.github/workflows/push-gradle-ci.yml
+++ b/.github/workflows/push-gradle-ci.yml
@@ -40,7 +40,7 @@ jobs:
       run: ./gradlew release
 
     - name: Upload release
-      if: github.repository == 'ion-fusion/fusion-java'
+      if: ${{ vars.PUBLISH_RELEASE == 'true' }}
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
@@ -71,7 +71,7 @@ jobs:
           build/distributions/*
 
   dependency-submission:
-    if: github.repository == 'ion-fusion/fusion-java'
+    if: ${{ vars.SUBMIT_DEPENDENCIES == 'true' }}
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Follow up for #207.

Make actions conditional on PUBLISH_RELEASE and SUBMIT_DEPENDENCIES repository variables, replacing the previous conditions based on repo name.

Tested in my fork. I'll add the repo variables prior to merging.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
