### PR TITLE
[trivial] Fix `FileCopyTemplate` to create intermediate parent directories.

### DIFF
--- a/src/main/java/dev/ionfusion/fusion/_private/doc/site/FileCopyTemplate.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/site/FileCopyTemplate.java
@@ -15,6 +15,7 @@ public class FileCopyTemplate
     public Generator<Path> populate(Artifact<Path> artifact)
     {
         return dest -> {
+            Files.createDirectories(dest.getParent());
             Files.copy(artifact.getEntity(), dest, REPLACE_EXISTING);
         };
     }


### PR DESCRIPTION
## Description

Discovered this bug while adding an `assets/fonts` folder, which caused the doc build to crash.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
