### PR TITLE
Remove `FusionException.raise()`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionException.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionException.java
@@ -169,23 +169,4 @@ public class FusionException
 
         return out.toString();
     }
-
-
-    static Object raise(Evaluator eval, Object value)
-        throws FusionException
-    {
-        if (value instanceof FusionException)
-        {
-            throw (FusionException) value;
-        }
-
-        if (value instanceof Throwable)
-        {
-            String message =
-                "Java Throwables cannot be raised from Fusion code";
-            throw new IllegalArgumentException(message, (Throwable) value);
-        }
-
-        throw new FusionUserException(value);
-    }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/RaiseProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/RaiseProc.java
@@ -7,9 +7,21 @@ final class RaiseProc
     extends Procedure1
 {
     @Override
-    Object doApply(Evaluator eval, Object arg)
+    Object doApply(Evaluator eval, Object value)
         throws FusionException
     {
-        return FusionException.raise(eval, arg);
+        if (value instanceof FusionException)
+        {
+            throw (FusionException) value;
+        }
+
+        if (value instanceof Throwable)
+        {
+            String message =
+                "Java Throwables cannot be raised from Fusion code";
+            throw new IllegalArgumentException(message, (Throwable) value);
+        }
+
+        throw new FusionUserException(value);
     }
 }


### PR DESCRIPTION
It was only used by the Fusion `raise` procedure, so inline it.

## Description

Also this public class should not depend on `Evaluator` or other implementation details.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
