### PR TITLE
Move docgen code out of the main package.

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/DocIndex.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/DocIndex.java
@@ -1,9 +1,11 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion;
+package dev.ionfusion.fusion._private.doc.tool;
 
+import dev.ionfusion.fusion.ModuleIdentity;
 import dev.ionfusion.fusion._private.doc.model.BindingDoc;
+import dev.ionfusion.fusion._private.doc.model.DocTreeNode;
 import dev.ionfusion.fusion._private.doc.model.ModuleDocs;
 import java.util.Map;
 import java.util.Set;
@@ -29,7 +31,7 @@ final class DocIndex
     //========================================================================
 
 
-    static DocIndex buildDocIndex(ModuleDoc doc)
+    static DocIndex buildDocIndex(DocTreeNode doc)
     {
         DocIndex index = new DocIndex();
         index.addEntriesForTree(doc);
@@ -37,11 +39,11 @@ final class DocIndex
     }
 
 
-    private void addEntriesForTree(ModuleDoc doc)
+    private void addEntriesForTree(DocTreeNode doc)
     {
         addEntriesForModule(doc.getModuleDocs());
 
-        for (ModuleDoc submodule : doc.submodules())
+        for (DocTreeNode submodule : doc.submodules())
         {
             addEntriesForTree(submodule);
         }

--- a/src/main/java/dev/ionfusion/fusion/cli/Document.java
+++ b/src/main/java/dev/ionfusion/fusion/cli/Document.java
@@ -3,7 +3,7 @@
 
 package dev.ionfusion.fusion.cli;
 
-import static dev.ionfusion.fusion._Private_ModuleDocumenter.writeHtmlTree;
+import static dev.ionfusion.fusion._private.doc.tool.DocGenerator.writeHtmlTree;
 
 import dev.ionfusion.fusion.ModuleIdentity;
 import java.io.File;


### PR DESCRIPTION
Rename `ModuleDoc` to `DocTreeNode`.
Rename `_Private_ModuleDocumenter` to `DocGenerator`.

## Description

Much more refactoring to come. This code was a real mess.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
