### PR TITLE
Documentation versioning improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -257,8 +257,9 @@ tasks.javadoc {
         docEncoding = "UTF-8"
         overview = "$projectDir/src/main/java/overview.html"
 
-        header = "FusionJava API Reference"
+        header = "FusionJava API Reference<br />${project.version}"
         bottom = "<center>Copyright Ion Fusion contributors. All Rights Reserved.</center>"
+        noTimestamp(true)
     }
 }
 

--- a/src/doc/templates/common.html
+++ b/src/doc/templates/common.html
@@ -14,8 +14,8 @@
       <a id="toplink" href="index.html">Ion Fusion</a>
 
       <p class="version">
+        Release {{site.version}}
         {{#site.devBuild}}{{site.time}}{{/site.devBuild}}
-        {{^site.devBuild}}Release {{site.version}}{{/site.devBuild}}
       </p>
 
       <h1>Tutorials</h1>


### PR DESCRIPTION
* Always show the release label in the fusiondoc.
* Show the release label in the javadoc.

Fixes #245

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
