### PR TITLE
Update Gradle logic for `fusiondoc`.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -259,7 +259,10 @@ tasks.javadoc {
 
 val fusiondocDir = docsDir.get().dir("fusiondoc")
 
-tasks.register<JavaExec>("fusiondocGen") {
+tasks.register<JavaExec>("fusiondoc") {
+    group = "Documentation"
+    description = "Generates Fusion language and library documentation."
+
     var articlesDir = layout.projectDirectory.dir("src/doc/articles")
     var assetsDir   = layout.projectDirectory.dir("src/doc/assets")
 
@@ -273,17 +276,13 @@ tasks.register<JavaExec>("fusiondocGen") {
 
     enableAssertions = true
 
+    // Docgen has Java code! Not sure if this is the best solution...
+    dependsOn(tasks.compileJava)
+
     inputs.dir(layout.projectDirectory.dir("fusion"))
     inputs.dir(articlesDir)
     inputs.dir(assetsDir)
     outputs.dir(fusiondocDir)
-}
-
-val fusiondoc by tasks.register<Copy>("fusiondoc") {
-    group = "Documentation"
-    description = "Generates Fusion language and library documentation."
-
-    dependsOn("fusiondocGen")
 }
 
 


### PR DESCRIPTION
We no longer need the separate copy task, since our CLI does that now.

Also, I'm seeing Gradle do incorrect caching, which I don't know how to diagnose. I suspect its because the use of Java code wasn't modeled, so hopefully this helps.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
