### PR TITLE
Move generated-docs tests into the distro suite.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     testImplementation("org.hamcrest:hamcrest:3.0")
-    testImplementation("org.htmlunit:htmlunit:4.6.0")
 }
 
 java {
@@ -83,9 +82,6 @@ tasks.jar {
 // Tests
 
 tasks.test {
-    // dev.ionfusion.fusion.DocumentationTest checks the generated documentation.
-    dependsOn(fusiondoc)
-
     // dev.ionfusion.fusion.ClassLoaderModuleRepositoryTest uses ftst-repo.jar.
     dependsOn(ftstRepo)
 
@@ -129,6 +125,15 @@ testing {
     suites {
         // This test suite ensures the distribution is functional.
         register<JvmTestSuite>("testDist") {
+            dependencies {
+                // Docs claim that Jupiter is configured by default, but these
+                // are all necessary.
+                implementation(platform("org.junit:junit-bom:5.11.3"))
+                implementation("org.junit.jupiter:junit-jupiter")
+                implementation("org.hamcrest:hamcrest:3.0")
+                implementation("org.htmlunit:htmlunit:4.12.0")
+            }
+
             // "Future iterations of the plugin will allow defining multiple
             // targets based other attributes, such as a particular JDK runtime."
             targets {

--- a/src/testDist/java/DocumentationTest.java
+++ b/src/testDist/java/DocumentationTest.java
@@ -1,8 +1,6 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -21,6 +19,9 @@ import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Verifies the documentation tree in the distribution.
+ */
 public class DocumentationTest
 {
     /** Not thread-safe */
@@ -54,7 +55,7 @@ public class DocumentationTest
     private HtmlPage loadModule(String modulePath)
         throws IOException
     {
-        String   url  = "file:build/docs/fusiondoc" + modulePath + ".html";
+        String   url  = "file:build/install/fusion/docs" + modulePath + ".html";
         HtmlPage page = myWebClient.getPage(url);
         assertEquals(modulePath, page.getTitleText());
 


### PR DESCRIPTION
This means we no longer need to generate docs before running the primary test suite.

Also updated HTMLUnit 4.6.0 -> 4.12.0

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
