### PR TITLE
Remove unused name from `BindingDoc`.

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/Compiler.java
+++ b/src/main/java/dev/ionfusion/fusion/Compiler.java
@@ -368,8 +368,7 @@ class Compiler
             for (int i = 0; i < idCount; i++)
             {
                 Object docString = docSeq.get(myEval, i).unwrap(myEval);
-                BindingDoc doc = new BindingDoc(names[i],
-                                                null, // kind
+                BindingDoc doc = new BindingDoc(null, // kind
                                                 null, // usage
                                                 stringToJavaString(myEval, docString));
                 namespace.setDoc(addresses[i], doc);
@@ -421,8 +420,7 @@ class Compiler
         {
             // We have documentation. Sort of.
             Object docString = stx.get(myEval, 2).unwrap(myEval);
-            BindingDoc doc = new BindingDoc(identifier.stringValue(),
-                                            Kind.SYNTAX,
+            BindingDoc doc = new BindingDoc(Kind.SYNTAX,
                                             null, // usage
                                             stringToJavaString(myEval, docString));
             int address = ((NsDefinedBinding) binding).myAddress;

--- a/src/main/java/dev/ionfusion/fusion/Namespace.java
+++ b/src/main/java/dev/ionfusion/fusion/Namespace.java
@@ -913,7 +913,7 @@ abstract class Namespace
 
     final void setDoc(String name, BindingDoc.Kind kind, String doc)
     {
-        BindingDoc bDoc = new BindingDoc(name, kind,
+        BindingDoc bDoc = new BindingDoc(kind,
                                          null, // usage
                                          doc);
         setDoc(name, bDoc);

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/model/BindingDoc.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/model/BindingDoc.java
@@ -14,7 +14,6 @@ public final class BindingDoc
 
     public enum Kind { PROCEDURE, SYNTAX, CONSTANT }
 
-    private String myName;
     private Kind   myKind;
     // TODO one-liner
     // TODO intro
@@ -24,24 +23,11 @@ public final class BindingDoc
     private final HashSet<ModuleIdentity> myProvidingModules = new HashSet<>();
 
 
-    public BindingDoc(String name, Kind kind, String usage, String body)
+    public BindingDoc(Kind kind, String usage, String body)
     {
-        myName = name;
         myKind = kind;
         myUsage = usage;
         myBody = body;
-    }
-
-
-    public String getName()
-    {
-        return myName;
-    }
-
-    public void setName(String name)
-    {
-        assert myName == null;
-        myName = name;
     }
 
 


### PR DESCRIPTION
This is appropriate: docs are tied to bindings (that is, definition sites), not to names, and bindings can be renamed when exported or imported.

It would be more appropriate for these to be keyed by `BoundIdentifier`, which have the correct equality semantics even when renamed.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
