### PR TITLE
Replace string_split impl with string_split_noregexp

### DIFF
--- a/fusion/src/fusion/experimental/string.fusion
+++ b/fusion/src/fusion/experimental/string.fusion
@@ -74,24 +74,4 @@ Since Fusion doesn't define a specific implementation of strings, this procedure
 is not guaranteed to have better than O(_n_) time.
     '''
     "dev.ionfusion.fusion.FusionString$IndexCodePointsProc")
-
-
-  (defpub_j string_split_noregexp
-    '''
-    (string_split_noregexp string separator)
-
-Splits `string` into an immutable list of strings using `separator`.
-Both arguments must be actual strings.
-
-Returns an empty list when `string` is an empty string.
-
-The `separator` is _not_ a regular expression; callers needing that feature
-should use `regexp_split` from the [FusionJavaRegexp][] package, being careful
-to adapt code to that method's different argument order, result type (sexp
-instead of immutable list), and edge cases around leading matches. Test your
-code thoroughly.
-
-[FusionJavaRegexp]: wiki:FusionJavaRegexp
-    '''
-    "dev.ionfusion.fusion.FusionString$SplitNoRegexpProc")
 )

--- a/fusion/src/fusion/string.fusion
+++ b/fusion/src/fusion/string.fusion
@@ -178,29 +178,15 @@ Both arguments must be actual strings.
 
 Returns an empty list when `string` is an empty string.
 
-**DEPRECATED** where `separator` is a regular expression. That behavior was
-unintentional, and in conflict with this library's design goal to have no
-dependency on the Java language or library.
-
-  * Callers needing to split based on regular expressions should use
-    `regexp_split` from the [FusionJavaRegexp][] package, being careful to adapt code to that method's
-    different argument order, result type (sexp instead of immutable list), and
-    edge cases around leading matches. Test your code thoroughly.
-  * Callers needing separators that are escaped to avoid being regular
-    expressions should use [`string_split_noregexp`][ssn] until the regexp
-    behavior is removed from this procedure. For example, replace:
-
-        (string_split txt "\\\\.")
-
-    with:
-
-        (require "/fusion/experimental/string")
-        (string_split_noregexp txt ".")
+The `separator` is _not_ a regular expression; callers needing that feature
+should use `regexp_split` from the [FusionJavaRegexp][] package, being careful
+to adapt code to that method's different argument order, result type (sexp
+instead of immutable list), and edge cases around leading matches. Test your
+code thoroughly.
 
 [FusionJavaRegexp]: wiki:FusionJavaRegexp
-[ssn]: fusion/experimental/string.html#string_split_noregexp
     '''
-    (java_new "dev.ionfusion.fusion.FusionString$SplitProc"))
+    (java_new "dev.ionfusion.fusion.FusionString$SplitNoRegexpProc"))
 
   (define_values (string_starts_with)
     '''


### PR DESCRIPTION
## Summary
- Replaces `string_split` implementation to use `SplitNoRegexpProc` instead of `SplitProc`
- Removes the now-obsolete `string_split_noregexp` function from experimental/string module
- Updates documentation to remove deprecation warnings

## Changes Made

### fusion/src/fusion/string.fusion
- Changed `string_split` to use `dev.ionfusion.fusion.FusionString$SplitNoRegexpProc`
- Removed deprecation warnings from documentation
- Updated docs to clarify that separator is not a regular expression
- Kept reference to `regexp_split` for users needing regex functionality

### fusion/src/fusion/experimental/string.fusion
- Removed `string_split_noregexp` function entirely (lines 79-96)
- Function is no longer needed since `string_split` now has the same behavior

## Background
The `string_split` function was accidentally supporting regular expressions, which was unintended and conflicted with the library's design goal of avoiding dependencies on Java language features. The `string_split_noregexp` function was introduced as a migration path. Now that enough time has passed, we can complete the migration by replacing the implementation.

Fixes #349