### PR TITLE
Extract class `MarkdownPageWriter` from `DocGenerator`.

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/MarkdownPageWriter.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/MarkdownPageWriter.java
@@ -1,0 +1,65 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion._private.doc.tool;
+
+import static com.amazon.ion.system.IonTextWriterBuilder.UTF8;
+import static dev.ionfusion.fusion._private.doc.tool.DocGenerator.HEADER_LINKS;
+import static java.util.regex.Pattern.MULTILINE;
+import static java.util.regex.Pattern.compile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Transforms a single Markdown file into HTML.
+ * <p>
+ * The page title is taken from the first H1, assumed to be authored using
+ * the atx syntax: {@code # <Title content>}.
+ */
+class MarkdownPageWriter
+    extends MarkdownWriter
+{
+    private static final String  TITLE_REGEX   = "^#\\s+(\\p{Print}+)\\s*$";
+    private static final Pattern TITLE_PATTERN = compile(TITLE_REGEX, MULTILINE);
+
+
+    private final String myBaseUrl;
+    private final Path   myMarkdownFile;
+
+    MarkdownPageWriter(Path outputFile, String baseUrl, Path markdownFile)
+        throws IOException
+    {
+        super(outputFile.toFile());
+        myBaseUrl = baseUrl;
+        myMarkdownFile = markdownFile;
+    }
+
+
+    void render()
+        throws IOException
+    {
+        // TODO Java11: use Files.readString
+        byte[] bytes = Files.readAllBytes(myMarkdownFile);
+        String markdownContent = new String(bytes, UTF8);
+
+        Matcher matcher = TITLE_PATTERN.matcher(markdownContent);
+        String title =
+            (matcher.find() ? matcher.group(1) : "Ion Fusion Documentation");
+
+        openHtml();
+        {
+            renderHead(title, myBaseUrl, "common.css", "doc.css");
+            openBody();
+            {
+                append(HEADER_LINKS);
+                markdown(markdownContent);
+            }
+            closeBody();
+        }
+        closeHtml();
+    }
+}

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/MarkdownWriter.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/MarkdownWriter.java
@@ -1,0 +1,28 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion._private.doc.tool;
+
+import com.petebevin.markdown.MarkdownProcessor;
+import dev.ionfusion.fusion._private.HtmlWriter;
+import java.io.File;
+import java.io.IOException;
+
+public class MarkdownWriter
+    extends HtmlWriter
+{
+    private final MarkdownProcessor myMarkdown = new MarkdownProcessor();
+
+    public MarkdownWriter(File outputFile)
+        throws IOException
+    {
+        super(outputFile);
+    }
+
+    protected void markdown(String text)
+        throws IOException
+    {
+        String md = myMarkdown.markdown(text);
+        append(md);
+    }
+}

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/ModuleWriter.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/ModuleWriter.java
@@ -5,9 +5,7 @@ package dev.ionfusion.fusion._private.doc.tool;
 
 import static java.util.stream.Collectors.toList;
 
-import com.petebevin.markdown.MarkdownProcessor;
 import dev.ionfusion.fusion.ModuleIdentity;
-import dev.ionfusion.fusion._private.HtmlWriter;
 import dev.ionfusion.fusion._private.doc.model.BindingDoc;
 import dev.ionfusion.fusion._private.doc.model.ModuleDocs;
 import dev.ionfusion.fusion._private.doc.model.ModuleEntity;
@@ -20,14 +18,13 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 final class ModuleWriter
-    extends HtmlWriter
+    extends MarkdownWriter
 {
     private final Predicate<ModuleIdentity> myFilter;
     private final String                    myBaseUrl;
     private final ModuleEntity              myModuleEntity;
     private final ModuleDocs                myModuleDocs;
     private final ModuleIdentity            myModuleId;
-    private final MarkdownProcessor         myMarkdown = new MarkdownProcessor();
 
     public ModuleWriter(Predicate<ModuleIdentity> filter,
                         File outputFile,
@@ -271,13 +268,5 @@ final class ModuleWriter
         }
 
         append("</div>\n"); // binding
-    }
-
-
-    private void markdown(String text)
-        throws IOException
-    {
-        String md = myMarkdown.markdown(text);
-        append(md);
     }
 }


### PR DESCRIPTION
## Description

Continuing to shift page rendering out of the main orchestration class.

I've confirmed that exactly the same file content is generated after this change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
