### PR TITLE
Tidy `GlobalState.kernelBoundIdentifier()`.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionEval.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionEval.java
@@ -9,6 +9,7 @@ import static dev.ionfusion.fusion.FusionVoid.voidValue;
 import static dev.ionfusion.fusion.GlobalState.MODULE;
 import static dev.ionfusion.fusion.StandardReader.readSyntax;
 import static dev.ionfusion.fusion.Syntax.datumToSyntax;
+
 import com.amazon.ion.IonReader;
 import java.util.LinkedList;
 
@@ -206,7 +207,7 @@ final class FusionEval
             {
                 maybeKeyword = (SyntaxSymbol) ns.syntaxIntroduce(maybeKeyword);
                 SyntaxSymbol moduleKeyword =
-                    eval.getGlobalState().kernelBoundIdentifier(eval, MODULE);
+                    eval.getGlobalState().kernelBoundIdentifier(MODULE);
                 if (maybeKeyword.freeIdentifierEqual(moduleKeyword))
                 {
                     // Stash the resolved identifier back in the sexp.

--- a/runtime/src/main/java/dev/ionfusion/fusion/GlobalState.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/GlobalState.java
@@ -207,14 +207,16 @@ final class GlobalState
     /**
      * Creates a new identifier that's bound in this kernel.
      *
-     * @param eval not null.
      * @param name must be defined by this kernel!
      */
-    SyntaxSymbol kernelBoundIdentifier(Evaluator eval, String name)
+    SyntaxSymbol kernelBoundIdentifier(String name)
     {
-        SyntaxSymbol sym = SyntaxSymbol.make(eval, name);
-        sym = sym.copyReplacingBinding(kernelBinding(name));
-        return sym;
+        ModuleDefinedBinding b = kernelBinding(name);
+
+        BaseSymbol sym = b.getName();
+        assert sym.stringValue().equals(name);
+
+        return SyntaxSymbol.make(null, sym).copyReplacingBinding(b);
     }
 
     private static IonStruct kernelDocs(IonSystem system)

--- a/runtime/src/test/java/dev/ionfusion/fusion/ExpandProgramTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/ExpandProgramTest.java
@@ -18,6 +18,7 @@ import static dev.ionfusion.fusion.GlobalState.LAMBDA;
 import static dev.ionfusion.fusion.GlobalState.MODULE;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 
 
@@ -98,9 +99,9 @@ public class ExpandProgramTest
         Evaluator eval = evaluator();
         GlobalState globals = eval.getGlobalState();
 
-        Object kernelLambdaId = globals.kernelBoundIdentifier(eval, LAMBDA);
-        Object kernelModuleId = globals.kernelBoundIdentifier(eval, MODULE);
-        Object kernelDefValuesId = globals.kernelBoundIdentifier(eval, DEFINE_VALUES);
+        Object kernelLambdaId = globals.kernelBoundIdentifier(LAMBDA);
+        Object kernelModuleId = globals.kernelBoundIdentifier(MODULE);
+        Object kernelDefValuesId = globals.kernelBoundIdentifier(DEFINE_VALUES);
 
         CoreFormCollector collector = new CoreFormCollector();
 


### PR DESCRIPTION
It doesn't need `Evaluator` and shouldn't intern the text twice.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
