### PR TITLE
Remove all uses of doc-strings on lambdas.

### DIFF
--- a/ftst/repo/src/ftst/check_more.fusion
+++ b/ftst/repo/src/ftst/check_more.fusion
@@ -40,13 +40,13 @@ Basically even-more-experimental stuff.
 
 
   (define_syntax run_top_and_module
-    (lambda (stx)
-      '''
+    '''
     (run_top_and_module expr ...)
 
 Evaluates the body expressions at top-level, and then within a single new
 module.  The module is `require`d to ensure it runs.
-      '''
+    '''
+    (lambda (stx)
       (let [(body (pair (quote begin) (tail (syntax_unwrap stx)))),
              (modname (make_module_name))]
         (d2s_at stx
@@ -58,13 +58,13 @@ module.  The module is `require`d to ensure it runs.
 
 
   (define_syntax expect_syntax_errors_top_and_module
-    (lambda (stx)
-      '''
+    '''
     (expect_syntax_errors_top_and_module expr ...)
 
 Evaluates each individual expression at top-level and within a new module,
 expecting each one to raise a syntax error.
-      '''
+    '''
+    (lambda (stx)
       (let [(exprs (tail (syntax_unwrap stx)))]
         (d2s_at stx
           (pair (quote begin)
@@ -81,12 +81,12 @@ expecting each one to raise a syntax error.
 
 
   (define_syntax expect_result_error_top
-    (lambda (stx)
-      '''
+    '''
     (expect_result_error_top expr ...)
 
 Evaluates the body expressions at top-level, expecting a (single) result error.
-      '''
+    '''
+    (lambda (stx)
       (lets [(exprs (tail (syntax_unwrap stx))),
              (body (pair (quote begin) exprs))]
         (d2s_at stx
@@ -95,13 +95,13 @@ Evaluates the body expressions at top-level, expecting a (single) result error.
 
 
   (define_syntax expect_result_errors_top_and_module
-    (lambda (stx)
-      '''
+    '''
     (expect_result_errors_top_and_module expr ...)
 
 Evaluates each individual expression at top-level and within a new module,
 expecting all to raise result errors.
-      '''
+    '''
+    (lambda (stx)
       (let [(exprs (tail (syntax_unwrap stx)))]
         (d2s_at stx
           (pair (quote begin)

--- a/ftst/repo/src/testutils.fusion
+++ b/ftst/repo/src/testutils.fusion
@@ -101,13 +101,14 @@
             {f:1, g:2})))
 
 
-  (defpub_syntax check_representative_ion_data
-    (lambda (stx)
-      '''
-      (check_representative_ion_data FORM)
+  (provide check_representative_ion_data)
+  (define_syntax check_representative_ion_data
+    '''
+    (check_representative_ion_data FORM)
 
 Maps the given syntactic form over each entry in `representative_ion_data`.
-      '''
+    '''
+    (lambda (stx)
       (let [(form_stx (syntax_get stx 1))]
         (datum_to_syntax
           (pair (quote begin)

--- a/ftst/syntax.test.fusion
+++ b/ftst/syntax.test.fusion
@@ -47,8 +47,7 @@
 // datum_to_syntax and syntax_to_datum
 
 (define_syntax check_xforms1
-  (lambda (stx)
-    '''
+  '''
     (check_xforms1 datum annotations)
     =>
     (begin (check_annotations (quote ANNOTATIONS) (quote DATUM))
@@ -56,7 +55,8 @@
              (syntax_to_datum (quote_syntax DATUM))
              (quote DATUM))
            /* And several variants */ )
-    '''
+  '''
+  (lambda (stx)
     (lets [(datum_stx (syntax_get stx 1)),
            (quote_datum_stx (quasisyntax (quote (unsyntax datum_stx))))]
       (quasisyntax
@@ -82,15 +82,15 @@
                                 (unsyntax datum_stx))))))))))
 
 (define_syntax check_xforms
-  (lambda (stx)
-    '''
+  '''
     (check_xforms datum)
     =>
     (begin (check_xforms1 datum)
            (check_xforms1 a::datum)    // TODO How to annotate syntax objects?
            (check_xforms1 a::a::datum)
            (check_xforms1 a::b::datum))
-    '''
+  '''
+  (lambda (stx)
     (lets [(datum_stx (syntax_get stx 1)),
            (datum     (syntax_unwrap datum_stx)),
            (  a_datum_stx (datum_to_syntax (annotate datum "a"    ))),

--- a/fusion/src/fusion/experimental/syntax.fusion
+++ b/fusion/src/fusion/experimental/syntax.fusion
@@ -153,7 +153,7 @@ otherwise the result is void.
                    false))),
              (has_duplicate_identifier
                (lambda (id ids)
-                 "Is `id` `bound_identifier_equal` to any element of `ids`?"
+                 // Is `id` `bound_identifier_equal` to any element of `ids`?
                  (if (is_pair ids)
                    (if (bound_identifier_equal id (head ids))
                      true

--- a/fusion/src/fusion/private/record.fusion
+++ b/fusion/src/fusion/private/record.fusion
@@ -40,9 +40,8 @@ TODO
 
 
   (define_syntax record
-    (lambda (stx)
-      '''
-      (record name (field_name ...))
+    '''
+    (record name (field_name ...))
 
 Creates a new record type and defines various related bindings based on the _name_.
 Each `name` and `field_name` must be a non-empty symbol; the `field_name`s must be
@@ -55,7 +54,8 @@ The bindings defined are:
   * `NAME_FIELD_NAME` for each `FIELD_NAME` is an accessor procedure.
     It accepts an instance of this record type and returns the value of
     the relevant field.
-      '''
+    '''
+    (lambda (stx)
       (unless (== (syntax_size stx) 3)
         (wrong_syntax stx "record: expected name and sexp of field names"))
       (lets [(name_stx   (syntax_get stx 1)),

--- a/src/main/java/dev/ionfusion/fusion/LambdaForm.java
+++ b/src/main/java/dev/ionfusion/fusion/LambdaForm.java
@@ -159,6 +159,9 @@ final class LambdaForm
             Object maybeDoc = stx.get(eval, 2).unwrap(eval);
             if (isString(eval, maybeDoc))
             {
+                System.err.println("WARNING: lambda docstring found at " + stx.getLocation() + ": " + stx);
+                assert false: "We don't want to use this any more";
+
                 doc = stringToJavaString(eval, maybeDoc);
                 if (doc != null) doc = doc.trim();
                 bodyStart = 3;
@@ -212,6 +215,7 @@ final class LambdaForm
 
         CompiledLambdaBase(String doc, String[] argNames, CompiledForm body)
         {
+            assert doc == null;
             myDoc      = doc;
             myArgNames = argNames;
             myBody     = body;

--- a/src/main/java/dev/ionfusion/fusion/ModuleBuilderImpl.java
+++ b/src/main/java/dev/ionfusion/fusion/ModuleBuilderImpl.java
@@ -60,6 +60,7 @@ final class ModuleBuilderImpl
             BindingDoc doc = ((Procedure) value).document();
             if (doc != null)
             {
+                assert false;
                 myNamespace.setDoc(name, doc);
             }
         }

--- a/src/main/java/dev/ionfusion/fusion/ModuleInstance.java
+++ b/src/main/java/dev/ionfusion/fusion/ModuleInstance.java
@@ -169,6 +169,7 @@ final class ModuleInstance
             if (value instanceof Procedure)
             {
                 doc = ((Procedure) value).document();
+                assert doc == null: "Doc on procs should be unused";
                 if (doc != null)
                 {
                     {

--- a/src/main/java/dev/ionfusion/fusion/Procedure.java
+++ b/src/main/java/dev/ionfusion/fusion/Procedure.java
@@ -44,7 +44,7 @@ abstract class Procedure
     @Deprecated
     Procedure(String doc, String... argNames)
     {
-        assert doc == null || ! doc.endsWith("\n");
+        assert doc == null;
         myArity = argNames.length;
 
         StringBuilder buf = new StringBuilder();

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/model/BindingDoc.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/model/BindingDoc.java
@@ -26,6 +26,7 @@ public final class BindingDoc
 
     public BindingDoc(String name, Kind kind, String usage, String body)
     {
+        assert myUsage == null;
         myName = name;
         myKind = kind;
         myUsage = usage;
@@ -62,6 +63,7 @@ public final class BindingDoc
         if (myUsage != null
             && ! (myUsage.startsWith("(") && myUsage.endsWith(")")))
         {
+            assert false: "I think this is unused.";
             StringBuilder buf = new StringBuilder();
             buf.append('(');
             buf.append(myName == null ? "_" : myName);
@@ -80,6 +82,7 @@ public final class BindingDoc
 
     void setUsage(String usage)
     {
+        assert false: "I don't think this can happen.";
         assert myUsage == null;
         myUsage = usage;
     }

--- a/src/test/java/dev/ionfusion/fusion/TailCallTest.java
+++ b/src/test/java/dev/ionfusion/fusion/TailCallTest.java
@@ -5,6 +5,7 @@ package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionNumber.checkIntArgToJavaInt;
 import static dev.ionfusion.fusion.FusionNumber.makeInt;
+
 import org.junit.jupiter.api.Test;
 
 public class TailCallTest
@@ -58,7 +59,7 @@ public class TailCallTest
     {
         CountupProc()
         {
-            super("countup", "i", "limit");
+            super(null, "i", "limit");
         }
 
         @Override


### PR DESCRIPTION
Add asserts to the compiler to prove readiness for code removal.

## Description

_What does this change achieve?_


## Related Issues

_What issue(s) does this change address?_



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
