### PR TITLE
Extract `PermutedIndex` from `PermutedIndexWriter`.

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/DocIndex.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/DocIndex.java
@@ -75,4 +75,12 @@ public final class DocIndex
             }
         }
     }
+
+
+    public PermutedIndex permute()
+    {
+        PermutedIndex permuted = new PermutedIndex();
+        myNameMap.forEach(permuted::addEntries);
+        return permuted;
+    }
 }

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/PermutedIndex.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/PermutedIndex.java
@@ -1,0 +1,106 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion._private.doc.tool;
+
+import dev.ionfusion.fusion.ModuleIdentity;
+import java.util.Iterator;
+import java.util.TreeSet;
+
+public class PermutedIndex
+    implements Iterable<PermutedIndex.PermutedEntry>
+{
+    private final TreeSet<PermutedEntry> myEntries = new TreeSet<>();
+
+    @Override
+    public Iterator<PermutedEntry> iterator()
+    {
+        return myEntries.iterator();
+    }
+
+
+    /**
+     * An entry in the permuted index.
+     */
+    public static final class PermutedEntry
+        implements Comparable<PermutedEntry>
+    {
+        private final String                   myName;
+        private final String                   myPrefix;
+        private final String                   myKeyword;
+        private final Iterable<ModuleIdentity> myModules;
+
+
+        PermutedEntry(String name, Iterable<ModuleIdentity> modules,
+                      int keywordStartPos, int keywordLimitPos)
+        {
+            myName = name;
+            myPrefix = name.substring(0, keywordStartPos);
+            myKeyword = name.substring(keywordStartPos, keywordLimitPos);
+            myModules = modules;
+        }
+
+        public String bindingName()
+        {
+            return myName;
+        }
+
+        public String prefix()
+        {
+            return myPrefix;
+        }
+
+        public String keyword()
+        {
+            return myKeyword;
+        }
+
+        public String suffix()
+        {
+            int pos = myPrefix.length() + myKeyword.length();
+            return myName.substring(pos);
+        }
+
+        public Iterable<ModuleIdentity> modules()
+        {
+            return myModules;
+        }
+
+        @Override
+        public int compareTo(PermutedEntry that)
+        {
+            int result = myKeyword.compareTo(that.myKeyword);
+            if (result == 0)
+            {
+                result = myPrefix.compareTo(that.myPrefix);
+                if (result == 0)
+                {
+                    // We shouldn't get this far often, so we spend time to
+                    // get the suffix rather than memory to cache it.
+                    result = suffix().compareTo(that.suffix());
+                }
+            }
+            return result;
+        }
+    }
+
+
+    public void addEntries(String name, Iterable<ModuleIdentity> exportingModules)
+    {
+        int pos = 0;
+        while (true)
+        {
+            int underscorePos = name.indexOf('_', pos);
+            if (underscorePos == -1)
+            {
+                myEntries.add(new PermutedEntry(name, exportingModules, pos, name.length()));
+                break;
+            }
+            else if (pos < underscorePos)
+            {
+                myEntries.add(new PermutedEntry(name, exportingModules, pos, underscorePos));
+            }
+            pos = underscorePos + 1;
+        }
+    }
+}

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/SiteBuilder.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/SiteBuilder.java
@@ -156,10 +156,10 @@ public class SiteBuilder
     public void prepareIndexes()
         throws FusionException
     {
-        // The two index artifacts are different layouts of the same entity.
         DocIndex docIndex = buildDocIndex(myModuleSelector, myRepo.getSelectedModules());
+        PermutedIndex permuted = docIndex.permute();
 
         placePage(docIndex, "binding-index.html", AlphabeticalIndexLayout::new);
-        placePage(docIndex, "permuted-index.html", PermutedIndexLayout::new);
+        placePage(permuted, "permuted-index.html", PermutedIndexLayout::new);
     }
 }

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/PermutedIndexLayout.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/PermutedIndexLayout.java
@@ -5,14 +5,14 @@ package dev.ionfusion.fusion._private.doc.tool.layout;
 
 import dev.ionfusion.fusion._private.StreamWriter;
 import dev.ionfusion.fusion._private.doc.site.Artifact;
-import dev.ionfusion.fusion._private.doc.tool.DocIndex;
+import dev.ionfusion.fusion._private.doc.tool.PermutedIndex;
 import java.io.IOException;
 import java.util.ArrayList;
 
 public final class PermutedIndexLayout
-    extends CommonLayout<DocIndex>
+    extends CommonLayout<PermutedIndex>
 {
-    public PermutedIndexLayout(Artifact<DocIndex> artifact)
+    public PermutedIndexLayout(Artifact<PermutedIndex> artifact)
     {
         super(artifact);
     }


### PR DESCRIPTION
This moves more logic out of the rendering layer.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
