### PR TITLE
Streamline `ModuleInstance.getDocs()`.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/GlobalState.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/GlobalState.java
@@ -10,6 +10,7 @@ import com.amazon.ion.IonReader;
 import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.system.IonReaderBuilder;
+import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.fusion.ModuleNamespace.ModuleDefinedBinding;
 import java.io.IOException;
 import java.io.InputStream;
@@ -190,7 +191,8 @@ final class GlobalState
      */
     private ModuleDefinedBinding kernelBinding(String name)
     {
-        ModuleDefinedBinding b = myKernelModule.resolveProvidedName(name).target();
+        BaseSymbol sym = FusionSymbol.makeSymbol(null, name);
+        ModuleDefinedBinding b = myKernelModule.resolveProvidedName(sym).target();
         assert b != null;
         return b;
     }

--- a/runtime/src/main/java/dev/ionfusion/fusion/ModuleInstance.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ModuleInstance.java
@@ -112,15 +112,6 @@ final class ModuleInstance
         return Collections.unmodifiableSet(myProvidedBindings.keySet());
     }
 
-
-    /**
-     * @return null if the name isn't provided by this module.
-     */
-    ProvidedBinding resolveProvidedName(String name)
-    {
-        return resolveProvidedName(BaseSymbol.internSymbol(name));
-    }
-
     /**
      * @return null if the name isn't provided by this module.
      */
@@ -144,9 +135,7 @@ final class ModuleInstance
 
         for (BaseSymbol name : names)
         {
-            String text = name.stringValue();
-            BindingDoc doc = documentProvidedName(text);
-            bindings.put(text, doc);
+            bindings.put(name.stringValue(), documentProvidedName(name));
         }
 
         return new ModuleDocs(myIdentity, myDocs, bindings);
@@ -155,30 +144,17 @@ final class ModuleInstance
     /**
      * @return may be null.
      */
-    private BindingDoc documentProvidedName(String name)
+    private BindingDoc documentProvidedName(BaseSymbol name)
     {
         ModuleDefinedBinding binding = resolveProvidedName(name).target();
-
-        return documentProvidedName(binding);
-    }
-
-    private BindingDoc documentProvidedName(ModuleDefinedBinding binding)
-    {
-        BindingDoc doc;
-
         if (binding.myModuleId == myIdentity)
         {
-            doc = myStore.document(binding.myAddress);
-        }
-        else
-        {
-            ModuleInstance module =
-                myStore.getRegistry().lookup(binding.myModuleId);
-            assert module != null
-                : "Module not found: " + binding.myModuleId;
-            doc = module.myStore.document(binding.myAddress);
+            return myStore.document(binding.myAddress);
         }
 
-        return doc;
+        ModuleInstance module = myStore.getRegistry().lookup(binding.myModuleId);
+        assert module != null : "Module not found: " + binding.myModuleId;
+
+        return module.myStore.document(binding.myAddress);
     }
 }


### PR DESCRIPTION
For some reason it was re-interning each binding name.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
