### PR TITLE
Filter binding cross-references in the `DocIndex` model, not the template

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/_private/doc/model/BindingDoc.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/model/BindingDoc.java
@@ -91,6 +91,12 @@ public final class BindingDoc
     }
 
 
+    /**
+     * Identifies the (visited) modules that provide this binding. This can
+     * include modules not selected for doc generation.
+     *
+     * @return not null.
+     */
     public Set<ModuleIdentity> getProvidingModules()
     {
         return myProvidingModules;

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/model/RepoEntity.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/model/RepoEntity.java
@@ -86,7 +86,7 @@ public class RepoEntity
      *
      * @throws FusionException if there's a problem during discovery.
      */
-    public Set<ModuleEntity> getModules()
+    public Set<ModuleEntity> getSelectedModules()
         throws FusionException
     {
         if (myModules == null)

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/SiteBuilder.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/SiteBuilder.java
@@ -70,7 +70,7 @@ public class SiteBuilder
     {
         Template<ModuleEntity, StreamWriter> template = ModuleLayout.template(myModuleSelector);
 
-        for (ModuleEntity module : myRepo.getModules())
+        for (ModuleEntity module : myRepo.getSelectedModules())
         {
             ModuleIdentity id = module.getIdentity();
             Path file = Paths.get(".", id.absolutePath() + ".html");
@@ -127,9 +127,9 @@ public class SiteBuilder
         throws FusionException
     {
         // The two index artifacts are different layouts of the same entity.
-        DocIndex docIndex = buildDocIndex(myRepo.getModules());
+        DocIndex docIndex = buildDocIndex(myModuleSelector, myRepo.getSelectedModules());
 
-        placePage(docIndex, "binding-index.html", AlphabeticalIndexLayout.template(myModuleSelector));
-        placePage(docIndex, "permuted-index.html", PermutedIndexLayout.template(myModuleSelector));
+        placePage(docIndex, "binding-index.html", AlphabeticalIndexLayout::new);
+        placePage(docIndex, "permuted-index.html", PermutedIndexLayout::new);
     }
 }

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/AlphabeticalIndexLayout.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/AlphabeticalIndexLayout.java
@@ -3,30 +3,18 @@
 
 package dev.ionfusion.fusion._private.doc.tool.layout;
 
-import dev.ionfusion.fusion.ModuleIdentity;
 import dev.ionfusion.fusion._private.StreamWriter;
 import dev.ionfusion.fusion._private.doc.site.Artifact;
-import dev.ionfusion.fusion._private.doc.site.Template;
 import dev.ionfusion.fusion._private.doc.tool.DocIndex;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.function.Predicate;
 
 public final class AlphabeticalIndexLayout
     extends CommonLayout<DocIndex>
 {
-    private final Predicate<ModuleIdentity> myFilter;
-
-    private AlphabeticalIndexLayout(Artifact<DocIndex> artifact, Predicate<ModuleIdentity> filter)
+    public AlphabeticalIndexLayout(Artifact<DocIndex> artifact)
     {
         super(artifact);
-        myFilter = filter;
-    }
-
-
-    public static Template<DocIndex, StreamWriter> template(Predicate<ModuleIdentity> filter)
-    {
-        return artifact -> new AlphabeticalIndexLayout(artifact, filter);
     }
 
 
@@ -49,6 +37,6 @@ public final class AlphabeticalIndexLayout
     void renderContent(StreamWriter out)
         throws IOException
     {
-        new AlphabeticalIndexWriter(getEntity(), myFilter, out).renderIndex();
+        new AlphabeticalIndexWriter(getEntity(), out).renderIndex();
     }
 }

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/AlphabeticalIndexWriter.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/AlphabeticalIndexWriter.java
@@ -10,20 +10,17 @@ import dev.ionfusion.fusion._private.doc.tool.DocIndex;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Predicate;
 
 final class AlphabeticalIndexWriter
     extends HtmlWriter
 {
-    private final DocIndex                  myIndex;
-    private final Predicate<ModuleIdentity> myFilter;
+    private final DocIndex myIndex;
 
 
-    AlphabeticalIndexWriter(DocIndex index, Predicate<ModuleIdentity> filter, StreamWriter out)
+    AlphabeticalIndexWriter(DocIndex index, StreamWriter out)
     {
         super(out);
         myIndex = index;
-        myFilter = filter;
     }
 
     void renderIndex()
@@ -42,15 +39,12 @@ final class AlphabeticalIndexWriter
             boolean printedOne = false;
             for (ModuleIdentity id : entry.getValue())
             {
-                if (myFilter.test(id))
+                if (printedOne)
                 {
-                    if (printedOne)
-                    {
-                        append(", ");
-                    }
-                    linkToBindingAsModulePath(id, escapedName);
-                    printedOne = true;
+                    append(", ");
                 }
+                linkToBindingAsModulePath(id, escapedName);
+                printedOne = true;
             }
 
             append("</td></tr>\n");

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/PermutedIndexLayout.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/PermutedIndexLayout.java
@@ -3,29 +3,18 @@
 
 package dev.ionfusion.fusion._private.doc.tool.layout;
 
-import dev.ionfusion.fusion.ModuleIdentity;
 import dev.ionfusion.fusion._private.StreamWriter;
 import dev.ionfusion.fusion._private.doc.site.Artifact;
-import dev.ionfusion.fusion._private.doc.site.Template;
 import dev.ionfusion.fusion._private.doc.tool.DocIndex;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.function.Predicate;
 
 public final class PermutedIndexLayout
     extends CommonLayout<DocIndex>
 {
-    private final Predicate<ModuleIdentity> myFilter;
-
-    private PermutedIndexLayout(Artifact<DocIndex> artifact, Predicate<ModuleIdentity> filter)
+    public PermutedIndexLayout(Artifact<DocIndex> artifact)
     {
         super(artifact);
-        myFilter = filter;
-    }
-
-    public static Template<DocIndex, StreamWriter> template(Predicate<ModuleIdentity> filter)
-    {
-        return artifact -> new PermutedIndexLayout(artifact, filter);
     }
 
     @Override
@@ -47,6 +36,6 @@ public final class PermutedIndexLayout
     void renderContent(StreamWriter out)
         throws IOException
     {
-        new PermutedIndexWriter(myFilter, getEntity(), out).renderIndex();
+        new PermutedIndexWriter(getEntity(), out).renderIndex();
     }
 }

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/PermutedIndexWriter.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/PermutedIndexWriter.java
@@ -11,13 +11,11 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.function.Predicate;
 
 final class PermutedIndexWriter
     extends HtmlWriter
 {
-    private final Predicate<ModuleIdentity> myFilter;
-    private final DocIndex                  myIndex;
+    private final DocIndex myIndex;
 
     /**
      * Maps keywords to the lines in which they exist.
@@ -89,11 +87,10 @@ final class PermutedIndexWriter
     }
 
 
-    PermutedIndexWriter(Predicate<ModuleIdentity> filter, DocIndex index, StreamWriter out)
+    PermutedIndexWriter(DocIndex index, StreamWriter out)
     {
         super(out);
 
-        myFilter = filter;
         myIndex = index;
         myLines = new TreeSet<>();
     }
@@ -147,15 +144,12 @@ final class PermutedIndexWriter
             boolean printedOne = false;
             for (ModuleIdentity id : line.modules())
             {
-                if (myFilter.test(id))
+                if (printedOne)
                 {
-                    if (printedOne)
-                    {
-                        append(", ");
-                    }
-                    linkToBindingAsModulePath(id, escapedName);
-                    printedOne = true;
+                    append(", ");
                 }
+                linkToBindingAsModulePath(id, escapedName);
+                printedOne = true;
             }
 
             append("</td></tr>\n");


### PR DESCRIPTION

## Description

I'm moving logic out of the template / page-rendering layer, to prepare for doing all HTML generation with a proper template system.

I'm experimenting with Mustache templates, and while I find some of its choices questionable, it's wayyy better than doing HTML in Java.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
