### PR TITLE
Add CSS and navbar to non-module documentation.

### DIFF
--- a/doc/doc.css
+++ b/doc/doc.css
@@ -1,0 +1,6 @@
+/* Copyright Ion Fusion contributors. All rights reserved. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.indexlink {
+  float: right;
+}

--- a/src/main/java/dev/ionfusion/fusion/_Private_ModuleDocumenter.java
+++ b/src/main/java/dev/ionfusion/fusion/_Private_ModuleDocumenter.java
@@ -30,6 +30,14 @@ import java.util.regex.Pattern;
  */
 public final class _Private_ModuleDocumenter
 {
+    /** HTML content for the masthead links */
+    private static final String HEADER_LINKS =
+        "<div class='indexlink'>" +
+        "<a href='index.html'>Top</a> " +
+        "<a href='binding-index.html'>Binding Index</a> " +
+        "(<a href='permuted-index.html'>Permuted</a>)" +
+        "</div>\n";
+
     private _Private_ModuleDocumenter() {}
 
 
@@ -158,7 +166,8 @@ public final class _Private_ModuleDocumenter
 
         try (HtmlWriter writer = new HtmlWriter(outputFile))
         {
-            writer.renderHead(title, baseUrl, null /*style*/);
+            writer.renderHead(title, baseUrl, "doc.css");
+            writer.append(HEADER_LINKS);
             writer.append(html);
         }
     }
@@ -266,12 +275,7 @@ public final class _Private_ModuleDocumenter
         private void renderHeader()
             throws IOException
         {
-            append("<div class='indexlink'>" +
-                   "<a href='index.html'>Top</a> " +
-                   "<a href='binding-index.html'>Binding Index</a> " +
-                   "(<a href='permuted-index.html'>Permuted</a>)" +
-                   "</div>\n");
-
+            append(HEADER_LINKS);
             append("<h1>Module ");
             renderModulePathWithLinks(myModuleId);
             append("</h1>");


### PR DESCRIPTION
## Description

Files in the source tree matching `fusion/**/*.md` are transformed into HTML as part of documentation generation.  At the moment, those have no style sheet at all, and don't include the same top-right navigation links that module-doc pages have.  This fixes both issues, though it doesn't add any meaningful styling.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
