### PR TITLE
Remove obsolete `FusionUtils.loadReader()`.

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/FusionUtils.java
+++ b/src/main/java/dev/ionfusion/fusion/FusionUtils.java
@@ -10,7 +10,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Reader;
 import java.net.URL;
 import java.util.Properties;
 
@@ -143,23 +142,6 @@ final class FusionUtils
                                          + file);
             }
         }
-    }
-
-
-    public static String loadReader(Reader in)
-        throws IOException
-    {
-        StringBuilder buf = new StringBuilder(2048);
-
-        char[] chars = new char[2048];
-
-        int len;
-        while ((len = in.read(chars)) != -1)
-        {
-            buf.append(chars, 0, len);
-        }
-
-        return buf.toString();
     }
 
 

--- a/src/main/java/dev/ionfusion/fusion/_Private_ModuleDocumenter.java
+++ b/src/main/java/dev/ionfusion/fusion/_Private_ModuleDocumenter.java
@@ -5,16 +5,14 @@ package dev.ionfusion.fusion;
 
 import static com.amazon.ion.system.IonTextWriterBuilder.UTF8;
 import static dev.ionfusion.fusion.DocIndex.buildDocIndex;
-import static dev.ionfusion.fusion.FusionUtils.EMPTY_STRING_ARRAY;
 import static dev.ionfusion.fusion.ModuleDoc.buildDocTree;
 
 import com.amazon.ion.Timestamp;
 import com.petebevin.markdown.MarkdownProcessor;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -150,17 +148,12 @@ public final class _Private_ModuleDocumenter
      */
     private static void writeMarkdownPage(File   outputFile,
                                           String baseUrl,
-                                          File   inputFile)
+                                          Path   inputFile)
         throws IOException
     {
-        String markdownContent;
-        try (FileInputStream inStream = new FileInputStream(inputFile))
-        {
-            try (Reader inReader = new InputStreamReader(inStream, UTF8))
-            {
-                markdownContent = FusionUtils.loadReader(inReader);
-            }
-        }
+        // TODO Java11: use Files.readString
+        byte[] bytes = Files.readAllBytes(inputFile);
+        String markdownContent = new String(bytes, UTF8);
 
         Matcher matcher = TITLE_PATTERN.matcher(markdownContent);
         String title =
@@ -204,7 +197,7 @@ public final class _Private_ModuleDocumenter
             {
                 String docName = fileName.substring(0, fileName.length() - 2);
                 File outputFile = new File(outputDir, docName + "html");
-                writeMarkdownPage(outputFile, baseUrl, repoFile);
+                writeMarkdownPage(outputFile, baseUrl, repoFile.toPath());
             }
             else if (repoFile.isDirectory())
             {
@@ -311,7 +304,7 @@ public final class _Private_ModuleDocumenter
 
             renderHeader2("Submodules");
 
-            String[] names = submodules.keySet().toArray(EMPTY_STRING_ARRAY);
+            String[] names = submodules.keySet().toArray(new String[0]);
             Arrays.sort(names);
 
             append("<ul class='submodules'>");


### PR DESCRIPTION
## Description

Cleanup, to avoid a future low-value cross-package dependency.  (I'll be moving the doc writer into a different package.)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
