### PR TITLE
Use a version label following Maven conventions.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,25 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+version = "0.38a1-SNAPSHOT"
+// Docs for how Maven compares version labels:
+// https://maven.apache.org/pom.html#Dependency_Version_Requirement_Specification
+// I find that nearly incomprehensible, while this blog post is more useful:
+// https://octopus.com/blog/maven-versioning-explained
+// Gradle's algorithm is different, and easier to understand:
+// https://docs.gradle.org/8.10.2/userguide/single_versions.html#version_ordering
+// https://docs.gradle.org/8.10.2/userguide/dependency_resolution.html#sec:base-version-comparison
+
+// WARNING: replacing -SNAPSHOT with -a1 (or even -rc) gives an *earlier*
+// version according to both algorithms.  Proactively including the `a1` preserves
+// our ability to release an alpha that will properly sort *after* its snapshots.
+
+
 plugins {
     java
     application
     jacoco
 }
-
-version = "R37_dev"
 
 repositories {
     mavenCentral()

--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,0 @@
-# The Ant build.xml copies this to the output class hierarchy
-# and adds several other properties based on the build environment.
-
-release_label = R38_dev

--- a/src/test/java/dev/ionfusion/fusion/util/FusionJarInfoTest.java
+++ b/src/test/java/dev/ionfusion/fusion/util/FusionJarInfoTest.java
@@ -3,8 +3,8 @@
 
 package dev.ionfusion.fusion.util;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import dev.ionfusion.fusion.FusionException;
 import org.junit.jupiter.api.Test;
 
@@ -18,13 +18,6 @@ public class FusionJarInfoTest
         throws FusionException
     {
         FusionJarInfo info = new FusionJarInfo();
-
-        // When running on a laptop that can't run our Ant targets (due to
-        // unavailable Brazil CLI and HappyTrails stuff) this test will fail.
-        // Adding -DNOBRAZIL to the Eclipse Installed JRE will allow us to
-        // succeed in that case.
-        if (System.getProperty("NOBRAZIL") != null) return;
-
-        assertTrue(info.getReleaseLabel().startsWith("R"));
+        assertTrue(info.getReleaseLabel().startsWith("0.3"));
     }
 }


### PR DESCRIPTION
## Description

This replaces the legacy version labeling scheme with something Maven- and Gradle-compatible.

The Maven version-comparison spec is a confusing mess with lots of weird edge cases.  It took me awhile to figure out how to form a snapshot label that can later be superseded by an alpha or beta.  The Gradle algorithm is more simple and comprehensible, but still has some awkward special cases (like why does `-rc` precede `-snapshot`?!).

Note that the inclusion of the `a1` field isn't meant to imply we will release alphas; it simply preserves our ability to do so.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
