### PR TITLE
Use toolchain JDK when Gradle runs `java`.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -218,6 +218,10 @@ val fcovTestReport = tasks.register<JavaExec>("fcovTestReport") {
     group = "verification"
     description = "Generates Fusion code coverage report"
 
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = java.toolchain.languageVersion
+    }
+
     classpath = sourceSets["main"].runtimeClasspath
     mainClass = "dev.ionfusion.fusion.cli.Cli"
     args = listOf("report_coverage",
@@ -266,6 +270,10 @@ tasks.register<JavaExec>("fusiondoc") {
 
     var articlesDir = layout.projectDirectory.dir("src/doc/articles")
     var assetsDir   = layout.projectDirectory.dir("src/doc/assets")
+
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = java.toolchain.languageVersion
+    }
 
     classpath = sourceSets["main"].runtimeClasspath
     mainClass = "dev.ionfusion.fusion.cli.Cli"


### PR DESCRIPTION
Otherwise, this defaults to the JDK running Gradle itself, which can vary by environment. For example, my IDEA uses JDK 8, but my command-line `gradle` chose JDK 21.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
