### PR TITLE
Ensure that all nulls are singletons after annotation removal.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionList.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionList.java
@@ -80,14 +80,12 @@ final class FusionList
 
     static NullList nullList(Evaluator eval, BaseSymbol[] annotations)
     {
-        if (annotations.length == 0) return NULL_LIST;
-        return new NullList(annotations);
+        return NULL_LIST.annotate(eval, annotations);
     }
 
     static NullList nullList(Evaluator eval, String[] annotations)
     {
-        if (annotations.length == 0) return NULL_LIST;
-        return new NullList(internSymbols(annotations));
+        return nullList(eval, internSymbols(annotations));
     }
 
 
@@ -886,8 +884,9 @@ final class FusionList
         }
 
         @Override
-        public Object annotate(Evaluator eval, BaseSymbol[] annotations)
+        public NullList annotate(Evaluator eval, BaseSymbol[] annotations)
         {
+            if (annotations.length == 0) return NULL_LIST;
             return new NullList(annotations);
         }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionSexp.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionSexp.java
@@ -50,14 +50,12 @@ final class FusionSexp
 
     static NullSexp nullSexp(Evaluator eval, BaseSymbol[] annotations)
     {
-        if (annotations.length == 0) return NULL_SEXP;
-        return new NullSexp(annotations);
+        return NULL_SEXP.annotate(eval, annotations);
     }
 
     static NullSexp nullSexp(Evaluator eval, String[] annotations)
     {
-        if (annotations.length == 0) return NULL_SEXP;
-        return new NullSexp(internSymbols(annotations));
+        return NULL_SEXP.annotate(eval, internSymbols(annotations));
     }
 
     /**
@@ -70,14 +68,12 @@ final class FusionSexp
 
     static EmptySexp emptySexp(Evaluator eval, BaseSymbol[] annotations)
     {
-        if (annotations.length == 0) return EMPTY_SEXP;
-        return new EmptySexp(annotations);
+        return EMPTY_SEXP.annotate(eval, annotations);
     }
 
     static EmptySexp emptySexp(Evaluator eval, String[] annotations)
     {
-        if (annotations.length == 0) return EMPTY_SEXP;
-        return new EmptySexp(internSymbols(annotations));
+        return EMPTY_SEXP.annotate(eval, internSymbols(annotations));
     }
 
 
@@ -557,9 +553,9 @@ final class FusionSexp
         }
 
         @Override
-        public Object annotate(Evaluator eval, BaseSymbol[] annotations)
-            throws FusionException
+        public NullSexp annotate(Evaluator eval, BaseSymbol[] annotations)
         {
+            if (annotations.length == 0) return NULL_SEXP;
             return new NullSexp(annotations);
         }
 
@@ -637,9 +633,9 @@ final class FusionSexp
         }
 
         @Override
-        public Object annotate(Evaluator eval, BaseSymbol[] annotations)
-            throws FusionException
+        public EmptySexp annotate(Evaluator eval, BaseSymbol[] annotations)
         {
+            if (annotations.length == 0) return EMPTY_SEXP;
             return new EmptySexp(annotations);
         }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionStruct.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionStruct.java
@@ -87,14 +87,12 @@ final class FusionStruct
 
     static NullStruct nullStruct(Evaluator eval, BaseSymbol[] annotations)
     {
-        if (annotations.length == 0) return NULL_STRUCT;
-        return new NullStruct(annotations);
+        return NULL_STRUCT.annotate(eval, annotations);
     }
 
     static NullStruct nullStruct(Evaluator eval, String[] annotations)
     {
-        if (annotations.length == 0) return NULL_STRUCT;
-        return new NullStruct(internSymbols(annotations));
+        return NULL_STRUCT.annotate(eval, internSymbols(annotations));
     }
 
 
@@ -622,9 +620,9 @@ final class FusionStruct
         }
 
         @Override
-        public Object annotate(Evaluator eval, BaseSymbol[] annotations)
-            throws FusionException
+        public NullStruct annotate(Evaluator eval, BaseSymbol[] annotations)
         {
+            if (annotations.length == 0) return NULL_STRUCT;
             return new NullStruct(annotations);
         }
 

--- a/runtime/src/test/fusion/scripts/annotate.test.fusion
+++ b/runtime/src/test/fusion/scripts/annotate.test.fusion
@@ -1,0 +1,10 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+(require "/fusion/experimental/check"
+         "/testutils")
+
+(define (test_value_is_singleton v)
+  (check_same v (annotate (annotate v "ann"))))
+
+(do test_value_is_singleton all_nulls)


### PR DESCRIPTION
## Description

From a design perspective, I'd like all of the trivial null and empty values to be singletons.  TBH I was kinda surprised it wasn't already the case.

Similar test for empty list/struct still needs some work.  The FusionStruct type hierarchy is a hot mess.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
