### PR TITLE
Modernize HTML of module reference pages.

### DIFF
--- a/src/doc/assets/module.css
+++ b/src/doc/assets/module.css
@@ -1,44 +1,46 @@
 /* Copyright Ion Fusion contributors. All rights reserved. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-.submodules .oneliner p {
+nav.submodules .oneliner p {
   display: inline;
 }
-.exports {
-  display: block;
-  margin-left: 1em; margin-bottom: 1em
+
+nav.exports ol {
+  list-style-type: none;
+  padding-left: 1em;
 }
-.binding {
+nav.exports li {
+  display: inline;
+  margin-right: .5em;
+}
+
+.export {
   display: block;
   border-top: 1px solid #999;
-  padding-top: .5em;
+  padding: .8em 0;
 }
-.binding .name {
+.export .name {
   font-family: monospace;
   font-size: 1.17em;
   font-weight: bold;
 }
-.binding .kind {
+.export .kind {
   float: right; font-style: italic;
 }
-.binding .nodoc {
+.export .nodoc {
   font-style: italic;
 }
-.binding .doc {
+.export .doc {
    margin-left: 1em;
 }
-.binding .doc .oneliner {
-}
-.binding .doc .body {
-}
-.binding .doc .also {
+.export .also {
   font-size: 0.8em;
   font-style: italic;
 }
 
-/* Highlight the binding when arriving via a link.
+/* Highlight the targeted section when arriving via a link.
 /* From http://css-tricks.com/on-target/  */
-:target.binding {
+:target.export {
   -moz-animation:    highlight 2s ease;
   -webkit-animation: highlight 2s ease;
 }

--- a/src/doc/templates/module.html
+++ b/src/doc/templates/module.html
@@ -2,11 +2,11 @@
 {{! SPDX-License-Identifier: Apache-2.0 }}
 {{!
   CSS hierarchy:
-    -- should be something for the overview
-    submodules
+    section.overview
+    nav.submodules
       oneliner
-    exports
-    binding
+    nav.exports
+    section.export
       name
       kind
       doc
@@ -21,28 +21,36 @@
   {{$title}}{{entity.identity.absolutePath}}{{/title}}
   {{$main}}
     <h1 class="headline">Module {{#entity.identity}}{{>breadcrumbs}}{{/entity.identity}}</h1>
-    {{#entity.moduleDocs.overview}}{{#md}}{{&.}}{{/md}}{{/entity.moduleDocs.overview}}
+
+    <section class='overview'>
+      {{#entity.moduleDocs.overview}}{{#md}}{{&.}}{{/md}}{{/entity.moduleDocs.overview}}
+    </section>
 
     {{^entity.submodules.empty}}
-      <h2>Submodules</h2>
-      <ul class='submodules'>
-      {{#entity.submodules}}
-        <li>{{<module-link}}{{$id}}{{identity}}{{/id}}{{$link}}{{identity.baseName}}{{/link}}{{/module-link}}
-          {{#moduleDocs.oneLiner}} &ndash; <span class='oneliner'>{{#md}}{{&.}}{{/md}}</span>{{/moduleDocs.oneLiner}}
-        </li>
-      {{/entity.submodules}}
-      </ul>
+      <nav class='submodules'>
+        <h2>Submodules</h2>
+        <ul>
+        {{#entity.submodules}}
+          <li>{{<module-link}}{{$id}}{{identity}}{{/id}}{{$link}}{{identity.baseName}}{{/link}}{{/module-link}}
+            {{#moduleDocs.oneLiner}} &ndash; <span class='oneliner'>{{#md}}{{&.}}{{/md}}</span>{{/moduleDocs.oneLiner}}
+          </li>
+        {{/entity.submodules}}
+        </ul>
+      </nav>
     {{/entity.submodules.empty}}
 
     {{^entity.exports.empty}}
-      <h2>Exported Bindings</h2>
-      <div class='exports'>
-        {{#entity.exports}}{{<binding-link}}{{$id}}{{moduleId}}{{/id}}{{$name}}{{name}}{{/name}}{{/binding-link}}&nbsp;&nbsp;
-        {{/entity.exports}}
-      </div>
+      <nav class='exports'>
+        <h2>Exported Bindings</h2>
+        <ol>
+          {{#entity.exports}}
+            <li>{{<binding-link}}{{$id}}{{moduleId}}{{/id}}{{$name}}{{name}}{{/name}}{{/binding-link}}</li>
+          {{/entity.exports}}
+        </ol>
+      </nav>
 
       {{#entity.exports}}
-        <div class='binding' id='{{name}}'><span class='name'>{{name}}</span>
+        <section class='export' id='{{name}}'><span class='name'>{{name}}</span>
           {{#docs.kind}}<span class='kind'>{{toString.toLowerCase}}</span>{{/docs.kind}}
           <div class='doc'>
             <div class='body'>
@@ -50,12 +58,12 @@
               {{#docs.body}}{{#md}}{{&nl}}{{&.}}{{&nl}}{{/md}}{{/docs.body}}
             </div>
             {{^alsoProvidedBy.empty}}
-               <p class='also'>Also provided by
+               <aside class='also'>Also provided by
                {{#alsoProvidedBy}}{{>export-link}}, {{/alsoProvidedBy}}
-               </p>
+               </aside>
             {{/alsoProvidedBy.empty}}
           </div>
-        </div>
+        </section>
       {{/entity.exports}}
     {{/entity.exports.empty}}
   {{/main}}

--- a/src/testDist/java/DocumentationTest.java
+++ b/src/testDist/java/DocumentationTest.java
@@ -66,7 +66,7 @@ public class DocumentationTest
         assertEquals(modulePath, page.getTitleText());
 
         HtmlBody     body    = page.getBody();
-        HtmlHeading1 firstH1 = body.getFirstByXPath("//h1[@class=\"headline\"]");
+        HtmlHeading1 firstH1 = body.getFirstByXPath("//main/h1[@class=\"headline\"]");
         assertNotNull(firstH1, "Missing first <h1> in " + url);
         assertEquals("Module " + modulePath, firstH1.getTextContent());
 
@@ -84,7 +84,7 @@ public class DocumentationTest
         HtmlPage page = loadModule("/fusion");
         HtmlBody body = page.getBody();
 
-        HtmlParagraph p = body.getFirstByXPath("//main/p");
+        HtmlParagraph p = body.getFirstByXPath("//main/section[@class='overview']/p");
         assertNotNull(p, "missing first <p>");
         assertThat(p.getTextContent(), startsWith("The main Fusion language."));
     }


### PR DESCRIPTION
Use modern semantic elements like `nav`, `section`, and `aside` instead of the generic `div`.

Also reword "binding" to "export" in the markup, which is more accurate.  The same binding can be exported under multiple names, and the names are what matters here.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
