### PR TITLE
Remove `struct_for_each`, deprecated since 2013-11.

### DIFF
--- a/ftst/struct.test.fusion
+++ b/ftst/struct.test.fusion
@@ -17,7 +17,7 @@
       (if (is_null s)
         s
         (let [(args (stretchy_list))]
-          (struct_for_each
+          (struct_do
             (lambda (name value)
               (add_m args name)
               (add_m args value))
@@ -493,13 +493,13 @@
 
 
 //==========================================================================
-// struct_do (aka struct_for_each)
+// struct_do
 
 (define rip_and_zip
   (lambda (struct)
     (let [(names  (stretchy_list)),
           (values (stretchy_list))]
-      (let [(result (struct_for_each
+      (let [(result (struct_do
                       (lambda (name value)
                         (add_m names name)
                         (add_m values value))
@@ -514,9 +514,10 @@
 (rip_and_zip {a:1,b:[2,3],a:{d:(quote e)}})  // Repeated field
 
 
-// struct_for_each returns its input struct.
-(check === 1
-  (. (struct_for_each (lambda (k v) 3) {f:1}) "f"))
+// struct_do returns its input struct.
+(lets [(original {f:1}),
+       (result   (struct_do (lambda (k v) 3) original))]
+  (check ident result original))
 
 
 //==========================================================================

--- a/fusion/src/fusion.fusion
+++ b/fusion/src/fusion.fusion
@@ -155,7 +155,7 @@ contact us for clarification.
 
   (require "/fusion/struct")
   (provide is_struct put remove_keys retain_keys struct struct_do
-    struct_for_each struct_iterator struct_merge struct_unzip struct_zip)
+    struct_iterator struct_merge struct_unzip struct_zip)
 
 
   //=========================================================================

--- a/fusion/src/fusion/struct.fusion
+++ b/fusion/src/fusion/struct.fusion
@@ -77,7 +77,7 @@ the fields from two structs.
 
 `struct_iterator` creates a multi-valued [iterator](fusion/iterator.html) over
 a struct's key-value pairs.
-The procedure `struct_for_each` iterates the name/value pairs within a struct,
+The procedure `struct_do` iterates the name/value pairs within a struct,
 but since the input isn't modified one must use side effects.
 
 More general [collection](fusion/collection.html) operations like `any` and
@@ -340,17 +340,6 @@ See also: [`do`](fusion/collection.html#do)
             (proc k v)
             (loop))
           struct))))
-
-  (defpub struct_for_each
-    '''
-DEPRECATED: renamed to [`struct_do`](fusion/struct.html#struct_do) for
-consistency with [`do`](fusion/collection.html#do).
-
-**This binding was deprecated in R11 (November 2013) and will be removed in**
-**Q2 2014.**  https://github.com/ion-fusion/fusion-java/issues/66
-    '''
-    struct_do)
-
 
 
   (defpub (struct_unzip struct)

--- a/src/test/java/dev/ionfusion/fusion/StructTest.java
+++ b/src/test/java/dev/ionfusion/fusion/StructTest.java
@@ -13,6 +13,7 @@ import static dev.ionfusion.fusion.FusionStruct.unsafeStructSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -108,42 +109,42 @@ public class StructTest
 
 
     @Test
-    public void testStructForEach()
+    public void testStructDo()
         throws Exception
     {
         eval("(define add_name (lambda (name value) (add_m value name)))");
         assertEval("{f:[f],g:[g],f:[true,false,f]}",
-                   "(struct_for_each add_name " +
+                   "(struct_do add_name " +
                    "  (mutable_struct \"f\" (stretchy_list) " +
                    "                  \"g\" (stretchy_list) " +
                    "                  \"f\" (stretchy_list true false)))");
     }
 
     @Test
-    public void testStructForEachArity()
+    public void testStructDoArity()
         throws Exception
     {
         eval("(define add_name (lambda (name value) (add value name)))");
-        expectArityExn("(struct_for_each)");
-        expectArityExn("(struct_for_each add_name)");
-        expectArityExn("(struct_for_each add_name {} 3)");
+        expectArityExn("(struct_do)");
+        expectArityExn("(struct_do add_name)");
+        expectArityExn("(struct_do add_name {} 3)");
     }
 
     @Test
-    public void testStructForEachArgTypes()
+    public void testStructDoArgTypes()
         throws Exception
     {
         eval("(define add_name (lambda (name value) (add value name)))");
 
         for (String form : allIonExpressions())
         {
-            String expr = "(struct_for_each " + form + " {})";
+            String expr = "(struct_do " + form + " {})";
             expectArgumentExn(expr, 0);
         }
 
         for (String form : nonStructExpressions())
         {
-            String expr = "(struct_for_each add_name " + form + ")";
+            String expr = "(struct_do add_name " + form + ")";
             expectArgumentExn(expr, 1);
         }
     }


### PR DESCRIPTION
It was renamed to `struct_do`.

Fixes #66

## Description

A little messy since internal code hadn't made the migration. 😅 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
