### PR TITLE
Store a symbol (not String) in `NamedValue`.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/NamedObject.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/NamedObject.java
@@ -5,6 +5,9 @@ package dev.ionfusion.fusion;
 
 /**
  * Fusion objects that support {@code object_name}.
+ * <p>
+ * Object names are intended for {@linkplain FusionIo#display display} in
+ * error messages and debugging.
  *
  * @see ObjectNameProc
  */
@@ -15,7 +18,7 @@ interface NamedObject
      * {@code object_name} function.
      * The result must not change between invocations.
      *
-     * @return the object name, or void; not (Java) null.
+     * @return the object name. If null, {@code object_name} returns void.
      */
-    Object objectName(Evaluator eval);
+    Object objectName();
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/NamedValue.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/NamedValue.java
@@ -11,29 +11,21 @@ abstract class NamedValue
     extends BaseValue
     implements NamedObject
 {
-    private String myName;
+    private BaseSymbol myName;
 
 
     @Override
-    public final Object objectName(Evaluator eval)
-    {
-        if (myName == null)
-        {
-            return FusionVoid.voidValue(eval);
-        }
-        else
-        {
-            // TODO don't do this every time.
-            return FusionSymbol.makeSymbol(eval, myName);
-        }
-    }
-
-    final String getInferredName()
+    public final BaseSymbol objectName()
     {
         return myName;
     }
 
-    final void inferName(String name)
+    final String getInferredName()
+    {
+        return myName == null ? null : myName.stringValue();
+    }
+
+    final void inferName(BaseSymbol name)
     {
         if (myName == null)
         {
@@ -45,7 +37,7 @@ abstract class NamedValue
     {
         if (value instanceof NamedValue)
         {
-            ((NamedValue)value).inferName(name.stringValue());
+            ((NamedValue)value).inferName(name);
         }
     }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/ObjectNameProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ObjectNameProc.java
@@ -19,7 +19,11 @@ class ObjectNameProc
     {
         if (arg instanceof NamedObject)
         {
-            return ((NamedObject) arg).objectName(eval);
+            Object o = ((NamedObject) arg).objectName();
+            if (o != null)
+            {
+                return o;
+            }
         }
 
         return FusionVoid.voidValue(eval);

--- a/runtime/src/main/java/dev/ionfusion/fusion/Records.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Records.java
@@ -9,6 +9,8 @@ import static dev.ionfusion.fusion.FusionNull.isNullNull;
 import static dev.ionfusion.fusion.FusionNumber.checkIntArgToJavaInt;
 import static dev.ionfusion.fusion.FusionNumber.checkNullableIntArg;
 import static dev.ionfusion.fusion.FusionSymbol.checkRequiredSymbolArg;
+import static dev.ionfusion.fusion.FusionSymbol.makeSymbol;
+
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -93,7 +95,7 @@ final class Records
         }
 
         @Override
-        public Object objectName(Evaluator eval)
+        public BaseSymbol objectName()
         {
             return myName;
         }
@@ -179,7 +181,7 @@ final class Records
             // implementing procedure’s name."
             // https://tinyurl.com/object-name
 
-            this.inferName(myProc.getInferredName());
+            this.inferName(myProc.objectName());
 
             // I have to wonder if there's contexts in which myProc hasn't had
             // its inferred name assigned yet; perhaps this should be dynamic?
@@ -407,9 +409,9 @@ final class Records
             Procedure accessor
                 = new RecordAccessorProc(type);
 
-            ctor.inferName("make_" + name);
-            pred.inferName("is_" + name);
-            accessor.inferName(name + "_element");
+            inferObjectName(ctor,     makeSymbol(eval, "make_" + name));
+            inferObjectName(pred,     makeSymbol(eval, "is_" + name));
+            inferObjectName(accessor, makeSymbol(eval, name + "_element"));
 
             return new Object[] { type, ctor, pred, accessor };
         }


### PR DESCRIPTION
## Description

These all start as symbols, and are supplied as symbols, so we should store them as symbols.

## Notes

Don't get hung up on the distinction between `NamedObject` and `NamedValue`.  The former is about to replace/become the latter.

FWIW `abstract class NamedValue` is very old, and I've learned that it's better to model these capabilities as interfaces when possible.  `NamedObject` was a recent addition, a first step in that direction.  I'm finally reconciling them, and will end up with just `interface NamedValue`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
