### PR TITLE
Remove obsolete `FusionUtils.createParentDirs()`.

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/CoverageDatabase.java
+++ b/src/main/java/dev/ionfusion/fusion/CoverageDatabase.java
@@ -13,12 +13,12 @@ import com.amazon.ion.IonWriter;
 import com.amazon.ion.system.IonReaderBuilder;
 import com.amazon.ion.system.IonTextWriterBuilder;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -84,19 +84,19 @@ class CoverageDatabase
     //=========================================================================
 
 
-    private final File myCoverageFile;
+    private final Path myStorageFile;
 
     private final Set<File> myRepositories = new HashSet<>();
 
     private final Map<SourceLocation,Boolean> myLocations = new HashMap<>();
 
 
-    public CoverageDatabase(File dataDir)
+    public CoverageDatabase(Path dataDir)
         throws IOException
     {
-        myCoverageFile = new File(dataDir, "coverage.ion");
+        myStorageFile = dataDir.resolve("coverage.ion");
 
-        if (myCoverageFile.exists())
+        if (Files.exists(myStorageFile))
         {
             read();
         }
@@ -340,8 +340,8 @@ class CoverageDatabase
     synchronized void write()
         throws IOException
     {
-        FusionUtils.createParentDirs(myCoverageFile);
-        try (OutputStream out = new FileOutputStream(myCoverageFile))
+        Files.createDirectories(myStorageFile.getParent());
+        try (OutputStream out = Files.newOutputStream(myStorageFile))
         {
             IonTextWriterBuilder builder =
                 IonTextWriterBuilder.minimal()
@@ -551,7 +551,7 @@ class CoverageDatabase
     private void read()
         throws IOException
     {
-        try (InputStream is = new FileInputStream(myCoverageFile))
+        try (InputStream is = Files.newInputStream(myStorageFile))
         {
             try (IonReader ir = IonReaderBuilder.standard().build(is))
             {

--- a/src/main/java/dev/ionfusion/fusion/FusionUtils.java
+++ b/src/main/java/dev/ionfusion/fusion/FusionUtils.java
@@ -130,21 +130,6 @@ final class FusionUtils
     }
 
 
-    static void createParentDirs(File file)
-        throws IOException
-    {
-        File parent = file.getParentFile();
-        if (parent != null && ! parent.exists())
-        {
-            if (! parent.mkdirs())
-            {
-                throw new IOException("Unable to create parent directory of "
-                                         + file);
-            }
-        }
-    }
-
-
     //=========================================================================
 
 

--- a/src/main/java/dev/ionfusion/fusion/HtmlWriter.java
+++ b/src/main/java/dev/ionfusion/fusion/HtmlWriter.java
@@ -7,11 +7,12 @@ import static com.amazon.ion.system.IonTextWriterBuilder.UTF8;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 class HtmlWriter
     implements AutoCloseable
@@ -22,10 +23,12 @@ class HtmlWriter
     HtmlWriter(File outputFile)
         throws IOException
     {
-        FusionUtils.createParentDirs(outputFile);
+        Path outputPath = outputFile.toPath();
+        Files.createDirectories(outputPath.getParent());
 
-        myOutStream = new FileOutputStream(outputFile);
+        myOutStream = Files.newOutputStream(outputPath);
 
+        // FIXME OutputStream will not be closed if this fails:
         myOut = new BufferedWriter(new OutputStreamWriter(myOutStream, UTF8));
     }
 

--- a/src/main/java/dev/ionfusion/fusion/_Private_CoverageCollectorImpl.java
+++ b/src/main/java/dev/ionfusion/fusion/_Private_CoverageCollectorImpl.java
@@ -57,7 +57,7 @@ public final class _Private_CoverageCollectorImpl
         throws FusionException, IOException
     {
         myConfig   = new CoverageConfiguration(dataDir);
-        myDatabase = new CoverageDatabase(dataDir);
+        myDatabase = new CoverageDatabase(dataDir.toPath());
     }
 
 

--- a/src/main/java/dev/ionfusion/fusion/_Private_CoverageWriter.java
+++ b/src/main/java/dev/ionfusion/fusion/_Private_CoverageWriter.java
@@ -169,7 +169,7 @@ public final class _Private_CoverageWriter
     public _Private_CoverageWriter(File dataDir)
         throws FusionException, IOException
     {
-        myDatabase = new CoverageDatabase(dataDir);
+        myDatabase = new CoverageDatabase(dataDir.toPath());
         myConfig   = new CoverageConfiguration(dataDir);
 
         myModules                 = new HashSet<>();


### PR DESCRIPTION
## Description

I'm opportunistically updating from `File` to `Path` as code is touched.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
