### PR TITLE
Rework CLI's `document` interface.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -262,7 +262,7 @@ val fusiondocDir = docsDir.get().dir("fusiondoc")
 tasks.register<JavaExec>("fusiondocGen") {
     classpath = sourceSets["main"].runtimeClasspath
     mainClass = "dev.ionfusion.fusion.cli.Cli"
-    args = listOf("document", fusiondocDir.asFile.path, "fusion")
+    args = listOf("document", "--modules", "fusion", fusiondocDir.asFile.path)
 
     enableAssertions = true
 

--- a/src/main/java/dev/ionfusion/fusion/cli/Command.java
+++ b/src/main/java/dev/ionfusion/fusion/cli/Command.java
@@ -9,6 +9,8 @@ import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -212,6 +214,11 @@ abstract class Command
                 {
                     throw new UsageException("Missing argument: " + arg);
                 }
+                else if (propClass.equals(Path.class))
+                {
+                    // TODO handle InvalidPathException (etc?)
+                    value = Paths.get(value.toString());
+                }
                 else if (! propClass.equals(String.class))
                 {
                     throw new UsageException("Invalid option: " + arg);
@@ -321,7 +328,6 @@ abstract class Command
      *
      * @return null if there are no command options.
      */
-    final  // TODO See comment in prepare() before adding a command w/ options
     Object makeOptions(GlobalOptions globals)
     {
         return null;
@@ -350,10 +356,7 @@ abstract class Command
         // so any options we find will cause an error.
         if (options == null) options = new Object();
 
-        // TODO The `false` here causes the parser to accept options mingled
-        //  within the arguments. I don't think that's a good idea, but so far
-        //  no command has options, so it doesn't matter.
-        args = extractOptions(options, args, false);
+        args = extractOptions(options, args, true);
 
         return makeExecutor(globals, options, args);
     }

--- a/src/test/java/dev/ionfusion/fusion/cli/DocumentTest.java
+++ b/src/test/java/dev/ionfusion/fusion/cli/DocumentTest.java
@@ -6,6 +6,7 @@ package dev.ionfusion.fusion.cli;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import java.io.File;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ public class DocumentTest
     {
         String aFile = plainFile().getPath();
 
-        run(1, "document", aFile, "fusion");
+        run(1, "document", aFile);
 
         assertThat(stderrText, containsString(aFile));
     }
@@ -57,7 +58,7 @@ public class DocumentTest
     {
         String repo = noSuchFile().getPath();
 
-        run(1, "document", outputDir().getPath(), repo);
+        run(1, "document", "--modules", repo, outputDir().getPath());
 
         assertThat(stderrText, containsString("not a directory"));
         assertThat(stderrText, containsString(repo));
@@ -69,7 +70,7 @@ public class DocumentTest
     {
         String repo = plainFile().getPath();
 
-        run(1, "document", outputDir().getPath(), repo);
+        run(1, "document", "--modules", repo, outputDir().getPath());
 
         assertThat(stderrText, containsString("not a directory"));
         assertThat(stderrText, containsString(repo));
@@ -81,7 +82,7 @@ public class DocumentTest
     {
         String repo = newFolder(tmpDir, "junit").getPath();
 
-        run(1, "document", outputDir().getPath(), repo);
+        run(1, "document", "--modules", repo, outputDir().getPath());
 
         assertThat(stderrText, containsString("has no src"));
         assertThat(stderrText, containsString(repo));


### PR DESCRIPTION
Use a `--modules` option to declare what's being documented, instead of a second anonymous argument.

This prepares for more named arguments for different kinds of source files.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
