### PR TITLE
Remove obsolete `type='text/css'` attributes.

### DIFF
--- a/src/doc/templates/article.html
+++ b/src/doc/templates/article.html
@@ -2,7 +2,7 @@
 {{! SPDX-License-Identifier: Apache-2.0 }}
 {{<common}}
   {{$moreHead}}
-    <link href='doc.css' rel='stylesheet' type='text/css'></link>
+    <link href='doc.css' rel='stylesheet'></link>
   {{/moreHead}}
   {{$title}}{{entity.title}}{{/title}}
   {{$content}}

--- a/src/doc/templates/binding-index.html
+++ b/src/doc/templates/binding-index.html
@@ -2,7 +2,7 @@
 {{! SPDX-License-Identifier: Apache-2.0 }}
 {{<common}}
   {{$moreHead}}
-    <link href='index.css' rel='stylesheet' type='text/css'></link>
+    <link href='index.css' rel='stylesheet'></link>
   {{/moreHead}}
   {{$title}}Fusion Binding Index{{/title}}
   {{$content}}

--- a/src/doc/templates/common.html
+++ b/src/doc/templates/common.html
@@ -2,8 +2,8 @@
 {{! SPDX-License-Identifier: Apache-2.0 }}
 {{<base}}
   {{$head}}
-    <link href='fonts.css' rel='stylesheet' type='text/css'></link>
-    <link href='common.css' rel='stylesheet' type='text/css'></link>
+    <link href='fonts.css' rel='stylesheet'></link>
+    <link href='common.css' rel='stylesheet'></link>
     {{$moreHead}}{{/moreHead}}
   {{/head}}
   {{$title}}Proto Template{{/title}}

--- a/src/doc/templates/module.html
+++ b/src/doc/templates/module.html
@@ -16,7 +16,7 @@
 }}
 {{<common}}
   {{$moreHead}}
-    <link href='module.css' rel='stylesheet' type='text/css'></link>
+    <link href='module.css' rel='stylesheet'></link>
   {{/moreHead}}
   {{$title}}{{entity.identity.absolutePath}}{{/title}}
   {{$content}}

--- a/src/doc/templates/permuted-index.html
+++ b/src/doc/templates/permuted-index.html
@@ -2,7 +2,7 @@
 {{! SPDX-License-Identifier: Apache-2.0 }}
 {{<common}}
   {{$moreHead}}
-    <link href='index.css' rel='stylesheet' type='text/css'></link>
+    <link href='index.css' rel='stylesheet'></link>
   {{/moreHead}}
   {{$title}}Fusion Binding Index (Permuted){{/title}}
   {{$content}}

--- a/src/main/java/dev/ionfusion/fusion/_private/HtmlWriter.java
+++ b/src/main/java/dev/ionfusion/fusion/_private/HtmlWriter.java
@@ -127,7 +127,7 @@ public class HtmlWriter
     {
         openHead(title, null);
 
-        myOut.append("<style type='text/css'><!--\n");
+        myOut.append("<style><!--\n");
         myOut.append(css);
         myOut.append("\n--></style>");
 
@@ -149,7 +149,7 @@ public class HtmlWriter
         {
             myOut.append("<link href='");
             escape(cssUrl);
-            myOut.append("' rel='stylesheet' type='text/css'></link>\n");
+            myOut.append("' rel='stylesheet'></link>\n");
         }
 
         myOut.append("</head>\n");


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style#type

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
