### PR TITLE
Make `FusionException.getContext()` public.

### DIFF
--- a/runtime/src/test/java/dev/ionfusion/fusion/StackTraceTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/StackTraceTest.java
@@ -18,8 +18,8 @@ public class StackTraceTest
         throws Exception
     {
         FusionException e = assertEvalThrows(FusionException.class, code);
-        List<SourceLocation> locations = e.getContextLocations();
-        if (locations == null)
+        List<SourceLocation> locations = e.getContext();
+        if (locations.isEmpty())
         {
             // This is probably a parsing error, since the evaluator will
             // otherwise ensure a topmost locations.


### PR DESCRIPTION
This should be accessible by tools.

## Description

In preparation for moving `FusionException` outside of the implementation package, there's a number of things to clean up and increase visibility.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
