### PR TITLE
[small] Rename `moreCss` template section to `moreHead`.

### DIFF
--- a/src/doc/templates/article.html
+++ b/src/doc/templates/article.html
@@ -1,9 +1,9 @@
 {{! Copyright Ion Fusion contributors. All rights reserved. }}
 {{! SPDX-License-Identifier: Apache-2.0 }}
 {{<common}}
-  {{$moreCss}}
+  {{$moreHead}}
     <link href='doc.css' rel='stylesheet' type='text/css'></link>
-  {{/moreCss}}
+  {{/moreHead}}
   {{$title}}{{entity.title}}{{/title}}
   {{$content}}
     {{#md}}{{&entity.content}}{{/md}}

--- a/src/doc/templates/binding-index.html
+++ b/src/doc/templates/binding-index.html
@@ -1,9 +1,9 @@
 {{! Copyright Ion Fusion contributors. All rights reserved. }}
 {{! SPDX-License-Identifier: Apache-2.0 }}
 {{<common}}
-  {{$moreCss}}
+  {{$moreHead}}
     <link href='index.css' rel='stylesheet' type='text/css'></link>
-  {{/moreCss}}
+  {{/moreHead}}
   {{$title}}Fusion Binding Index{{/title}}
   {{$content}}
     <h1>Binding Index</h1>

--- a/src/doc/templates/common.html
+++ b/src/doc/templates/common.html
@@ -3,7 +3,7 @@
 {{<base}}
   {{$head}}
     <link href='common.css' rel='stylesheet' type='text/css'></link>
-    {{$moreCss}}{{/moreCss}}
+    {{$moreHead}}{{/moreHead}}
   {{/head}}
   {{$title}}Proto Template{{/title}}
   {{$body}}

--- a/src/doc/templates/module.html
+++ b/src/doc/templates/module.html
@@ -15,9 +15,9 @@
         also
 }}
 {{<common}}
-  {{$moreCss}}
+  {{$moreHead}}
     <link href='module.css' rel='stylesheet' type='text/css'></link>
-  {{/moreCss}}
+  {{/moreHead}}
   {{$title}}{{entity.identity.absolutePath}}{{/title}}
   {{$content}}
     <h1>Module {{#entity.identity}}{{>breadcrumbs}}{{/entity.identity}}</h1>

--- a/src/doc/templates/permuted-index.html
+++ b/src/doc/templates/permuted-index.html
@@ -1,9 +1,9 @@
 {{! Copyright Ion Fusion contributors. All rights reserved. }}
 {{! SPDX-License-Identifier: Apache-2.0 }}
 {{<common}}
-  {{$moreCss}}
+  {{$moreHead}}
     <link href='index.css' rel='stylesheet' type='text/css'></link>
-  {{/moreCss}}
+  {{/moreHead}}
   {{$title}}Fusion Binding Index (Permuted){{/title}}
   {{$content}}
     <h1>Permuted Binding Index</h1>


### PR DESCRIPTION
This could be used for any `<head>` content.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
