### PR TITLE
Refactor binding cross-reference indexing.

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/AlphaIndex.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/AlphaIndex.java
@@ -1,0 +1,64 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion._private.doc.tool;
+
+import java.util.Iterator;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+public class AlphaIndex
+    implements Iterable<AlphaIndex.AlphaEntry>
+{
+    private final TreeSet<AlphaEntry> myEntries;
+
+    public AlphaIndex()
+    {
+        myEntries = new TreeSet<>();
+    }
+
+    @Override
+    public Iterator<AlphaEntry> iterator()
+    {
+        return myEntries.iterator();
+    }
+
+
+    /**
+     * An entry in the alphabetical index.
+     */
+    public static final class AlphaEntry
+        implements Comparable<AlphaEntry>
+    {
+        private final String                     myName;
+        private final SortedSet<ExportedBinding> myExports;
+
+        AlphaEntry(String name, SortedSet<ExportedBinding> exports)
+        {
+            myName = name;
+            myExports = exports;
+        }
+
+        public String bindingName()
+        {
+            return myName;
+        }
+
+        public SortedSet<ExportedBinding> exports()
+        {
+            return myExports;
+        }
+
+        @Override
+        public int compareTo(AlphaEntry that)
+        {
+            return myName.compareTo(that.myName);
+        }
+    }
+
+
+    public void addEntry(String name, SortedSet<ExportedBinding> exports)
+    {
+        myEntries.add(new AlphaEntry(name, exports));
+    }
+}

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/BindingComparator.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/BindingComparator.java
@@ -1,7 +1,7 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion._private.doc.tool.layout;
+package dev.ionfusion.fusion._private.doc.tool;
 
 import java.util.Comparator;
 

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/ExportedBinding.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/ExportedBinding.java
@@ -1,0 +1,64 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion._private.doc.tool;
+
+import static java.util.Comparator.comparing;
+
+import dev.ionfusion.fusion.ModuleIdentity;
+import dev.ionfusion.fusion._private.doc.model.BindingDoc;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Denotes a name exported from a specific module, holding the docs for its
+ * associated binding (that is, unique definition site).
+ */
+public class ExportedBinding
+{
+    // TODO A module can export one binding under multiple names, so this
+    //  should sort secondarily by name, using the right comparator.
+    //  (But that shouldn't be static, since the index determines the sort.)
+    public static final Comparator<ExportedBinding> COMPARE_BY_MODULE =
+        comparing(ExportedBinding::getModuleId);
+
+    private final ModuleEntity myModule;
+    private final String       myName;
+    private final BindingDoc   myDocs;
+
+    public ExportedBinding(ModuleEntity module, String name, BindingDoc docs)
+    {
+        assert module != null;
+        assert name != null;
+
+        myModule = module;
+        myName = name;
+        myDocs = docs;
+    }
+
+
+    public ModuleIdentity getModuleId()
+    {
+        return myModule.getIdentity();
+    }
+
+    public String getName()
+    {
+        return myName;
+    }
+
+    /**
+     * Get any documentation associated with this export.
+     *
+     * @return may be null.
+     */
+    public BindingDoc getDocs()
+    {
+        return myDocs;
+    }
+
+    public List<ExportedBinding> alsoProvidedBy()
+    {
+        return myModule.getIndex().otherExportsOf(this);
+    }
+}

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/ModuleEntity.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/ModuleEntity.java
@@ -3,27 +3,37 @@
 
 package dev.ionfusion.fusion._private.doc.tool;
 
+import static java.util.Comparator.comparing;
+
 import dev.ionfusion.fusion.ModuleIdentity;
+import dev.ionfusion.fusion._private.doc.model.BindingDoc;
 import dev.ionfusion.fusion._private.doc.model.ModuleDocs;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * Holds aggregated documentation and cross-references for a module.
  */
 public class ModuleEntity
 {
-    private final DocIndex                  myIndex;
-    private final ModuleIdentity            myModuleIdentity;
-    private       ModuleDocs                myModuleDocs;
-    private final Map<String, ModuleEntity> myChildren;
+    private final DocIndex                   myIndex;
+    private final ModuleIdentity             myModuleIdentity;
+    private       ModuleDocs                 myModuleDocs;
+    private final Map<String, ModuleEntity>  myChildren;
+    private final SortedSet<ExportedBinding> myExports;
+
 
     ModuleEntity(DocIndex index, ModuleIdentity id)
     {
         myIndex = index;
         myModuleIdentity = id;
         myChildren = new HashMap<>();
+        myExports = new TreeSet<>(comparing(ExportedBinding::getName,
+                                            index.getBoundNameComparator()));
     }
 
 
@@ -43,6 +53,8 @@ public class ModuleEntity
         assert myModuleDocs == null;
         assert docs.getIdentity() == myModuleIdentity;
         myModuleDocs = docs;
+
+        docs.getBindingDocs().forEach(this::addExport);
     }
 
     /**
@@ -54,6 +66,9 @@ public class ModuleEntity
     }
 
 
+    //=========================================================================
+    // Submodules
+
     void addChild(ModuleEntity child)
     {
         myChildren.put(child.getIdentity().baseName(), child);
@@ -64,8 +79,30 @@ public class ModuleEntity
         return myChildren.get(name);
     }
 
+    /**
+     * Not sorted.
+     */
     public Set<String> getChildNames()
     {
         return myChildren.keySet();
+    }
+
+
+    //=========================================================================
+    // Exported bindings
+
+    private void addExport(String name, BindingDoc export)
+    {
+        myExports.add(new ExportedBinding(this, name, export));
+    }
+
+    /**
+     * Gets the docs for exported bindings, sorted by name.
+     *
+     * @return not null
+     */
+    public Collection<ExportedBinding> exports()
+    {
+        return myExports;
     }
 }

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/PermutedIndex.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/PermutedIndex.java
@@ -3,8 +3,8 @@
 
 package dev.ionfusion.fusion._private.doc.tool;
 
-import dev.ionfusion.fusion.ModuleIdentity;
 import java.util.Iterator;
+import java.util.SortedSet;
 import java.util.TreeSet;
 
 public class PermutedIndex
@@ -25,19 +25,19 @@ public class PermutedIndex
     public static final class PermutedEntry
         implements Comparable<PermutedEntry>
     {
-        private final String                   myName;
-        private final String                   myPrefix;
-        private final String                   myKeyword;
-        private final Iterable<ModuleIdentity> myModules;
+        private final String                     myName;
+        private final String                     myPrefix;
+        private final String                     myKeyword;
+        private final SortedSet<ExportedBinding> myExports;
 
 
-        PermutedEntry(String name, Iterable<ModuleIdentity> modules,
+        PermutedEntry(String name, SortedSet<ExportedBinding> exports,
                       int keywordStartPos, int keywordLimitPos)
         {
             myName = name;
             myPrefix = name.substring(0, keywordStartPos);
             myKeyword = name.substring(keywordStartPos, keywordLimitPos);
-            myModules = modules;
+            myExports = exports;
         }
 
         public String bindingName()
@@ -61,9 +61,9 @@ public class PermutedIndex
             return myName.substring(pos);
         }
 
-        public Iterable<ModuleIdentity> modules()
+        public SortedSet<ExportedBinding> exports()
         {
-            return myModules;
+            return myExports;
         }
 
         @Override
@@ -85,7 +85,7 @@ public class PermutedIndex
     }
 
 
-    public void addEntries(String name, Iterable<ModuleIdentity> exportingModules)
+    public void addEntries(String name, SortedSet<ExportedBinding> exports)
     {
         int pos = 0;
         while (true)
@@ -93,12 +93,12 @@ public class PermutedIndex
             int underscorePos = name.indexOf('_', pos);
             if (underscorePos == -1)
             {
-                myEntries.add(new PermutedEntry(name, exportingModules, pos, name.length()));
+                myEntries.add(new PermutedEntry(name, exports, pos, name.length()));
                 break;
             }
             else if (pos < underscorePos)
             {
-                myEntries.add(new PermutedEntry(name, exportingModules, pos, underscorePos));
+                myEntries.add(new PermutedEntry(name, exports, pos, underscorePos));
             }
             pos = underscorePos + 1;
         }

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/SiteBuilder.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/SiteBuilder.java
@@ -163,9 +163,10 @@ public class SiteBuilder
     public void prepareIndexes()
         throws FusionException
     {
+        AlphaIndex alpha = myIndex.alphabetize();
         PermutedIndex permuted = myIndex.permute();
 
-        placePage(myIndex, "binding-index.html", AlphabeticalIndexLayout::new);
+        placePage(alpha, "binding-index.html", AlphabeticalIndexLayout::new);
         placePage(permuted, "permuted-index.html", PermutedIndexLayout::new);
     }
 }

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/AlphabeticalIndexLayout.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/AlphabeticalIndexLayout.java
@@ -5,14 +5,14 @@ package dev.ionfusion.fusion._private.doc.tool.layout;
 
 import dev.ionfusion.fusion._private.StreamWriter;
 import dev.ionfusion.fusion._private.doc.site.Artifact;
-import dev.ionfusion.fusion._private.doc.tool.DocIndex;
+import dev.ionfusion.fusion._private.doc.tool.AlphaIndex;
 import java.io.IOException;
 import java.util.ArrayList;
 
 public final class AlphabeticalIndexLayout
-    extends CommonLayout<DocIndex>
+    extends CommonLayout<AlphaIndex>
 {
-    public AlphabeticalIndexLayout(Artifact<DocIndex> artifact)
+    public AlphabeticalIndexLayout(Artifact<AlphaIndex> artifact)
     {
         super(artifact);
     }

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/AlphabeticalIndexWriter.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/AlphabeticalIndexWriter.java
@@ -3,21 +3,19 @@
 
 package dev.ionfusion.fusion._private.doc.tool.layout;
 
-import dev.ionfusion.fusion.ModuleIdentity;
 import dev.ionfusion.fusion._private.HtmlWriter;
 import dev.ionfusion.fusion._private.StreamWriter;
-import dev.ionfusion.fusion._private.doc.tool.DocIndex;
+import dev.ionfusion.fusion._private.doc.tool.AlphaIndex;
+import dev.ionfusion.fusion._private.doc.tool.ExportedBinding;
 import java.io.IOException;
-import java.util.Map;
-import java.util.Set;
 
 final class AlphabeticalIndexWriter
     extends HtmlWriter
 {
-    private final DocIndex myIndex;
+    private final AlphaIndex myIndex;
 
 
-    AlphabeticalIndexWriter(DocIndex index, StreamWriter out)
+    AlphabeticalIndexWriter(AlphaIndex index, StreamWriter out)
     {
         super(out);
         myIndex = index;
@@ -29,21 +27,21 @@ final class AlphabeticalIndexWriter
         renderHeader1("Binding Index");
 
         append("<table><tbody>");
-        for (Map.Entry<String, Set<ModuleIdentity>> entry : myIndex.getNameMap().entrySet())
+        for (AlphaIndex.AlphaEntry entry : myIndex)
         {
-            String escapedName = escapeString(entry.getKey());
+            String escapedName = escapeString(entry.bindingName());
             append("<tr><td class='bound'>");
             append(escapedName);
             append("</td><td>");
 
             boolean printedOne = false;
-            for (ModuleIdentity id : entry.getValue())
+            for (ExportedBinding export : entry.exports())
             {
                 if (printedOne)
                 {
                     append(", ");
                 }
-                linkToBindingAsModulePath(id, escapedName);
+                linkToBindingAsModulePath(export.getModuleId(), escapedName);
                 printedOne = true;
             }
 

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/PermutedIndexWriter.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/layout/PermutedIndexWriter.java
@@ -3,9 +3,9 @@
 
 package dev.ionfusion.fusion._private.doc.tool.layout;
 
-import dev.ionfusion.fusion.ModuleIdentity;
 import dev.ionfusion.fusion._private.HtmlWriter;
 import dev.ionfusion.fusion._private.StreamWriter;
+import dev.ionfusion.fusion._private.doc.tool.ExportedBinding;
 import dev.ionfusion.fusion._private.doc.tool.PermutedIndex;
 import dev.ionfusion.fusion._private.doc.tool.PermutedIndex.PermutedEntry;
 import java.io.IOException;
@@ -41,13 +41,13 @@ final class PermutedIndexWriter
             append("</td><td>");
 
             boolean printedOne = false;
-            for (ModuleIdentity id : line.modules())
+            for (ExportedBinding export : line.exports())
             {
                 if (printedOne)
                 {
                     append(", ");
                 }
-                linkToBindingAsModulePath(id, escapedName);
+                linkToBindingAsModulePath(export.getModuleId(), escapedName);
                 printedOne = true;
             }
 


### PR DESCRIPTION
The main goal is to get sorting out of the rendering layer to prepare for a template system that cannot do that.

* Add `ExportedBinding` to keep track of each specific export.
* Add `AlphaIndex` to align with `PermutedIndex` and expose just the right data to the template.

## Notes

This should be the last big refactoring step before swapping out all the `*Layout` and `*Writer` code for proper templates.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
