### PR TITLE
Cleanup base URL handling.

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/_private/doc/site/Artifact.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/site/Artifact.java
@@ -17,6 +17,7 @@ import java.nio.file.Paths;
 public class Artifact <Entity>
 {
     private static final Path EMPTY_PATH = Paths.get("");
+    private static final Path DOT_PATH   = Paths.get(".");
 
     private final Entity myEntity;
     private final Path   myPath;
@@ -34,8 +35,14 @@ public class Artifact <Entity>
             throw new IllegalArgumentException("File path must be relative to site root");
         }
 
+        // Leading dots complicate path manipulation.
+        while (path.startsWith(DOT_PATH))
+        {
+            path = path.subpath(1, path.getNameCount());
+        }
+
         myEntity = requireNonNull(entity);
-        myPath = requireNonNull(path);
+        myPath = path;
     }
 
 
@@ -67,23 +74,18 @@ public class Artifact <Entity>
      */
     public Path getPathToBase()
     {
+        // NOTE: Path.relativize() is defective in Java 8 and earlier when
+        //  given paths that include a `.` component.
+        //  https://bugs.openjdk.org/browse/JDK-8066943
         Path parent = myPath.getParent();
         return (parent == null ? EMPTY_PATH : parent.relativize(EMPTY_PATH));
     }
 
     public String baseUrl()
     {
+        // It's unclear to me whether <base> handles "" and "." identically, so
+        // lets play it safe.
         String baseUrl = getPathToBase().toString();
-        if (baseUrl.isEmpty() || baseUrl.equals("."))
-        {
-            baseUrl = ".";
-        }
-        else
-        {
-            // TODO Remove this prefix. It is not necessary but prevents
-            //  the output from changing at this time.
-            baseUrl = "./" + baseUrl;
-        }
-        return baseUrl;
+        return (baseUrl.isEmpty() ? "." : baseUrl);
     }
 }


### PR DESCRIPTION
Workaround a Java 8 bug and simplify the paths.

## Notes

I finally tracked down an oddity that's been bugging me: sometimes docgen would produce the wrong base URLs, breaking various links (most obviously, stylesheets).   Turns out that running the `fusiondoc` Gradle task from inside IDEA would run `fusion` CLI using Java 8, which the `gradle` CLI used Java 21.  **AND** there's a bug in Java 8 and earlier that broke our relative-path-to-base computation.   This PR works around that bug.  In another PR I'll attempt to ensure Gradle uses a consistent JDK for these tasks.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
