### PR TITLE
Use flexbox instead of fixed position for sidebar.

### DIFF
--- a/src/doc/assets/common.css
+++ b/src/doc/assets/common.css
@@ -12,12 +12,29 @@ code, pre {
     font-weight: 350;
 }
 
+/* Outermost page layout uses flexbox so the site nav shifts above the main
+ * content on narrow viewports.
+ */
+body {
+    height: 100vh;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+
+    nav {
+        /* TODO perhaps use intrinsic width? */
+        flex-basis: 15rem; /* Width when on the side */
+        flex-grow: 1;
+    }
+
+    main {
+        flex-basis: 0;
+        flex-grow: 999;
+        min-inline-size: 70%; /* Threshold for flowing inline (right) */
+    }
+}
+
 .leftnav {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 15rem; /* Sync with main left */
     padding: 0.5rem;
     overflow-y: scroll;
     background-color: lightsteelblue;
@@ -60,11 +77,6 @@ code, pre {
 
 
 main {
-    position: fixed;
-    top: 0;
-    left: 15rem;     /* Sync with .leftnav width */
-    bottom: 0;
-    width: auto;
     padding: 0 1rem;
     overflow: scroll;
 }


### PR DESCRIPTION
This makes the layout responsive: on narrow screens, the nav moves above the main block.

Technique via https://every-layout.dev/layouts/sidebar/

## Description

I feel like I'm making some progress up the CSS learning cliff.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
