### PR TITLE
Streamline object name inference.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/Compiler.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Compiler.java
@@ -338,7 +338,7 @@ class Compiler
             }
         }
 
-        String[] names  = new String[idCount];
+        BaseSymbol[] names  = new BaseSymbol[idCount];
         int[] addresses = new int   [idCount];
 
         for (int i = 0; i < idCount; i++)
@@ -346,7 +346,7 @@ class Compiler
             SyntaxSymbol identifier = ids[i];
             Binding b = identifier.getBinding();
 
-            names[i] = b.getName().stringValue();
+            names[i] = b.getName();
             addresses[i] = ((ModuleDefinedBinding) b).myAddress;
         }
 
@@ -401,8 +401,7 @@ class Compiler
             @Override
             public Object visit(NsDefinedBinding b) throws FusionException
             {
-                String name = b.getName().stringValue();
-                return new CompiledNsDefineSyntax(name, b.myAddress, valueForm);
+                return new CompiledNsDefineSyntax(b.getName(), b.myAddress, valueForm);
             }
 
             @Override

--- a/runtime/src/main/java/dev/ionfusion/fusion/NamedValue.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/NamedValue.java
@@ -3,6 +3,7 @@
 
 package dev.ionfusion.fusion;
 
+import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import java.io.IOException;
 
 
@@ -37,6 +38,14 @@ abstract class NamedValue
         if (myName == null)
         {
             myName = name;
+        }
+    }
+
+    static void inferObjectName(Object value, BaseSymbol name)
+    {
+        if (value instanceof NamedValue)
+        {
+            ((NamedValue)value).inferName(name.stringValue());
         }
     }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/Namespace.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Namespace.java
@@ -7,6 +7,7 @@ import static dev.ionfusion.fusion.BindingSite.makeDefineBindingSite;
 import static dev.ionfusion.fusion.BindingSite.makeImportBindingSite;
 import static dev.ionfusion.fusion.FusionIo.safeWriteToString;
 import static dev.ionfusion.fusion.FusionVoid.voidValue;
+import static dev.ionfusion.fusion.NamedValue.inferObjectName;
 
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.fusion.ModuleNamespace.ModuleDefinedBinding;
@@ -523,14 +524,7 @@ abstract class Namespace
     {
         set(binding.myAddress, value);
 
-        if (value instanceof NamedValue)
-        {
-            String inferredName = binding.getName().stringValue();
-            if (inferredName != null)
-            {
-                ((NamedValue)value).inferName(inferredName);
-            }
-        }
+        inferObjectName(value, binding.getName());
     }
 
 
@@ -989,11 +983,11 @@ abstract class Namespace
     static class CompiledNsDefine
         implements CompiledForm
     {
-        private final String       myName;
+        private final BaseSymbol   myName;
         private final int          myAddress;
         private final CompiledForm myValueForm;
 
-        CompiledNsDefine(String name, int address, CompiledForm valueForm)
+        CompiledNsDefine(BaseSymbol name, int address, CompiledForm valueForm)
         {
             assert name != null;
             myName      = name;
@@ -1012,10 +1006,7 @@ abstract class Namespace
             NamespaceStore ns = store.namespace();
             ns.set(myAddress, value);
 
-            if (value instanceof NamedValue)
-            {
-                ((NamedValue)value).inferName(myName);
-            }
+            inferObjectName(value, myName);
 
             return voidValue(eval);
         }
@@ -1032,7 +1023,7 @@ abstract class Namespace
     static final class CompiledNsDefineSyntax
         extends CompiledNsDefine
     {
-        CompiledNsDefineSyntax(String name, int address,
+        CompiledNsDefineSyntax(BaseSymbol name, int address,
                                CompiledForm valueForm)
         {
             super(name, address, valueForm);
@@ -1067,11 +1058,11 @@ abstract class Namespace
     static class CompiledNsDefineValues
         implements CompiledForm
     {
-        private final String[]     myNames;
+        private final BaseSymbol[] myNames;
         private final int[]        myAddresses;
         private final CompiledForm myValuesForm;
 
-        CompiledNsDefineValues(String[] names,
+        CompiledNsDefineValues(BaseSymbol[] names,
                                int[] addresses,
                                CompiledForm valuesForm)
         {
@@ -1106,10 +1097,7 @@ abstract class Namespace
                 {
                     Object value = vals[i];
                     ns.set(myAddresses[i], value);
-                    if (value instanceof NamedValue)
-                    {
-                        ((NamedValue)value).inferName(myNames[i]);
-                    }
+                    inferObjectName(value, myNames[i]);
                 }
             }
             else

--- a/runtime/src/main/java/dev/ionfusion/fusion/TopLevelNamespace.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/TopLevelNamespace.java
@@ -4,6 +4,7 @@
 package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionVoid.voidValue;
+import static dev.ionfusion.fusion.NamedValue.inferObjectName;
 
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.fusion.ModuleNamespace.ProvidedBinding;
@@ -267,10 +268,7 @@ final class TopLevelNamespace
 
             ns.set(binding.myAddress, value);
 
-            if (value instanceof NamedValue)
-            {
-                ((NamedValue)value).inferName(myId.stringValue());
-            }
+            inferObjectName(value, myId.getName());
 
             return voidValue(eval);
         }
@@ -355,10 +353,7 @@ final class TopLevelNamespace
 
             ns.set(binding.myAddress, value);
 
-            if (value instanceof NamedValue)
-            {
-                ((NamedValue) value).inferName(boundId.stringValue());
-            }
+            inferObjectName(value, boundId.getName());
         }
     }
 


### PR DESCRIPTION
## Description

I want to retain Fusion symbols, not Java strings, as inferred object names, since that's what needs to be returned to Fusion code anyway via `object_name`.

This passes symbols from code all the way to the point where it's injected.  It's still unwrapped there, but the next PR will fix that.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
