### PR TITLE
Remove unused `NamedValue.nameInferred()`.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/NamedValue.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/NamedValue.java
@@ -37,16 +37,7 @@ abstract class NamedValue
         if (myName == null)
         {
             myName = name;
-            nameInferred(name);
         }
-    }
-
-    /**
-     * Hook for subclass to be notified when a name has been inferred for this
-     * value.
-     */
-    void nameInferred(String name)
-    {
     }
 
 


### PR DESCRIPTION
This was historically used to get the name into `BindingDoc` during documentation collection, but that's since been refactored.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
