### PR TITLE
Remove `FusionException.addContext(SyntaxValue)`.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/AmbiguousBindingFailure.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/AmbiguousBindingFailure.java
@@ -6,9 +6,9 @@ package dev.ionfusion.fusion;
 import static com.amazon.ion.util.IonTextUtils.printQuotedSymbol;
 
 /**
- * Indicates an import of an identifier that is already bound.
+ * Indicates an import or definition of an identifier that is already bound
+ * and cannot be redefined.
  */
-@SuppressWarnings("serial")
 final class AmbiguousBindingFailure
     extends SyntaxException
 {
@@ -19,10 +19,16 @@ final class AmbiguousBindingFailure
               " is already defined or imported from elsewhere");
     }
 
+    /**
+     * @param expr may be null.
+     */
     public AmbiguousBindingFailure(String whatForm, String identifier,
                                    SyntaxValue expr)
     {
         this(whatForm, identifier);
-        addContext(expr);
+        if (expr != null)
+        {
+            addContext(expr.getLocation());
+        }
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionException.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionException.java
@@ -74,20 +74,6 @@ public class FusionException
 
 
     /**
-     * Prepends a now location to the continuation of this exception.
-     *
-     * @param stx can be null to indicate an unknown location.
-     */
-    void addContext(SyntaxValue stx)
-    {
-        if (stx != null)
-        {
-            addContext(stx.getLocation());
-        }
-    }
-
-
-    /**
      * Returns the Fusion stack trace of this exception.
      * The first element in the list is the deepest stack frame, normally the
      * site of the exception.

--- a/runtime/src/main/java/dev/ionfusion/fusion/LocalEnvironment.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/LocalEnvironment.java
@@ -138,6 +138,7 @@ final class LocalEnvironment
                      SyntaxValue formForErrors)
         throws FusionException
     {
+        assert formForErrors != null;
         myEnclosure = enclosure;
         myNamespace = enclosure.namespace();
         myDepth = 1 + enclosure.getDepth();

--- a/runtime/src/main/java/dev/ionfusion/fusion/MacroForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/MacroForm.java
@@ -88,7 +88,7 @@ final class MacroForm
         }
         catch (FusionException e)
         {
-            e.addContext(stx);
+            e.addContext(stx.getLocation());
             throw e;
         }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/ModuleForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ModuleForm.java
@@ -106,7 +106,7 @@ final class ModuleForm
             }
             catch (FusionException e)
             {
-                e.addContext(initialBindingsStx);
+                e.addContext(initialBindingsStx.getLocation());
                 throw e;
             }
 
@@ -184,7 +184,7 @@ final class ModuleForm
                     }
                     catch (FusionException e)
                     {
-                        e.addContext(form);
+                        e.addContext(form.getLocation());
                         throw e;
                     }
                     formIsExpanded = true;
@@ -200,7 +200,7 @@ final class ModuleForm
                     }
                     catch (FusionException e)
                     {
-                        e.addContext(form);
+                        e.addContext(form.getLocation());
                         throw e;
                     }
                     formIsExpanded = true;

--- a/runtime/src/main/java/dev/ionfusion/fusion/ModuleNotFoundException.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ModuleNotFoundException.java
@@ -7,7 +7,6 @@ package dev.ionfusion.fusion;
 /**
  * Indicates failure to locate a required module.
  */
-@SuppressWarnings("serial")
 public final class ModuleNotFoundException
     extends FusionErrorException
 {
@@ -22,6 +21,9 @@ public final class ModuleNotFoundException
     ModuleNotFoundException(String message, SyntaxValue location)
     {
         this(message);
-        addContext(location);
+        if (location != null)
+        {
+            addContext(location.getLocation());
+        }
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/RequireForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/RequireForm.java
@@ -275,7 +275,7 @@ final class RequireForm
             }
             catch (FusionException e)
             {
-                e.addContext(spec);
+                e.addContext(spec.getLocation());
                 throw e;
             }
         }

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxChecker.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxChecker.java
@@ -17,6 +17,8 @@ class SyntaxChecker
 
     SyntaxChecker(Evaluator eval, String formName, SyntaxSequence form)
     {
+        assert form != null;
+
         myEvaluator = eval;
         myFormName = formName;
         myForm = form;
@@ -29,6 +31,8 @@ class SyntaxChecker
     SyntaxChecker(Evaluator eval, SyntaxSexp form)
         throws FusionException
     {
+        assert form != null;
+
         SyntaxSymbol id = form.firstIdentifier(eval);
 
         myEvaluator = eval;
@@ -37,6 +41,11 @@ class SyntaxChecker
     }
 
 
+    /**
+     * Gets the syntax form being checked.
+     *
+     * @return not null.
+     */
     SyntaxSequence form()
     {
         return myForm;
@@ -53,7 +62,7 @@ class SyntaxChecker
     SyntaxException failure(String message, SyntaxValue subform)
     {
         SyntaxException e = new SyntaxException(myFormName, message, subform);
-        e.addContext(myForm);
+        e.addContext(myForm.getLocation());
         return e;
     }
 
@@ -246,7 +255,7 @@ class SyntaxChecker
         {
             SyntaxException e =
                 new SyntaxException(myBaseForm.myFormName, message, myForm);
-            e.addContext(myBaseForm.myForm);
+            e.addContext(myBaseForm.myForm.getLocation());
             return e;
         }
 
@@ -255,7 +264,7 @@ class SyntaxChecker
         {
             SyntaxException e =
                 new SyntaxException(myBaseForm.myFormName, message, subform);
-            e.addContext(myBaseForm.myForm);
+            e.addContext(myBaseForm.myForm.getLocation());
             return e;
         }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSymbol.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSymbol.java
@@ -380,7 +380,7 @@ final class SyntaxSymbol
                         printQuotedSymbol(id.stringValue());
 
                 SyntaxException ex = new SyntaxException(null, message, id);
-                ex.addContext(formForErrors);
+                ex.addContext(formForErrors.getLocation());
                 throw ex;
             }
         }


### PR DESCRIPTION
Decoupling the base exception from implementation.

## Note

IDEA say that some `serial` suppressions are redundant (I guess they're inherited), so removed those from files I changed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
