### PR TITLE
Replace `<div class="main">` with HTML5 `<main>`

### DIFF
--- a/src/doc/articles/about_cli.md
+++ b/src/doc/articles/about_cli.md
@@ -1,7 +1,8 @@
 <!-- Copyright Ion Fusion contributors. All rights reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-<!-- MarkdownJ can't handle backticks in headers -->
+<!-- MarkdownJ can't handle backticks in headers
+     https://github.com/ion-fusion/fusion-java/issues/334 -->
 # About the <code>fusion</code> CLI
 
 The `fusion` command-line interface is intended to support evaluation of Fusion code across a 

--- a/src/doc/assets/common.css
+++ b/src/doc/assets/common.css
@@ -62,7 +62,7 @@ code, pre {
 }
 
 
-.main {
+main {
     width: auto;
     margin-top: 1rem;
     margin-left: 15.5rem;  /* Sync with leftnav width */

--- a/src/doc/templates/article.html
+++ b/src/doc/templates/article.html
@@ -5,7 +5,7 @@
     <link href='doc.css' rel='stylesheet'></link>
   {{/moreHead}}
   {{$title}}{{entity.title}}{{/title}}
-  {{$content}}
+  {{$main}}
     {{#md}}{{&entity.content}}{{/md}}
-  {{/content}}
+  {{/main}}
 {{/common}}

--- a/src/doc/templates/binding-index.html
+++ b/src/doc/templates/binding-index.html
@@ -5,7 +5,7 @@
     <link href='index.css' rel='stylesheet'></link>
   {{/moreHead}}
   {{$title}}Fusion Binding Index{{/title}}
-  {{$content}}
+  {{$main}}
     <h1>Binding Index</h1>
     <table>
       <tbody>
@@ -14,5 +14,5 @@
         {{/entity}}
       </tbody>
     </table>
-  {{/content}}
+  {{/main}}
 {{/common}}

--- a/src/doc/templates/common.html
+++ b/src/doc/templates/common.html
@@ -43,8 +43,8 @@
         <a href='javadoc/index.html'>Java API Reference</a>
       </nav>
     </nav>
-    <div class="main">
-      {{$content}}No content{{/content}}
-    </div>
+    <main>
+      {{$main}}This page is unintentionally blank.{{/main}}
+    </main>
   {{/body}}
 {{/base}}

--- a/src/doc/templates/module.html
+++ b/src/doc/templates/module.html
@@ -19,7 +19,7 @@
     <link href='module.css' rel='stylesheet'></link>
   {{/moreHead}}
   {{$title}}{{entity.identity.absolutePath}}{{/title}}
-  {{$content}}
+  {{$main}}
     <h1 class="headline">Module {{#entity.identity}}{{>breadcrumbs}}{{/entity.identity}}</h1>
     {{#entity.moduleDocs.overview}}{{#md}}{{&.}}{{/md}}{{/entity.moduleDocs.overview}}
 
@@ -58,5 +58,5 @@
         </div>
       {{/entity.exports}}
     {{/entity.exports.empty}}
-  {{/content}}
+  {{/main}}
 {{/common}}

--- a/src/doc/templates/permuted-index.html
+++ b/src/doc/templates/permuted-index.html
@@ -5,12 +5,12 @@
     <link href='index.css' rel='stylesheet'></link>
   {{/moreHead}}
   {{$title}}Fusion Binding Index (Permuted){{/title}}
-  {{$content}}
+  {{$main}}
     <h1>Permuted Binding Index</h1>
     <table><tbody>
       {{#entity}}
 <tr><td class='prefix'>{{prefix}}</td><td class='tail'><span class='keyword'>{{keyword}}</span>{{suffix}}</td><td>{{#exports}}{{>export-link}}, {{/exports}}</td></tr>
       {{/entity}}
     </tbody></table>
-  {{/content}}
+  {{/main}}
 {{/common}}

--- a/src/testDist/java/DocumentationTest.java
+++ b/src/testDist/java/DocumentationTest.java
@@ -84,7 +84,7 @@ public class DocumentationTest
         HtmlPage page = loadModule("/fusion");
         HtmlBody body = page.getBody();
 
-        HtmlParagraph p = body.getFirstByXPath("//div[@class='main']/p");
+        HtmlParagraph p = body.getFirstByXPath("//main/p");
         assertNotNull(p, "missing first <p>");
         assertThat(p.getTextContent(), startsWith("The main Fusion language."));
     }


### PR DESCRIPTION
This follows current page structure recommendations.

We change the corresponding template section name to align.

## Description

HTML has improved quite a bit since I first built these pages in 2012!  I'm slowly working through to use more semantic markup and modern CSS practices.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
