### PR TITLE
Misc documentation formatting updates.

### DIFF
--- a/src/doc/assets/common.css
+++ b/src/doc/assets/common.css
@@ -99,3 +99,13 @@ main {
     padding: 0 1rem;
     overflow: scroll;
 }
+
+pre {
+    padding-inline-start: 1em;
+    overflow-x: auto;
+}
+
+/* When a link is targeted, ensure some visible room around it. */
+:target {
+    scroll-margin: 2rlh;
+}

--- a/src/doc/assets/reset.css
+++ b/src/doc/assets/reset.css
@@ -47,7 +47,9 @@
     h1, h2, h3, h4, h5, h6 {
         text-wrap: balance;
     }
-    p {
+
+    p, li, dd {
+        max-inline-size: 88ch;
         text-wrap: pretty;
     }
 


### PR DESCRIPTION
  * Limit the width of prose to ~88 characters for accessibility.
  * Improve `<pre>`:
    * Add a left indent so it stands out from the prose.
    * Allow horizontal scrolling when the layout is narrow.
  * When a link is targeted, keep some surrounding content visible.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
