### PR TITLE
Use binding comparator for indexes.

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/AlphaIndex.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/AlphaIndex.java
@@ -3,6 +3,7 @@
 
 package dev.ionfusion.fusion._private.doc.tool;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -10,12 +11,15 @@ import java.util.TreeSet;
 public class AlphaIndex
     implements Iterable<AlphaIndex.AlphaEntry>
 {
+    private final Comparator<String>  myBoundNameComparator;
     private final TreeSet<AlphaEntry> myEntries;
 
-    public AlphaIndex()
+    public AlphaIndex(Comparator<String> boundNameComparator)
     {
+        myBoundNameComparator = boundNameComparator;
         myEntries = new TreeSet<>();
     }
+
 
     @Override
     public Iterator<AlphaEntry> iterator()
@@ -27,7 +31,7 @@ public class AlphaIndex
     /**
      * An entry in the alphabetical index.
      */
-    public static final class AlphaEntry
+    public final class AlphaEntry
         implements Comparable<AlphaEntry>
     {
         private final String                     myName;
@@ -52,7 +56,7 @@ public class AlphaIndex
         @Override
         public int compareTo(AlphaEntry that)
         {
-            return myName.compareTo(that.myName);
+            return myBoundNameComparator.compare(this.myName, that.myName);
         }
     }
 

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/DocIndex.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/DocIndex.java
@@ -63,14 +63,14 @@ public final class DocIndex
 
     public AlphaIndex alphabetize()
     {
-        AlphaIndex alpha = new AlphaIndex();
+        AlphaIndex alpha = new AlphaIndex(myBoundNameComparator);
         myExports.forEach(alpha::addEntry);
         return alpha;
     }
 
     public PermutedIndex permute()
     {
-        PermutedIndex permuted = new PermutedIndex();
+        PermutedIndex permuted = new PermutedIndex(myBoundNameComparator);
         myExports.forEach(permuted::addEntries);
         return permuted;
     }

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/PermutedIndex.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/PermutedIndex.java
@@ -3,6 +3,7 @@
 
 package dev.ionfusion.fusion._private.doc.tool;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -10,7 +11,15 @@ import java.util.TreeSet;
 public class PermutedIndex
     implements Iterable<PermutedIndex.PermutedEntry>
 {
-    private final TreeSet<PermutedEntry> myEntries = new TreeSet<>();
+    private final Comparator<String>     myBoundNameComparator;
+    private final TreeSet<PermutedEntry> myEntries;
+
+    public PermutedIndex(Comparator<String> boundNameComparator)
+    {
+        myBoundNameComparator = boundNameComparator;
+        myEntries = new TreeSet<>();
+    }
+
 
     @Override
     public Iterator<PermutedEntry> iterator()
@@ -22,7 +31,7 @@ public class PermutedIndex
     /**
      * An entry in the permuted index.
      */
-    public static final class PermutedEntry
+    public final class PermutedEntry
         implements Comparable<PermutedEntry>
     {
         private final String                     myName;
@@ -69,15 +78,16 @@ public class PermutedIndex
         @Override
         public int compareTo(PermutedEntry that)
         {
-            int result = myKeyword.compareTo(that.myKeyword);
+            Comparator<String> c = myBoundNameComparator;
+            int result = c.compare(this.myKeyword, that.myKeyword);
             if (result == 0)
             {
-                result = myPrefix.compareTo(that.myPrefix);
+                result = c.compare(this.myPrefix, that.myPrefix);
                 if (result == 0)
                 {
                     // We shouldn't get this far often, so we spend time to
                     // get the suffix rather than memory to cache it.
-                    result = suffix().compareTo(that.suffix());
+                    result = c.compare(this.suffix(), that.suffix());
                 }
             }
             return result;


### PR DESCRIPTION
This makes sort-order consistent between the list of export bindings atop each module reference page, and the lists in the indexes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
