### PR TITLE
Use a simple two-column layout for docs.

### DIFF
--- a/src/doc/assets/common.css
+++ b/src/doc/assets/common.css
@@ -1,6 +1,55 @@
 /* Copyright Ion Fusion contributors. All rights reserved. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-.indexlink {
-  float: right;
+.leftnav {
+    position: fixed;
+    z-index: 2;
+    overflow-y: scroll;
+/*  float: none; /* Not sure why Racket has this */
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 14rem; /* Sync with main margin-left */
+    padding: 0.5rem 0.5rem 0.5rem 0.5rem;
+    background-color: lightsteelblue;
+/*  border-top: 6rem solid hsl(216, 15%, 70%); */
+}
+
+#toplink {
+    /* TODO font */
+    font-size: 2rem;
+    font-weight: bold;
+    margin-left: 0;
+    margin-bottom: .5rem;
+}
+
+.leftnav h1 {
+    font-size: 1.25rem;
+    margin-top: 1rem;
+    margin-bottom: 0.25rem;
+}
+
+.leftnav nav {
+    margin-left: 1rem;
+    margin-bottom: .5rem;
+}
+
+.leftnav a {
+    display: block;
+    color: black;
+    text-decoration: none;
+}
+
+.leftnav a:hover {
+    text-decoration: underline;
+}
+
+
+.main {
+    width: auto;
+    margin-top: 1rem;
+    margin-left: 15.5rem;  /* Sync with leftnav width */
+    margin-right: 2rem;
+    max-width: 700px;
+    min-width: 370px; /* below this size, code samples don't fit */
 }

--- a/src/doc/templates/common.html
+++ b/src/doc/templates/common.html
@@ -6,12 +6,39 @@
     {{$moreCss}}{{/moreCss}}
   {{/head}}
   {{$title}}Proto Template{{/title}}
+  {{! TODO Add skip links for accessibility:
+      https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#skip_links }}
   {{$body}}
-    <div class='indexlink'>
-      <a href='index.html'>Top</a>
-      <a href='binding-index.html'>Binding Index</a>
-      (<a href='permuted-index.html'>Permuted</a>)
+    <nav class="leftnav">
+      <a id="toplink" href="index.html">Ion Fusion</a>
+
+      <h1>Tutorials</h1>
+      <nav>
+        <a href='tutorial_cli.html'>Exploring the <code>fusion</code> CLI</a>
+      </nav>
+
+      <h1>How-To Guides</h1>
+      <nav>
+        <a href='howto_build.html'>How to Build Ion Fusion</a>
+      </nav>
+
+      <h1>Explanation</h1>
+      <nav>
+        <a href='about_cli.html'>About the <code>fusion</code> CLI</a>
+      </nav>
+
+      <h1>Reference</h1>
+      <nav>
+        <a href='fusion.html'>Language Reference</a>
+        <nav>
+          <a href='binding-index.html'>Alphabetical Index</a>
+          <a href='permuted-index.html'>Permuted Index</a>
+        </nav>
+        <a href='javadoc/index.html'>Java API Reference</a>
+      </nav>
+    </nav>
+    <div class="main">
+      {{$content}}No content{{/content}}
     </div>
-    {{$content}}No content{{/content}}
   {{/body}}
 {{/base}}

--- a/src/doc/templates/module.html
+++ b/src/doc/templates/module.html
@@ -20,7 +20,7 @@
   {{/moreCss}}
   {{$title}}{{entity.identity.absolutePath}}{{/title}}
   {{$content}}
-    <h1>Module {{#entity.identity}}{{>breadcrumbs}}{{/entity.identity}}</h1>
+    <h1 class="headline">Module {{#entity.identity}}{{>breadcrumbs}}{{/entity.identity}}</h1>
     {{#entity.moduleDocs.overview}}{{#md}}{{&.}}{{/md}}{{/entity.moduleDocs.overview}}
 
     {{^entity.submodules.empty}}

--- a/src/testDist/java/DocumentationTest.java
+++ b/src/testDist/java/DocumentationTest.java
@@ -66,7 +66,8 @@ public class DocumentationTest
         assertEquals(modulePath, page.getTitleText());
 
         HtmlBody     body    = page.getBody();
-        HtmlHeading1 firstH1 = body.getFirstByXPath("h1");
+        HtmlHeading1 firstH1 = body.getFirstByXPath("//h1[@class=\"headline\"]");
+        assertNotNull(firstH1, "Missing first <h1> in " + url);
         assertEquals("Module " + modulePath, firstH1.getTextContent());
 
         return page;
@@ -83,7 +84,7 @@ public class DocumentationTest
         HtmlPage page = loadModule("/fusion");
         HtmlBody body = page.getBody();
 
-        HtmlParagraph p = body.getFirstByXPath("p");
+        HtmlParagraph p = body.getFirstByXPath("//div[@class='main']/p");
         assertNotNull(p, "missing first <p>");
         assertThat(p.getTextContent(), startsWith("The main Fusion language."));
     }


### PR DESCRIPTION
A fixed left-side column holds global navigation.

Some basic CSS was inspired by Racket's.

## Description

Here's where the last couple months of work pays off, IMO: straightforward site changes, outside of Java.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
