### PR TITLE
Make the doc-collection parameter part of global state.

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/BindingDoc.java
+++ b/src/main/java/dev/ionfusion/fusion/BindingDoc.java
@@ -11,9 +11,6 @@ final class BindingDoc
 {
     static final BindingDoc[] EMPTY_ARRAY = new BindingDoc[0];
 
-    /** Private continuation mark to trigger documentation collection. */
-    static final Object COLLECT_DOCS_MARK = new DynamicParameter(null);
-
     enum Kind { PROCEDURE, SYNTAX, CONSTANT }
 
     private String myName;

--- a/src/main/java/dev/ionfusion/fusion/GlobalState.java
+++ b/src/main/java/dev/ionfusion/fusion/GlobalState.java
@@ -5,11 +5,12 @@ package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionString.makeString;
 import static dev.ionfusion.fusion.FusionValue.UNDEF;
-import dev.ionfusion.fusion.ModuleNamespace.ModuleDefinedBinding;
+
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.system.IonReaderBuilder;
+import dev.ionfusion.fusion.ModuleNamespace.ModuleDefinedBinding;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -48,6 +49,7 @@ final class GlobalState
     final LoadHandler                myLoadHandler;
     final _Private_CoverageCollector myCoverageCollector;
 
+    final DynamicParameter myCollectDocsParam;
     final DynamicParameter myCurrentIonReaderParam;
     final DynamicParameter myCurrentNamespaceParam;
     final DynamicParameter myCurrentOutputPortParam;
@@ -66,12 +68,12 @@ final class GlobalState
     final Binding myKernelRequireBinding;
 
     private GlobalState(IonSystem                  ionSystem,
+                        FusionRuntimeBuilder       builder,
                         IonReaderBuilder           ionReaderBuilder,
                         FileSystemSpecialist       fileSystemSpecialist,
                         ModuleInstance             kernel,
                         ModuleNameResolver         resolver,
-                        LoadHandler                loadHandler,
-                        _Private_CoverageCollector coverageCollector)
+                        LoadHandler                loadHandler)
     {
         myIonSystem             = ionSystem;
         myIonReaderBuilder      = ionReaderBuilder;
@@ -79,7 +81,9 @@ final class GlobalState
         myKernelModule          = kernel;
         myModuleNameResolver    = resolver;
         myLoadHandler           = loadHandler;
-        myCoverageCollector     = coverageCollector;
+        myCoverageCollector     = builder.getCoverageCollector();
+
+        myCollectDocsParam          = new DynamicParameter(builder.isDocumenting());
 
         myCurrentIonReaderParam     = kernelValue("current_ion_reader");
         myCurrentNamespaceParam     = kernelValue("current_namespace");
@@ -175,8 +179,7 @@ final class GlobalState
         ModuleInstance kernel = registry.lookup(KERNEL_MODULE_IDENTITY);
 
         GlobalState globals =
-            new GlobalState(system, readerBuilder, fs, kernel, resolver, loadHandler,
-                            builder.getCoverageCollector());
+            new GlobalState(system, builder, readerBuilder, fs, kernel, resolver, loadHandler);
         return globals;
     }
 

--- a/src/main/java/dev/ionfusion/fusion/ModuleForm.java
+++ b/src/main/java/dev/ionfusion/fusion/ModuleForm.java
@@ -4,7 +4,6 @@
 package dev.ionfusion.fusion;
 
 import static com.amazon.ion.util.IonTextUtils.printQuotedSymbol;
-import static dev.ionfusion.fusion.BindingDoc.COLLECT_DOCS_MARK;
 import static dev.ionfusion.fusion.FusionSexp.isPair;
 import static dev.ionfusion.fusion.FusionSexp.unsafePairHead;
 import static dev.ionfusion.fusion.FusionSexp.unsafePairTail;
@@ -363,7 +362,7 @@ final class ModuleForm
             {
                 // We're gonna call this documentation!
                 moduleDatum = unsafePairTail(eval, moduleDatum);
-                if (eval.firstContinuationMark(COLLECT_DOCS_MARK) != null)
+                if (comp.isDocCollectingEnabled())
                 {
                     docs = unsafeStringToJavaString(eval, maybeDoc);
                 }

--- a/src/main/java/dev/ionfusion/fusion/StandardRuntime.java
+++ b/src/main/java/dev/ionfusion/fusion/StandardRuntime.java
@@ -3,12 +3,10 @@
 
 package dev.ionfusion.fusion;
 
-import static dev.ionfusion.fusion.BindingDoc.COLLECT_DOCS_MARK;
-import static dev.ionfusion.fusion.FusionUtils.EMPTY_OBJECT_ARRAY;
 import static dev.ionfusion.fusion.GlobalState.KERNEL_MODULE_IDENTITY;
 import static dev.ionfusion.fusion.ModuleIdentity.forAbsolutePath;
 import static dev.ionfusion.fusion.ModuleIdentity.isValidAbsoluteModulePath;
-import static java.lang.Boolean.TRUE;
+
 import com.amazon.ion.IonCatalog;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonSystem;
@@ -48,12 +46,7 @@ final class StandardRuntime
             myGlobalState =
                 GlobalState.initialize(ionSystem, builder, myRegistry, topNs);
 
-            Object[] parameterization =
-                (builder.isDocumenting()
-                     ? new Object[]{ COLLECT_DOCS_MARK, TRUE }
-                     : EMPTY_OBJECT_ARRAY);
-
-            myTopLevel = makeTopLevel(topNs, myDefaultLanguage, parameterization);
+            myTopLevel = makeTopLevel(topNs, myDefaultLanguage);
         }
         catch (FusionException e)
         {


### PR DESCRIPTION
This ensures that the flag is set globally for the runtime, not just its default TopLevel.

Also, deduplicate the logic for checking the flag's value.

## Description

Continuing to refactor and improve the doc-gen code, which is quite old so cleanup is overdue. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
