### PR TITLE
Use more distinctive fonts for documentation.

### DIFF
--- a/src/doc/assets/common.css
+++ b/src/doc/assets/common.css
@@ -1,6 +1,17 @@
 /* Copyright Ion Fusion contributors. All rights reserved. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+body {
+    font-family: "Bitter", serif;
+    font-weight: 400;
+    line-height: 1.5;
+}
+
+code, pre {
+    font-family: "Monaspace Neon", monospace;
+    font-weight: 350;
+}
+
 .leftnav {
     position: fixed;
     z-index: 2;

--- a/src/doc/assets/fonts.css
+++ b/src/doc/assets/fonts.css
@@ -1,0 +1,17 @@
+/* Copyright Ion Fusion contributors. All rights reserved. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* Get Bitter Pro from Google Fonts, which does a good job serving small files.
+ */
+@import url('https://fonts.googleapis.com/css2?family=Bitter:ital,wght@0,100..900;1,100..900&display=swap');
+
+/* Monaspace is not on Google Fonts, and looks like they don't want to add it.
+ *   https://github.com/githubnext/monaspace/issues/120
+ *   https://github.com/githubnext/monaspace/issues/172
+ */
+@font-face {
+    font-family: 'Monaspace Neon';
+    font-style: normal;
+    font-display: swap;
+    src: url('https://cdn.jsdelivr.net/gh/githubnext/monaspace@v1.301/fonts/Web Fonts/Variable Web Fonts/Monaspace Neon/Monaspace Neon Var.woff2') format('woff2');
+}

--- a/src/doc/templates/common.html
+++ b/src/doc/templates/common.html
@@ -2,6 +2,7 @@
 {{! SPDX-License-Identifier: Apache-2.0 }}
 {{<base}}
   {{$head}}
+    <link href='fonts.css' rel='stylesheet' type='text/css'></link>
     <link href='common.css' rel='stylesheet' type='text/css'></link>
     {{$moreHead}}{{/moreHead}}
   {{/head}}


### PR DESCRIPTION
For monospace, I selected Monaspace specifically for its "texture healing", which contextually adjusts character widths to improve readability.
  * https://monaspace.githubnext.com/
  * https://github.com/githubnext/monaspace/releases/tag/v1.301

For body text, I selected Bitter Pro because I prefer serif fonts, I really like its look, and it pairs nicely with Monaspace (to my eyes).
  * https://github.com/solmatas/BitterPro
  * https://fonts.google.com/specimen/Bitter

Both fonts are licensed under the SIL Open Font License, Version 1.1.
  * http://scripts.sil.org/OFL

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
