### PR TITLE
Extract `TestSetup` from `CoreTestCase`.

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/FusionRuntimeBuilder.java
+++ b/src/main/java/dev/ionfusion/fusion/FusionRuntimeBuilder.java
@@ -5,6 +5,7 @@ package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.ModuleIdentity.isValidAbsoluteModulePath;
 import static dev.ionfusion.fusion._Private_CoverageCollectorImpl.fromDirectory;
+
 import com.amazon.ion.IonCatalog;
 import com.amazon.ion.system.SimpleCatalog;
 import java.io.File;
@@ -999,6 +1000,8 @@ public class FusionRuntimeBuilder
 
         // When our own unit tests are running in an IDE, this is nonfunctional;
         // we rely on the test setup configuring the bootstrap explicitly.
+        // TODO Need a better way to handle this for our own test cases so we
+        //   can delete the bootstrap repo configuration point.
         repos.add(new ClassLoaderModuleRepository(getClass().getClassLoader(),
                                                   "FUSION-REPO"));
 

--- a/src/test/java/ScriptedTests.java
+++ b/src/test/java/ScriptedTests.java
@@ -1,14 +1,12 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import static dev.ionfusion.fusion.CoreTestCase.ftstRepositoryDirectory;
-import static dev.ionfusion.fusion.CoreTestCase.fusionBootstrapDirectory;
+import static dev.ionfusion.fusion.TestSetup.makeRuntimeBuilder;
+import static dev.ionfusion.fusion.TestSetup.testRepositoryDirectory;
+import static dev.ionfusion.fusion.TestSetup.testScriptDirectory;
 
-import dev.ionfusion.fusion.FusionException;
 import dev.ionfusion.fusion.FusionRuntime;
-import dev.ionfusion.fusion.FusionRuntimeBuilder;
 import dev.ionfusion.fusion.junit.TreeWalker;
-import java.nio.file.Paths;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicNode;
@@ -33,39 +31,13 @@ public class ScriptedTests
     Stream<DynamicNode> ftst()
         throws Exception
     {
-        FusionRuntime runtime = makeRuntimeBuilder().build();
+        FusionRuntime runtime =
+            makeRuntimeBuilder().withRepositoryDirectory(testRepositoryDirectory().toFile())
+                                .build();
 
-        return TreeWalker.walk(Paths.get("ftst"),
+        return TreeWalker.walk(testScriptDirectory(),
                                dir -> true,
                                file -> file.getFileName().toString().endsWith(".test.fusion"),
                                file -> runtime.makeTopLevel().load(file.toFile()));
-    }
-
-
-    //========================================================================
-
-
-    private FusionRuntimeBuilder makeRuntimeBuilder()
-        throws FusionException
-    {
-        FusionRuntimeBuilder b = FusionRuntimeBuilder.standard();
-
-        // This allows tests to run in an IDE, so that we don't have to copy the
-        // bootstrap repo into the classpath.  In scripted builds, this has no
-        // effect since the classpath includes the code, which will shadow the
-        // content of this directory.
-        b = b.withBootstrapRepository(fusionBootstrapDirectory().toFile());
-
-        // Enable this to have coverage collected during an IDE run.
-//      b = b.withCoverageDataDirectory(new File("build/private/fcoverage"));
-
-        // This has no effect in an IDE, since this file is not on its copy of
-        // the test classpath.  In scripted builds, this provides the coverage
-        // configuration. Historically, it also provided the bootstrap repo.
-        b = b.withConfigProperties(getClass(), "/fusion.properties");
-
-        b.addRepositoryDirectory(ftstRepositoryDirectory().toFile());
-
-        return b.immutable();
     }
 }

--- a/src/test/java/dev/ionfusion/fusion/ClassLoaderModuleRepositoryTest.java
+++ b/src/test/java/dev/ionfusion/fusion/ClassLoaderModuleRepositoryTest.java
@@ -5,9 +5,12 @@ package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionIo.read;
 import static dev.ionfusion.fusion.FusionSexp.isPair;
+import static dev.ionfusion.fusion.TestSetup.PROJECT_DIRECTORY;
+import static dev.ionfusion.fusion.TestSetup.testRepositoryDirectory;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.amazon.ion.IonReader;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -68,7 +71,7 @@ public class ClassLoaderModuleRepositoryTest
     public void loadModuleFromDirectory()
         throws Exception
     {
-        Path dir = CoreTestCase.ftstRepositoryDirectory();
+        Path dir = testRepositoryDirectory();
 
         URL url = dir.toUri().toURL();
         assert url.getProtocol().equals("file");

--- a/src/test/java/dev/ionfusion/fusion/CoreTestCase.java
+++ b/src/test/java/dev/ionfusion/fusion/CoreTestCase.java
@@ -13,6 +13,7 @@ import static dev.ionfusion.fusion.FusionString.isString;
 import static dev.ionfusion.fusion.FusionString.unsafeStringToJavaString;
 import static dev.ionfusion.fusion.FusionValue.isAnyNull;
 import static dev.ionfusion.fusion.FusionVoid.isVoid;
+import static dev.ionfusion.fusion.TestSetup.testRepositoryDirectory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -70,45 +71,12 @@ public class CoreTestCase
 
     //========================================================================
 
-    /**
-     * The absolute path of the root directory of this source code.
-     * <p>
-     * Historically, tests code assumed it was run from the project root, but
-     * we'd prefer that not be a requirement.  Points of coupling to source code
-     * layout should instead use this path so they are easily adjusted if this
-     * assumption becomes false.
-     * <p>
-     * This is {@code static final} because Java doesn't guarantee that the
-     * "working directory" can't be changed dynamically.
-     * <p>
-     * This is {@code public} because we'd prefer test code use this directly
-     * than be blocked by not having a better resolver here.
-     * </p>
-     */
-    public static final Path PROJECT_DIRECTORY =
-        Paths.get("").toAbsolutePath();
-
 
     private final IonSystem            mySystem = IonSystemBuilder.standard().build();
     private       FusionRuntimeBuilder myRuntimeBuilder;
     private       FusionRuntime        myRuntime;
     private       TopLevel             myTopLevel;
 
-
-    public static Path fusionBootstrapDirectory()
-    {
-        return PROJECT_DIRECTORY.resolve("fusion");
-    }
-
-    public static Path ftstScriptDirectory()
-    {
-        return PROJECT_DIRECTORY.resolve("ftst");
-    }
-
-    public static Path ftstRepositoryDirectory()
-    {
-        return ftstScriptDirectory().resolve("repo");
-    }
 
     protected IonSystem system()
     {
@@ -120,25 +88,8 @@ public class CoreTestCase
     {
         if (myRuntimeBuilder == null)
         {
-            FusionRuntimeBuilder b = FusionRuntimeBuilder.standard();
-
-            // This allows tests to run in an IDE, so that we don't have to copy the
-            // bootstrap repo into the classpath.  In scripted builds, this has no
-            // effect since the classpath includes the code, which will shadow the
-            // content of this directory.
-            b = b.withBootstrapRepository(fusionBootstrapDirectory().toFile());
-
-            // Enable this to have coverage collected during an IDE run.
-//          b = b.withCoverageDataDirectory(new File("build/private/fcoverage"));
-
-            // This has no effect in an IDE, since this file is not on its copy of
-            // the test classpath.  In scripted builds, this provides the coverage
-            // configuration. Historically, it also provided the bootstrap repo.
-            b = b.withConfigProperties(getClass(), "/fusion.properties");
-
-            b = b.withInitialCurrentOutputPort(stdout());
-
-            myRuntimeBuilder = b;
+            myRuntimeBuilder = TestSetup.makeRuntimeBuilder()
+                                        .withInitialCurrentOutputPort(stdout());
         }
         return myRuntimeBuilder;
     }
@@ -146,7 +97,7 @@ public class CoreTestCase
     protected void useTstRepo()
         throws FusionException
     {
-        runtimeBuilder().addRepositoryDirectory(ftstRepositoryDirectory().toFile());
+        runtimeBuilder().addRepositoryDirectory(testRepositoryDirectory().toFile());
     }
 
     protected synchronized FusionRuntime runtime()

--- a/src/test/java/dev/ionfusion/fusion/FusionRuntimeBuilderTest.java
+++ b/src/test/java/dev/ionfusion/fusion/FusionRuntimeBuilderTest.java
@@ -5,6 +5,7 @@ package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionRuntimeBuilder.standard;
 import static dev.ionfusion.fusion.FusionString.unsafeStringToJavaString;
+import static dev.ionfusion.fusion.TestSetup.fusionBootstrapDirectory;
 import static dev.ionfusion.fusion.junit.Reflect.assertEqualProperties;
 import static dev.ionfusion.fusion.junit.Reflect.getterFor;
 import static dev.ionfusion.fusion.junit.Reflect.invoke;
@@ -20,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.amazon.ion.IonCatalog;
 import com.amazon.ion.system.SimpleCatalog;
 import java.io.ByteArrayOutputStream;

--- a/src/test/java/dev/ionfusion/fusion/RuntimeTest.java
+++ b/src/test/java/dev/ionfusion/fusion/RuntimeTest.java
@@ -4,6 +4,7 @@
 package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionVoid.isVoid;
+import static dev.ionfusion.fusion.TestSetup.testScriptDirectory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -14,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import com.amazon.ion.IonInt;
+
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.IonWriter;
@@ -51,7 +52,7 @@ public class RuntimeTest
         assertEval(3328, "x");
 
         // Test loading a script with top-level modules
-        loadFile(ftstScriptDirectory().resolve("topmodules.test.fusion"));
+        loadFile(testScriptDirectory().resolve("topmodules.test.fusion"));
     }
 
 

--- a/src/test/java/dev/ionfusion/fusion/TestSetup.java
+++ b/src/test/java/dev/ionfusion/fusion/TestSetup.java
@@ -1,0 +1,74 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion;import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class TestSetup
+{
+    /**
+     * The root directory of this source code, as an absolute path.
+     * <p>
+     * Historically, test code assumed it was run from the project root, but
+     * we'd prefer that not be a requirement.  Points of coupling to the code
+     * layout should instead use this path so they are easily adjusted if this
+     * assumption becomes false.
+     * <p>
+     * This is {@code static final} because Java doesn't guarantee that the
+     * "working directory" can't be changed dynamically.
+     * <p>
+     * This is {@code public} because we'd prefer test code use this directly
+     * than be blocked by not having a better resolver here.
+     * </p>
+     */
+    public static final Path PROJECT_DIRECTORY =
+        Paths.get("").toAbsolutePath();
+
+    /**
+     * The directory holding the Fusion bootstrap code (core libraries).
+     *
+     * @return an absolute path.
+     */
+    public static Path fusionBootstrapDirectory()
+    {
+        return PROJECT_DIRECTORY.resolve("fusion");
+    }
+
+    public static Path testScriptDirectory()
+    {
+        return PROJECT_DIRECTORY.resolve("ftst");
+    }
+
+    public static Path testRepositoryDirectory()
+    {
+        return testScriptDirectory().resolve("repo");
+    }
+
+
+    /**
+     * Create a standard Fusion runtime builder, configured for testing.
+     *
+     * @return a new, mutable builder instance.
+     */
+    public static FusionRuntimeBuilder makeRuntimeBuilder()
+        throws FusionException
+    {
+        FusionRuntimeBuilder b = FusionRuntimeBuilder.standard();
+
+        // This allows tests to run in an IDE, so that we don't have to copy the
+        // bootstrap repo into the classpath.  In scripted builds, this has no
+        // effect since the classpath includes the code, which will shadow the
+        // content of this directory.
+        b = b.withBootstrapRepository(fusionBootstrapDirectory().toFile());
+
+        // Enable this to have coverage collected during an IDE run.
+//      b = b.withCoverageDataDirectory(new File("build/private/fcoverage"));
+
+        // This has no effect in an IDE, since this file is not on its copy of
+        // the test classpath.  In scripted builds, this provides the coverage
+        // configuration. Historically, it also provided the bootstrap repo.
+        b = b.withConfigProperties(TestSetup.class, "/fusion.properties");
+
+        return b;
+    }
+}


### PR DESCRIPTION
This decouples the core configuration from specific test classes.

## Description

Working toward moving the top-level `ftst` content under `src/test` per Gradle conventions.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
