### PR TITLE
Stop `ModuleInstance` extending `NamedValue`.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/ModuleInstance.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ModuleInstance.java
@@ -10,7 +10,6 @@ import dev.ionfusion.fusion.ModuleNamespace.ProvidedBinding;
 import dev.ionfusion.fusion.Namespace.NsDefinedBinding;
 import dev.ionfusion.fusion._private.doc.model.BindingDoc;
 import dev.ionfusion.fusion._private.doc.model.ModuleDocs;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,7 +23,6 @@ import java.util.Set;
  * holding its top-level bindings.
  */
 final class ModuleInstance
-    extends NamedValue
 {
     // TODO This should retain the Namespace, perhaps, so we can evaluate
     //  "inside" the module namespace
@@ -52,8 +50,6 @@ final class ModuleInstance
 
         // Use object identity since symbols are interned.
         myProvidedBindings = new IdentityHashMap<>(bindingCount);
-
-        inferName(identity.toString());
     }
 
     /**
@@ -184,16 +180,5 @@ final class ModuleInstance
         }
 
         return doc;
-    }
-
-    //========================================================================
-
-
-    @Override
-    final void identify(Appendable out)
-        throws IOException
-    {
-        out.append("module ");
-        out.append(myIdentity.absolutePath());
     }
 }

--- a/runtime/src/test/java/dev/ionfusion/fusion/NamespaceTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/NamespaceTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+
 import com.amazon.ion.IonReader;
 import com.amazon.ion.system.IonReaderBuilder;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,7 +55,7 @@ public class NamespaceTest
 
                 ModuleRegistry reg = ns.getRegistry();
                 ModuleInstance kernel = reg.lookup(KERNEL_MODULE_IDENTITY);
-                assertEquals(KERNEL_MODULE_NAME, kernel.getInferredName());
+                assertEquals(KERNEL_MODULE_NAME, kernel.getIdentity().absolutePath());
 
                 return null;
             }


### PR DESCRIPTION
These are not Fusion values and don't need to support names or any other capability of `BaseValue`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
