### PR TITLE
DRY source-code layout configuration.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,8 @@ java {
     withJavadocJar()
 }
 
+val mainFusionRepo = layout.projectDirectory.dir("fusion")
+val testFusionRepo = layout.projectDirectory.dir("ftst/repo")
 
 // Default output paths, hard-coded because the DSL doesn't seem to expose them.
 val docsDir    = layout.buildDirectory.dir("docs")
@@ -76,8 +78,7 @@ tasks.jar {
     // sourceSet, so they are automatically added to the classpath when testing.
     // It's unclear how to change the parent directory that way.
     into("FUSION-REPO") {
-        from(layout.projectDirectory.dir("fusion"))
-        exclude("**/*.md")
+        from(mainFusionRepo)
         includeEmptyDirs = true
     }
 }
@@ -95,7 +96,7 @@ tasks.test {
     // Collect Fusion coverage data IFF a report is being generated.
     mustRunAfter(fcovConfigure)
 
-    inputs.dir(layout.projectDirectory.dir("ftst"))
+    inputs.dir(testFusionRepo)
 
     jvmArgumentProviders.add {
         if (fcovRunning) {
@@ -113,7 +114,7 @@ val ftstRepo = tasks.register<Jar>("ftstRepo") {
     archiveFileName = "ftst-repo.jar"
 
     into("FUSION-REPO") {
-        from(layout.projectDirectory.dir("ftst/repo"))
+        from(testFusionRepo)
         includeEmptyDirs = true
     }
 }
@@ -282,7 +283,7 @@ tasks.register<JavaExec>("fusiondoc") {
     classpath = sourceSets["main"].runtimeClasspath
     mainClass = "dev.ionfusion.fusion.cli.Cli"
     args = listOf("document",
-                  "--modules", "fusion",
+                  "--modules", mainFusionRepo.toString(),
                   "--articles", articlesDir.toString(),
                   "--assets", assetsDir.toString(),
                   fusiondocDir.asFile.path)
@@ -292,7 +293,7 @@ tasks.register<JavaExec>("fusiondoc") {
     // Docgen has Java code! Not sure if this is the best solution...
     dependsOn(tasks.compileJava)
 
-    inputs.dir(layout.projectDirectory.dir("fusion"))
+    inputs.dir(mainFusionRepo)
     inputs.dir(articlesDir)
     inputs.dir(assetsDir)
     inputs.dir(layout.projectDirectory.dir("src/doc/templates"))

--- a/src/test/java/dev/ionfusion/fusion/cli/CliTestCase.java
+++ b/src/test/java/dev/ionfusion/fusion/cli/CliTestCase.java
@@ -3,6 +3,7 @@
 
 package dev.ionfusion.fusion.cli;
 
+import static dev.ionfusion.fusion.TestSetup.fusionBootstrapDirectory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import dev.ionfusion.fusion.junit.StdioTestCase;
@@ -46,9 +47,8 @@ public class CliTestCase
     {
         ArrayList<String> join = new ArrayList<>();
 
-        // This is needed to run tests in the IDE.
         join.add("--repositories");
-        join.add("fusion");
+        join.add(fusionBootstrapDirectory().toString());
 
         join.addAll(Arrays.asList(commandLine));
         return join.toArray(new String[0]);


### PR DESCRIPTION
## Description

These bits were missed by a previous DRY pass.

Next CR will move the root `fusion` and `ftst` source files under `src`.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
