### PR TITLE
Cleanup internal `isTruthy` and `not` code paths.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/AssertForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/AssertForm.java
@@ -64,7 +64,7 @@ final class AssertForm
             throws FusionException
         {
             Object result = eval.eval(store, myTestForm);
-            if (isTruthy(eval, result).isTrue())
+            if (FusionValue.isTruthy(eval, result))
             {
                 return voidValue(eval);
             }

--- a/runtime/src/main/java/dev/ionfusion/fusion/BaseValue.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/BaseValue.java
@@ -9,14 +9,15 @@ import static dev.ionfusion.fusion.FusionBool.trueBool;
 import static dev.ionfusion.fusion.FusionIo.safeWriteToString;
 import static dev.ionfusion.fusion.FusionSymbol.BaseSymbol.unsafeSymbolsToJavaStrings;
 import static dev.ionfusion.fusion.FusionValue.sameAnnotations;
-import dev.ionfusion.fusion.FusionBool.BaseBool;
-import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
+
 import com.amazon.ion.IonException;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.ValueFactory;
 import com.amazon.ion.system.IonTextWriterBuilder;
 import com.amazon.ion.util.IonTextUtils;
+import dev.ionfusion.fusion.FusionBool.BaseBool;
+import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import java.io.IOException;
 
 /**
@@ -24,6 +25,16 @@ import java.io.IOException;
  * <p>
  * This class, and all subclasses, are <b>not for application use.</b>
  * Any aspect of this class hierarchy can and will change without notice!
+ * <p>
+ * The following capabilities are aggregated here:
+ * <ul>
+ *     <li>Annotations</li>
+ *     <li>Checks for nullness, truthiness</li>
+ *     <li>Equality</li>
+ *     <li>Syntax Object construction</li>
+ *     <li>Serialization (ionize/write/display)</li>
+ * </ul>
+ * Some of these should probably be pushed down into separate interfaces.
  */
 abstract class BaseValue
 {
@@ -78,15 +89,9 @@ abstract class BaseValue
     }
 
 
-    BaseBool isTruthy(Evaluator eval)
+    boolean isTruthy(Evaluator eval)
     {
-        return makeBool(eval, ! isAnyNull());
-    }
-
-
-    BaseBool not(Evaluator eval)
-    {
-        return makeBool(eval, isAnyNull());
+        return ! isAnyNull();
     }
 
 
@@ -254,7 +259,9 @@ abstract class BaseValue
 
 
     //========================================================================
-    // Helper methods to avoid name conflicts with FusionValue imports
+    // Helper methods to work around name conflicts between methods on this
+    // class and static imports from FusionValue (for example).
+    // The problem is that virtual methods hide same-named static imports.
 
 
     static BaseBool isAnyNull(Evaluator eval, Object value)
@@ -262,20 +269,6 @@ abstract class BaseValue
     {
         boolean r = FusionValue.isAnyNull(eval, value);
         return makeBool(eval, r);
-    }
-
-
-    static BaseBool isTruthy(Evaluator eval, Object value)
-        throws FusionException
-    {
-        return FusionValue.isTruthy(eval, value);
-    }
-
-
-    static BaseBool not(Evaluator eval, Object value)
-        throws FusionException
-    {
-        return FusionValue.not(eval, value);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionBool.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionBool.java
@@ -7,12 +7,13 @@ import static dev.ionfusion.fusion.FusionSymbol.BaseSymbol.internSymbols;
 import static dev.ionfusion.fusion.SimpleSyntaxValue.makeSyntax;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
-import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
+
 import com.amazon.ion.IonException;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.ValueFactory;
+import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import java.io.IOException;
 
 
@@ -76,10 +77,7 @@ public final class FusionBool
         boolean isFalse()   { return false; }
 
         @Override
-        BaseBool isTruthy(Evaluator eval)  { return FALSE_BOOL; }
-
-        @Override
-        BaseBool not(Evaluator eval) { return TRUE_BOOL; }
+        boolean isTruthy(Evaluator eval)  { return false; }
 
         @Override
         BaseBool tightEquals(Evaluator eval, Object right)
@@ -136,10 +134,7 @@ public final class FusionBool
         boolean isFalse()   { return false; }
 
         @Override
-        BaseBool isTruthy(Evaluator eval)  { return TRUE_BOOL; }
-
-        @Override
-        BaseBool not(Evaluator eval) { return FALSE_BOOL; }
+        boolean isTruthy(Evaluator eval)  { return true; }
 
         @Override
         Boolean asJavaBoolean() { return TRUE; }
@@ -196,10 +191,7 @@ public final class FusionBool
         boolean isFalse()   { return true; }
 
         @Override
-        BaseBool isTruthy(Evaluator eval)  { return FALSE_BOOL; }
-
-        @Override
-        BaseBool not(Evaluator eval) { return TRUE_BOOL; }
+        boolean isTruthy(Evaluator eval)  { return false; }
 
         @Override
         Boolean asJavaBoolean() { return FALSE; }
@@ -287,10 +279,7 @@ public final class FusionBool
         boolean isFalse()   { return myValue.isFalse(); }
 
         @Override
-        BaseBool isTruthy(Evaluator eval)  { return myValue.isTruthy(eval); }
-
-        @Override
-        BaseBool not(Evaluator eval) { return myValue.not(eval); }
+        boolean isTruthy(Evaluator eval)  { return myValue.isTruthy(eval); }
 
         @Override
         BaseBool tightEquals(Evaluator eval, Object right)
@@ -471,7 +460,7 @@ public final class FusionBool
      * <p>
      * This is <em>not</em> a
      * <a href="{@docRoot}/../fusion/bool.html#truthiness">truthiness</a>
-     * test; use {@link #isTruthy(TopLevel, Object)} for that purpose.
+     * test; use {@link FusionValue#isTruthy(TopLevel, Object)} for that purpose.
      *
      * @param top the {@link TopLevel} in which to test the value
      * @param value the value to test
@@ -506,7 +495,7 @@ public final class FusionBool
      * <p>
      * This is <em>not</em> a
      * <a href="{@docRoot}/../fusion/bool.html#truthiness">truthiness</a>
-     * test; use {@link #isTruthy(TopLevel, Object)} for that purpose.
+     * test; use {@link FusionValue#isTruthy(TopLevel, Object)} for that purpose.
      *
      * @param top the {@link TopLevel} in which to test the value
      * @param value the value to test
@@ -533,50 +522,6 @@ public final class FusionBool
         }
 
         return false;
-    }
-
-
-    /**
-     * Determines whether a given Fusion value is "truthy".
-     * Fusion defines
-     * <a href="{@docRoot}/../fusion/bool.html#truthiness">truthiness</a>
-     * as follows:
-     * <ul>
-     *   <li>
-     *     Every value is truthy except for {@code false}, void, and any
-     *     variant of {@code null}.
-     *   </li>
-     * </ul>
-     * This definition is more lax (and hopefully more convenient) than Java,
-     * but less lenient (and hopefully less error-prone) than C or C++.
-     *
-     * @param top the {@link TopLevel} in which to test the value
-     * @param value the value to test
-     *
-     * @return {@code true} if the value is truthy,
-     * otherwise {@code false}
-     *
-     * @throws FusionException if an error occurs during evaluation
-     *
-     * @see <a href="{@docRoot}/../fusion/bool.html#truthiness">Truthiness</a>
-     * @see FusionBool#isTrue(TopLevel, Object)
-     */
-    public static boolean isTruthy(TopLevel top, Object value)
-        throws FusionException
-    {
-        Evaluator eval = StandardTopLevel.toEvaluator(top);
-        return isTruthy(eval, value).isTrue();
-    }
-
-    static BaseBool isTruthy(Evaluator eval, Object value)
-        throws FusionException
-    {
-        if (value instanceof BaseValue)
-        {
-            return ((BaseValue) value).isTruthy(eval);
-        }
-
-        return trueBool(eval);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionValue.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionValue.java
@@ -3,14 +3,13 @@
 
 package dev.ionfusion.fusion;
 
-import static dev.ionfusion.fusion.FusionBool.falseBool;
 import static dev.ionfusion.fusion.FusionSymbol.BaseSymbol.internSymbols;
 import static dev.ionfusion.fusion.FusionUtils.EMPTY_OBJECT_ARRAY;
 import static dev.ionfusion.fusion.FusionUtils.EMPTY_STRING_ARRAY;
-import dev.ionfusion.fusion.FusionBool.BaseBool;
-import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
+
 import com.amazon.ion.IonValue;
 import com.amazon.ion.ValueFactory;
+import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import java.io.IOException;
 
 /**
@@ -97,38 +96,23 @@ public final class FusionValue
      *
      * @see <a href="{@docRoot}/../fusion/bool.html#truthiness">Truthiness</a>
      * @see FusionBool#isTrue(TopLevel, Object)
-     *
-     * @deprecated As of R15 in March 2014.
-     * Moved to {@link FusionBool#isTruthy(TopLevel, Object)}.
      */
-    @Deprecated
     public static boolean isTruthy(TopLevel top, Object value)
         throws FusionException
     {
-        return FusionBool.isTruthy(top, value);
+        Evaluator eval = StandardTopLevel.toEvaluator(top);
+        return isTruthy(eval, value);
     }
 
-    /**
-     * @deprecated As of R15 in March 2014.
-     * Moved to {@link FusionBool#isTruthy(Evaluator, Object)}.
-     */
-    @Deprecated
-    static BaseBool isTruthy(Evaluator eval, Object value)
-        throws FusionException
-    {
-        return FusionBool.isTruthy(eval, value);
-    }
-
-
-    static BaseBool not(Evaluator eval, Object value)
+    static boolean isTruthy(Evaluator eval, Object value)
         throws FusionException
     {
         if (value instanceof BaseValue)
         {
-            return ((BaseValue) value).not(eval);
+            return ((BaseValue) value).isTruthy(eval);
         }
 
-        return falseBool(eval);
+        return true;
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionVoid.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionVoid.java
@@ -5,7 +5,7 @@ package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionBool.falseBool;
 import static dev.ionfusion.fusion.FusionBool.makeBool;
-import static dev.ionfusion.fusion.FusionBool.trueBool;
+
 import dev.ionfusion.fusion.FusionBool.BaseBool;
 import java.io.IOException;
 
@@ -25,15 +25,9 @@ public final class FusionVoid
         new BaseValue()
         {
             @Override
-            BaseBool isTruthy(Evaluator eval)
+            boolean isTruthy(Evaluator eval)
             {
-                return falseBool(eval);
-            }
-
-            @Override
-            BaseBool not(Evaluator eval)
-            {
-                return trueBool(eval);
+                return false;
             }
 
             @Override

--- a/runtime/src/main/java/dev/ionfusion/fusion/IfForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/IfForm.java
@@ -56,7 +56,7 @@ final class IfForm
         {
             Object result = eval.eval(store, myTestForm);
 
-            boolean truthy = isTruthy(eval, result).isTrue();
+            boolean truthy = FusionValue.isTruthy(eval, result);
 
             CompiledForm branch = truthy ? myThenForm : myElseForm;
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/NotProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/NotProc.java
@@ -4,6 +4,8 @@
 package dev.ionfusion.fusion;
 
 
+import static dev.ionfusion.fusion.FusionBool.makeBool;
+
 final class NotProc
     extends Procedure1
 {
@@ -11,6 +13,7 @@ final class NotProc
     Object doApply(Evaluator eval, Object arg)
         throws FusionException
     {
-        return not(eval, arg);
+        boolean truthy = FusionValue.isTruthy(eval, arg);
+        return makeBool(eval, !truthy);
     }
 }


### PR DESCRIPTION
* Undeprecated methods on `FusionValue` that were moved to `FusionBool`.  These apply to all values and shouldn't require coupling to any one type.

* Remove `BaseValue.not()` and `FusionValue.not()`. They are redundant given `isTruthy()`.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
