### PR TITLE
Use the site framework to render module reference pages.

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/_private/HtmlWriter.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/HtmlWriter.java
@@ -102,7 +102,17 @@ public class HtmlWriter
         if (baseUrl != null)
         {
             myOut.append("<base href='");
-            escape(baseUrl);
+            if (baseUrl.isEmpty() || baseUrl.equals("."))
+            {
+                myOut.append('.');
+            }
+            else
+            {
+                // TODO Remove this prefix. It is not necessary but prevents
+                //  the output from changing at this time.
+                myOut.append("./");
+                escape(baseUrl);
+            }
             myOut.append("'>");
         }
 

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/model/RepoEntity.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/model/RepoEntity.java
@@ -78,6 +78,14 @@ public class RepoEntity
         entity.setModuleDocs(module);
     }
 
+
+    /**
+     * Returns the modules selected from this repository.
+     *
+     * @return not null.
+     *
+     * @throws FusionException if there's a problem during discovery.
+     */
     public Set<ModuleEntity> getModules()
         throws FusionException
     {

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/SiteBuilder.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/SiteBuilder.java
@@ -1,0 +1,74 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion._private.doc.tool;
+
+import dev.ionfusion.fusion.FusionException;
+import dev.ionfusion.fusion.ModuleIdentity;
+import dev.ionfusion.fusion._private.StreamWriter;
+import dev.ionfusion.fusion._private.doc.model.ModuleEntity;
+import dev.ionfusion.fusion._private.doc.model.RepoEntity;
+import dev.ionfusion.fusion._private.doc.site.Site;
+import dev.ionfusion.fusion._private.doc.site.Template;
+import dev.ionfusion.fusion._private.doc.tool.layout.ModuleLayout;
+import dev.ionfusion.fusion._private.doc.tool.layout.StreamingTemplate;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.Predicate;
+
+public class SiteBuilder
+{
+    private final Site                      mySite = new Site();
+    private final RepoEntity                myRepo;
+    private final Predicate<ModuleIdentity> myModuleSelector;
+
+    /**
+     *
+     * @param repo
+     * @param selector predicate determining which modules will be documented.
+     */
+    public SiteBuilder(RepoEntity repo,
+                       Predicate<ModuleIdentity> selector)
+    {
+        myModuleSelector = selector;
+        myRepo = repo;
+    }
+
+    public Site build()
+        throws FusionException
+    {
+        return mySite;
+    }
+
+
+    private <E> void placePage(E entity, Path path, Template<E, StreamWriter> template)
+    {
+        mySite.placeArtifact(entity, path, new StreamingTemplate<E>(template));
+    }
+
+    private <E> void placePage(E entity, String path, Template<E, StreamWriter> template)
+    {
+        mySite.placeArtifact(entity, path, new StreamingTemplate<E>(template));
+    }
+
+
+    /**
+     * Discover selected modules in our {@link RepoEntity}, placing a page
+     * for each at the same path within the site.
+     *
+     * @throws FusionException for problems discovering modules.
+     */
+    public void placeModules()
+        throws FusionException
+    {
+        Template<ModuleEntity, StreamWriter> template = ModuleLayout.template(myModuleSelector);
+
+        for (ModuleEntity module : myRepo.getModules())
+        {
+            ModuleIdentity id = module.getIdentity();
+            Path file = Paths.get(".", id.absolutePath() + ".html");
+
+            placePage(module, file, template);
+        }
+    }
+}

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/BindingComparator.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/BindingComparator.java
@@ -1,7 +1,7 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion._private.doc.tool;
+package dev.ionfusion.fusion._private.doc.tool.layout;
 
 import java.util.Comparator;
 

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/CommonLayout.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/CommonLayout.java
@@ -1,0 +1,98 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion._private.doc.tool.layout;
+
+import dev.ionfusion.fusion._private.HtmlWriter;
+import dev.ionfusion.fusion._private.StreamWriter;
+import dev.ionfusion.fusion._private.doc.site.Artifact;
+import dev.ionfusion.fusion._private.doc.site.ArtifactGenerator;
+import java.io.IOException;
+import java.util.ArrayList;
+
+/**
+ * The base HTML layout for all pages, providing common structure and style.
+ *
+ * @param <E> the type of entity providing page content.
+ */
+public abstract class CommonLayout <E>
+    extends ArtifactGenerator<E, StreamWriter>
+{
+    /** HTML content for the masthead links */
+    private static final String HEADER_LINKS =
+        "<div class='indexlink'>" +
+        "<a href='index.html'>Top</a> " +
+        "<a href='binding-index.html'>Binding Index</a> " +
+        "(<a href='permuted-index.html'>Permuted</a>)" +
+        "</div>\n";
+
+
+    protected CommonLayout(Artifact<E> artifact)
+    {
+        super(artifact);
+    }
+
+
+    /**
+     * Collects the URLs of CSS style sheets to include in the HTML header.
+     * <p>
+     * This implementation adds the common style sheet.
+     * Subclasses that override to call this and add their own.
+     */
+    void addCssUrls(ArrayList<String> urls)
+        throws IOException
+    {
+        urls.add("common.css");
+    }
+
+
+    /**
+     * Gets the unescaped title of this page.
+     *
+     * @return the title. If null, a default title will be used.
+     *
+     * @throws IOException if the title cannot be retrieved.
+     */
+    abstract String getTitle()
+        throws IOException;
+
+
+    /**
+     * Writes layout content to the given output stream.
+     *
+     * @param out where to write content; not null.
+     *
+     * @throws IOException from the writer.
+     */
+    abstract void renderContent(StreamWriter out)
+        throws IOException;
+
+
+    @Override
+    public final void generate(StreamWriter out)
+        throws IOException
+    {
+        String title = getTitle();
+        if (title == null || title.isEmpty()) title = "Ion Fusion Documentation";
+
+        ArrayList<String> cssUrls = new ArrayList<>();
+        addCssUrls(cssUrls);
+
+        HtmlWriter writer = new HtmlWriter(out);
+        writer.openHtml();
+        {
+            writer.renderHead(title,
+                              getArtifact().getPathToBase().toString(),
+                              cssUrls.toArray(new String[0]));
+
+            writer.openBody();
+            {
+                writer.append(HEADER_LINKS);
+
+                renderContent(out);
+            }
+            writer.closeBody();
+        }
+        writer.closeHtml();
+    }
+}

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/ModuleLayout.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/ModuleLayout.java
@@ -1,0 +1,56 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion._private.doc.tool.layout;
+
+import dev.ionfusion.fusion.ModuleIdentity;
+import dev.ionfusion.fusion._private.StreamWriter;
+import dev.ionfusion.fusion._private.doc.model.ModuleEntity;
+import dev.ionfusion.fusion._private.doc.site.Artifact;
+import dev.ionfusion.fusion._private.doc.site.Template;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.function.Predicate;
+
+/**
+ * The HTML layout used for module reference pages.
+ * <p>
+ * The body of the page is rendered by a {@link ModuleWriter}.
+ */
+public final class ModuleLayout
+    extends CommonLayout<ModuleEntity>
+{
+    private final Predicate<ModuleIdentity> mySelector;
+
+    public ModuleLayout(Artifact<ModuleEntity> artifact, Predicate<ModuleIdentity> selector)
+    {
+        super(artifact);
+        mySelector = selector;
+    }
+
+    public static Template<ModuleEntity, StreamWriter> template(Predicate<ModuleIdentity> selector)
+    {
+        return artifact -> new ModuleLayout(artifact, selector);
+    }
+
+    @Override
+    void addCssUrls(ArrayList<String> urls)
+        throws IOException
+    {
+        super.addCssUrls(urls);
+        urls.add("module.css");
+    }
+
+    @Override
+    String getTitle()
+    {
+        return getEntity().getIdentity().absolutePath();
+    }
+
+    @Override
+    void renderContent(StreamWriter out)
+        throws IOException
+    {
+        new ModuleWriter(mySelector, out, getEntity()).renderModule();
+    }
+}

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/ModuleWriter.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/ModuleWriter.java
@@ -1,7 +1,7 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion._private.doc.tool;
+package dev.ionfusion.fusion._private.doc.tool.layout;
 
 import static java.util.stream.Collectors.toList;
 
@@ -10,6 +10,7 @@ import dev.ionfusion.fusion._private.StreamWriter;
 import dev.ionfusion.fusion._private.doc.model.BindingDoc;
 import dev.ionfusion.fusion._private.doc.model.ModuleDocs;
 import dev.ionfusion.fusion._private.doc.model.ModuleEntity;
+import dev.ionfusion.fusion._private.doc.tool.MarkdownWriter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -21,42 +22,29 @@ final class ModuleWriter
     extends MarkdownWriter
 {
     private final Predicate<ModuleIdentity> myFilter;
-    private final String                    myBaseUrl;
     private final ModuleEntity              myModuleEntity;
     private final ModuleDocs                myModuleDocs;
     private final ModuleIdentity            myModuleId;
 
     public ModuleWriter(Predicate<ModuleIdentity> filter,
                         StreamWriter out,
-                        String baseUrl,
                         ModuleEntity module)
     {
         super(out);
         myFilter = filter;
-        myBaseUrl = baseUrl;
         myModuleEntity = module;
         myModuleDocs = myModuleEntity.getModuleDocs();
         myModuleId = myModuleEntity.getIdentity();
     }
 
+
     void renderModule()
         throws IOException
     {
-        openHtml();
-        {
-            String modulePath = myModuleId.absolutePath();
-            renderHead(modulePath, myBaseUrl, "common.css", "module.css");
-
-            openBody();
-            {
-                renderHeader();
-                renderModuleIntro();
-                renderSubmoduleLinks();
-                renderBindings();
-            }
-            closeBody();
-        }
-        closeHtml();
+        renderHeader();
+        renderModuleIntro();
+        renderSubmoduleLinks();
+        renderBindings();
     }
 
 
@@ -87,7 +75,6 @@ final class ModuleWriter
     private void renderHeader()
         throws IOException
     {
-        append(DocGenerator.HEADER_LINKS);
         append("<h1>Module ");
         renderModulePathWithLinks(myModuleId);
         append("</h1>");

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/StreamingTemplate.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/StreamingTemplate.java
@@ -1,0 +1,41 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion._private.doc.tool.layout;
+
+import dev.ionfusion.fusion._private.StreamWriter;
+import dev.ionfusion.fusion._private.doc.site.Artifact;
+import dev.ionfusion.fusion._private.doc.site.Generator;
+import dev.ionfusion.fusion._private.doc.site.Template;
+import java.nio.file.Path;
+
+/**
+ * A template that writes to a {@link StreamWriter}, handling automatic
+ * creation and closing of the stream.
+ *
+ * @param <Entity> the type of entity that will populate the template.
+ */
+public class StreamingTemplate<Entity>
+    implements Template<Entity, Path>
+{
+    private final Template<Entity, StreamWriter> myStreamTemplate;
+
+    public StreamingTemplate(Template<Entity, StreamWriter> template)
+    {
+        myStreamTemplate = template;
+    }
+
+
+    @Override
+    public Generator<Path> populate(Artifact<Entity> artifact)
+    {
+        return (outFile) ->
+        {
+            Generator<StreamWriter> streamer = myStreamTemplate.populate(artifact);
+            try (StreamWriter writer = new StreamWriter(outFile))
+            {
+                streamer.generate(writer);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Description

This is a bigger change that refactors the docgen code producing module reference pages so that it uses the new site-generation mini-framework.

The new framework term here is `Layout` which is the result of populating a page template (that is, closing the template over its content entity).  As always, such results are artifact generators, in this case it just needs a `StreamWriter` to do so.

Suggested review order:
  * `StreamingTemplate` which is a little adaptor
  * `CommonLayout` abstract class generating the common page structure, leaving the main content to a subclass.
  * `ModuleLayout` subclasses it to generate module-ref page content; when given a `StreamWriter` it uses the existing `ModuleWriter` to render content.  
  * `ModuleWriter` can reference the stream as a member variable for code clarity.
  * `SiteBuilder` bundles up the preceding to place the reference pages within the `Site`.
  * (then the remaining small bits)

I recognize that the use of functional interfaces and lambdas can obscure things a bit, but otherwise the code is even more gnarly.

## Testing

I've verified that this change produces exactly the same output before and after.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
