### PR TITLE
Gradle logic improvements.

### DIFF
--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.amazon.ion:ion-java:1.11.11")
+    api("com.amazon.ion:ion-java:1.11.11")
 
     // TODO These shouldn't be needed when consumers embed Fusion.
     //  It's a build-time dependency, but here b/c consumers use the CLI to
@@ -24,20 +24,16 @@ base {
 
 java {
     withJavadocJar()
+    withSourcesJar()
 }
 
 
 val mainFusionRepo = layout.projectDirectory.dir("src/main/fusion")
 val testFusionRepo = layout.projectDirectory.dir("src/test/fusion")
 
-// Default output paths, hard-coded because the DSL doesn't seem to expose them.
-val docsDir    = layout.buildDirectory.dir("docs")
-val libsDir    = layout.buildDirectory.dir("libs")
-val reportsDir = layout.buildDirectory.dir("reports")
-
 // New output paths for Fusion code coverage.
 val fcovDataDir = layout.buildDirectory.dir("fcov")
-val fcovReportDir = reportsDir.get().dir("fcov")
+val fcovReportDir = reporting.baseDirectory.dir("fcov")
 
 
 // Various resources refer to the current version label.
@@ -83,7 +79,7 @@ tasks.test {
 }
 
 val ftstRepo = tasks.register<Jar>("ftstRepo") {
-    destinationDirectory = libsDir
+    destinationDirectory = base.libsDirectory
     archiveFileName = "ftst-repo.jar"
 
     into("FUSION-REPO") {
@@ -157,8 +153,8 @@ val fcovTestReport = tasks.register<JavaExec>("fcovTestReport") {
     classpath = sourceSets["main"].runtimeClasspath
     mainClass = "dev.ionfusion.fusion.cli.Cli"
     args = listOf("report_coverage",
-        fcovDataDir.get().asFile.path,
-        fcovReportDir.asFile.path)
+                  fcovDataDir.get().asFile.path,
+                  fcovReportDir.get().asFile.path)
 
     enableAssertions = true
 }
@@ -176,9 +172,9 @@ gradle.taskGraph.whenReady {
 
 tasks.javadoc {
     exclude("**/_Private_*",
-        "**/_private/**",
-        "dev/ionfusion/fusion/cli",
-        "dev/ionfusion/fusion/util/hamt/**")
+            "**/_private/**",
+            "dev/ionfusion/fusion/cli",
+            "dev/ionfusion/fusion/util/hamt/**")
 
     title = "FusionJava API Reference"
 

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -62,7 +62,7 @@ val fusiondoc = tasks.register<JavaExec>("fusiondoc") {
     group = "Documentation"
     description = "Generates Fusion language and library documentation."
 
-    val fusiondocDir = layout.buildDirectory.dir("docs/fusiondoc")
+    val fusiondocDir = java.docsDir.dir("fusiondoc")
 
     var docSrcDir   = layout.projectDirectory.dir("src/doc")
     var articlesDir = docSrcDir.dir("articles")


### PR DESCRIPTION
  * Declare `ion-java` as an `api` dependency, since it's needed at compile-time downstream.
  * Generate a source jar for the runtime so customers can debug.
  * Use DSL properties to find the `docs`, `libs`, and `reports` directories.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
