### PR TITLE
Have `ModuleInstance` make the `ModuleDocs`.

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/ModuleInstance.java
+++ b/src/main/java/dev/ionfusion/fusion/ModuleInstance.java
@@ -9,9 +9,11 @@ import dev.ionfusion.fusion.ModuleNamespace.ModuleDefinedBinding;
 import dev.ionfusion.fusion.ModuleNamespace.ProvidedBinding;
 import dev.ionfusion.fusion.Namespace.NsDefinedBinding;
 import dev.ionfusion.fusion._private.doc.model.BindingDoc;
+import dev.ionfusion.fusion._private.doc.model.ModuleDocs;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -102,11 +104,6 @@ final class ModuleInstance
         return myStore;
     }
 
-    String getDocs()
-    {
-        return myDocs;
-    }
-
     //========================================================================
 
     Collection<ProvidedBinding> providedBindings()
@@ -137,10 +134,31 @@ final class ModuleInstance
     }
 
 
+    //========================================================================
+    // Documentation metadata
+
+    ModuleDocs getDocs()
+    {
+        Set<BaseSymbol> names = providedNames();
+        Map<String, BindingDoc> bindings =
+            (names.isEmpty()
+                ? Collections.emptyMap()
+                : new HashMap<>(names.size()));
+
+        for (BaseSymbol name : names)
+        {
+            String text = name.stringValue();
+            BindingDoc doc = documentProvidedName(text);
+            bindings.put(text, doc);
+        }
+
+        return new ModuleDocs(myIdentity, myDocs, bindings);
+    }
+
     /**
      * @return may be null.
      */
-    BindingDoc documentProvidedName(String name)
+    private BindingDoc documentProvidedName(String name)
     {
         ModuleDefinedBinding binding = resolveProvidedName(name).target();
 
@@ -177,7 +195,7 @@ final class ModuleInstance
         return doc;
     }
 
-    BindingDoc documentProvidedName(ModuleDefinedBinding binding)
+    private BindingDoc documentProvidedName(ModuleDefinedBinding binding)
     {
         BindingDoc doc;
 

--- a/src/main/java/dev/ionfusion/fusion/StandardTopLevel.java
+++ b/src/main/java/dev/ionfusion/fusion/StandardTopLevel.java
@@ -3,11 +3,12 @@
 
 package dev.ionfusion.fusion;
 
+import static com.amazon.ion.util.IonTextUtils.printQuotedSymbol;
 import static dev.ionfusion.fusion.FusionIo.safeWriteToString;
 import static dev.ionfusion.fusion.FusionVoid.voidValue;
 import static dev.ionfusion.fusion.ModuleIdentity.isValidAbsoluteModulePath;
 import static dev.ionfusion.fusion.StandardReader.readSyntax;
-import static com.amazon.ion.util.IonTextUtils.printQuotedSymbol;
+
 import com.amazon.ion.IonReader;
 import java.io.File;
 import java.io.IOException;
@@ -189,6 +190,22 @@ final class StandardTopLevel
         try
         {
             return myNamespace.resolveAndLoadModule(myEvaluator, modulePath);
+        }
+        catch (FusionInterrupt e)
+        {
+            throw new FusionInterruptedException(e);
+        }
+    }
+
+    /**
+     * Get the instance of a previously loaded module.
+     */
+    ModuleInstance instantiateLoadedModule(ModuleIdentity id)
+        throws FusionInterruptedException, FusionException
+    {
+        try
+        {
+            return getRegistry().instantiate(myEvaluator, id);
         }
         catch (FusionInterrupt e)
         {

--- a/src/main/java/dev/ionfusion/fusion/_Private_Trampoline.java
+++ b/src/main/java/dev/ionfusion/fusion/_Private_Trampoline.java
@@ -3,6 +3,8 @@
 
 package dev.ionfusion.fusion;
 
+import dev.ionfusion.fusion._private.doc.model.ModuleDocs;
+
 /**
  * NOT FOR APPLICATION USE
  */
@@ -16,6 +18,26 @@ public class _Private_Trampoline
     {
         rb.setDocumenting(documenting);
     }
+
+    public static ModuleIdentity loadModule(TopLevel top, String modulePath)
+        throws FusionInterruptedException, FusionException
+    {
+        return ((StandardTopLevel) top).loadModule(modulePath);
+    }
+
+
+    /**
+     * Instantiates a previously loaded module and returns its documentation.
+     *
+     * @return null if the module isn't known in the top-level's registry.
+     */
+    public static ModuleDocs instantiateModuleDocs(TopLevel top, ModuleIdentity id)
+        throws FusionException
+    {
+        ModuleInstance moduleInstance = ((StandardTopLevel) top).instantiateLoadedModule(id);
+        return (moduleInstance == null ? null : moduleInstance.getDocs());
+    }
+
 
     public static FusionException newFusionException(String message,
                                                      Throwable cause)


### PR DESCRIPTION
This decouples the documentation model from the representation of those docs in source code.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
