### PR TITLE
Show the release version or local-build time atop the docs.

### DIFF
--- a/src/doc/assets/common.css
+++ b/src/doc/assets/common.css
@@ -23,6 +23,12 @@
     margin-bottom: .5rem;
 }
 
+.leftnav .version {
+    font-size: 0.9rem;
+    margin-top: -.5rem;
+    margin-left: 1rem;
+}
+
 .leftnav h1 {
     font-size: 1.25rem;
     margin-top: 1rem;

--- a/src/doc/templates/common.html
+++ b/src/doc/templates/common.html
@@ -12,6 +12,11 @@
     <nav class="leftnav">
       <a id="toplink" href="index.html">Ion Fusion</a>
 
+      <p class="version">
+        {{#site.devBuild}}{{site.time}}{{/site.devBuild}}
+        {{^site.devBuild}}Release {{site.version}}{{/site.devBuild}}
+      </p>
+
       <h1>Tutorials</h1>
       <nav>
         <a href='tutorial_cli.html'>Exploring the <code>fusion</code> CLI</a>

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/SiteBuilder.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/SiteBuilder.java
@@ -26,16 +26,19 @@ public class SiteBuilder
     private final Site                      mySite = new Site();
     private       RepoEntity                myRepo;
     private final Predicate<ModuleIdentity> myModuleSelector;
+    private final SiteModel                 mySiteModel;
 
     /**
      *
      * @param selector predicate determining which modules will be documented.
      */
     public SiteBuilder(TopLevel topLevel, Predicate<ModuleIdentity> selector)
+        throws FusionException
     {
         myTopLevel = topLevel;
         myIndex = new DocIndex(selector);
         myModuleSelector = selector;
+        mySiteModel = new SiteModel();
     }
 
     public Site build()
@@ -73,6 +76,11 @@ public class SiteBuilder
     }
 
 
+    private <E> Template<E, Path> mustacheTemplate(String templatePath)
+    {
+        return new MustacheTemplate<>(mySiteModel, templatePath);
+    }
+
     /**
      * Discover selected modules in our {@link RepoEntity}, placing a page
      * for each at the same path within the site.
@@ -82,8 +90,8 @@ public class SiteBuilder
     public void placeModules()
         throws FusionException
     {
-        MustacheTemplate<ModuleEntity> template =
-            new MustacheTemplate<>("src/doc/templates/module.html");
+        Template<ModuleEntity, Path> template =
+            mustacheTemplate("src/doc/templates/module.html");
 
         for (ModuleEntity module : myRepo.getSelectedModules())
         {
@@ -121,8 +129,8 @@ public class SiteBuilder
         String[] fileNames = fromDir.toFile().list();
         if (fileNames == null) return;
 
-        MustacheTemplate<MarkdownArticle> template =
-            new MustacheTemplate<>("src/doc/templates/article.html");
+        Template<MarkdownArticle, Path> template =
+            mustacheTemplate("src/doc/templates/article.html");
 
         for (String fileName : fileNames)
         {
@@ -178,10 +186,10 @@ public class SiteBuilder
         AlphaIndex alpha = myIndex.alphabetize();
         PermutedIndex permuted = myIndex.permute();
 
-        MustacheTemplate<AlphaIndex> alphaTemplate =
-            new MustacheTemplate<>("src/doc/templates/binding-index.html");
-        MustacheTemplate<PermutedIndex> permuTemplate =
-            new MustacheTemplate<>("src/doc/templates/permuted-index.html");
+        Template<AlphaIndex, Path> alphaTemplate =
+            mustacheTemplate("src/doc/templates/binding-index.html");
+        Template<PermutedIndex, Path> permuTemplate =
+            mustacheTemplate("src/doc/templates/permuted-index.html");
 
         placeArtifact(alpha, "binding-index.html", alphaTemplate);
         placeArtifact(permuted, "permuted-index.html", permuTemplate);

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/SiteModel.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/SiteModel.java
@@ -1,0 +1,40 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion._private.doc.tool;
+
+import com.amazon.ion.Timestamp;
+import dev.ionfusion.fusion.FusionException;
+import dev.ionfusion.fusion.util.FusionJarInfo;
+
+/**
+ * Holds site-wide information available to templates.
+ */
+public class SiteModel
+{
+    private final Timestamp     myTime;
+    private final FusionJarInfo myJarInfo;
+
+    public SiteModel()
+        throws FusionException
+    {
+        myTime = Timestamp.nowZ();
+        myJarInfo = new FusionJarInfo();
+    }
+
+
+    public Timestamp getTime()
+    {
+        return myTime;
+    }
+
+    public String getVersion()
+    {
+        return myJarInfo.getReleaseLabel();
+    }
+
+    public boolean isDevBuild()
+    {
+        return getVersion().endsWith("-SNAPSHOT");
+    }
+}

--- a/src/main/java/dev/ionfusion/fusion/_private/doc/tool/mustache/MustacheTemplate.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/doc/tool/mustache/MustacheTemplate.java
@@ -12,6 +12,7 @@ import com.petebevin.markdown.MarkdownProcessor;
 import dev.ionfusion.fusion._private.doc.site.Artifact;
 import dev.ionfusion.fusion._private.doc.site.Generator;
 import dev.ionfusion.fusion._private.doc.site.Template;
+import dev.ionfusion.fusion._private.doc.tool.SiteModel;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,29 +27,37 @@ public class MustacheTemplate <Entity>
 {
     private static final MustacheFactory FACTORY = new DefaultMustacheFactory();
 
+    private final SiteModel mySiteModel;
     private final Mustache myMustache;
 
-    public MustacheTemplate(Path templateFile)
+    public MustacheTemplate(SiteModel siteModel, Path templateFile)
     {
+        mySiteModel = siteModel;
         myMustache = FACTORY.compile(templateFile.toAbsolutePath().toString());
     }
 
-    public MustacheTemplate(String templateFile)
+    public MustacheTemplate(SiteModel siteModel, String templateFile)
     {
-        this(Paths.get(templateFile));
+        // Avoid direct use of MustacheFactory.compile(String) so we're not
+        // coupled to its (undocumented) interpretation of the string.
+        this(siteModel, Paths.get(templateFile));
     }
 
 
     /**
      * Variables we want to inject into all templates.
      */
-    static class BaseScope
+    class BaseScope
     {
         // Proper rendering relies on this processor being used through
         // the whole page. In particular, code-block detection fails
         // when it's not preceded by other content.
         private final MarkdownProcessor myMarkdownProcessor = new MarkdownProcessor();
 
+        SiteModel site()
+        {
+            return mySiteModel;
+        }
 
         String nl()
         {


### PR DESCRIPTION
Add `SiteModel` with site-wide data for templates.

## Description

The timestamp is helpful when working on the site so you can be sure you're seeing the new stuff.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
