### PR TITLE
Rewire `ArgumentException` creation from procedures.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/AnnotateProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/AnnotateProc.java
@@ -34,6 +34,6 @@ final class AnnotateProc
             return FusionValue.annotate(eval, target, annotations);
         }
 
-        throw argFailure("annotatable type", 0, args);
+        throw argError(eval, "annotatable type", 0, args);
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/ApplyProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ApplyProc.java
@@ -24,7 +24,7 @@ final class ApplyProc
 
         int arity = args.length;
 
-        Procedure proc = checkProcArg(0, args);
+        Procedure proc = checkProcArg(eval, 0, args);
 
         Object rest = args[arity - 1];
         boolean restIsList = isList(eval, rest);
@@ -41,7 +41,7 @@ final class ApplyProc
         }
         else
         {
-            throw argFailure("list or sexp", arity - 1, args);
+            throw argError(eval, "list or sexp", arity - 1, args);
         }
 
         // TODO if proc accepts a rest argument, optimize this copying.

--- a/runtime/src/main/java/dev/ionfusion/fusion/ArgumentException.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ArgumentException.java
@@ -70,28 +70,6 @@ final class ArgumentException
         this(name, expectation, badPos, new Object[] { actual });
     }
 
-    /**
-     * @param badPos the zero-based index of the problematic value.
-     *   -1 means a specific position isn't implicated.
-     * @param actuals must not be null or zero-length.
-     */
-    ArgumentException(Procedure name, String expectation,
-                      int badPos, Object... actuals)
-    {
-        this(name.identify(), expectation, badPos, actuals);
-    }
-
-    /**
-     * @param badPos the index of the problematic argument.
-     *   -1 means a specific arg isn't implicated.
-     * @param actual must not be null.
-     */
-    ArgumentException(Procedure name, String expectation,
-                      int badPos, Object actual)
-    {
-        this(name.identify(), expectation, badPos, new Object[]{ actual });
-        assert actual != null;
-    }
 
     String getName()
     {

--- a/runtime/src/main/java/dev/ionfusion/fusion/CallWithHandlerProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/CallWithHandlerProc.java
@@ -19,8 +19,8 @@ final class CallWithHandlerProc
         throws FusionException
     {
         // TODO Check arity of both procs before installing the handler.
-        checkArg(Procedure.class, "1-arg procedure", 0, handler, thunk);
-        checkArg(Procedure.class, "0-arg procedure", 1, handler, thunk);
+        checkArg(eval, Procedure.class, "1-arg procedure", 0, handler, thunk);
+        checkArg(eval, Procedure.class, "0-arg procedure", 1, handler, thunk);
 
         try
         {

--- a/runtime/src/main/java/dev/ionfusion/fusion/DatumToSyntaxProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/DatumToSyntaxProc.java
@@ -28,7 +28,7 @@ class DatumToSyntaxProc
             //  https://github.com/ion-fusion/fusion-java/issues/68
             if (! isIdentifier(eval, args[1]))
             {
-                throw argFailure("syntax identifier", 1, args);
+                throw argError(eval, "syntax identifier", 1, args);
             }
             context = (SyntaxSymbol) args[1];
 
@@ -36,7 +36,7 @@ class DatumToSyntaxProc
             {
                 if (! isSyntax(eval, args[2]))
                 {
-                    throw argFailure("syntax object", 2, args);
+                    throw argError(eval, "syntax object", 2, args);
                 }
                 location = unsafeSyntaxLocation(eval, args[2]);
             }

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionCollection.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionCollection.java
@@ -103,7 +103,7 @@ final class FusionCollection
             return arg;
         }
 
-        throw who.argFailure(expectation, argNum, args);
+        throw who.argError(eval, expectation, argNum, args);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionCompare.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionCompare.java
@@ -16,9 +16,10 @@ import static dev.ionfusion.fusion.FusionSymbol.isSymbol;
 import static dev.ionfusion.fusion.FusionSymbol.unsafeSymbolToJavaString;
 import static dev.ionfusion.fusion.FusionTimestamp.isTimestamp;
 import static dev.ionfusion.fusion.FusionTimestamp.unsafeTimestampToJavaTimestamp;
+
+import com.amazon.ion.Timestamp;
 import dev.ionfusion.fusion.FusionBool.BaseBool;
 import dev.ionfusion.fusion.FusionNumber.BaseNumber;
-import com.amazon.ion.Timestamp;
 import java.math.BigDecimal;
 
 /**
@@ -85,9 +86,9 @@ final class FusionCompare
     private static abstract class BaseCompareProc
         extends Procedure
     {
-        FusionException failure(Object[] args)
+        FusionException failure(Evaluator eval, Object[] args)
         {
-            return new ArgumentException(this, "comparable types", -1, args);
+            return argError(eval, "comparable types", -1, args);
         }
 
 
@@ -100,10 +101,10 @@ final class FusionCompare
             throws FusionException;
 
 
-        boolean compareStrings(String left, String right, Object[] args)
+        boolean compareStrings(Evaluator eval, String left, String right, Object[] args)
             throws FusionException
         {
-            throw failure(args);
+            throw failure(eval, args);
         }
 
 
@@ -149,7 +150,7 @@ final class FusionCompare
 
                 if (left != null && right != null)
                 {
-                    boolean r = compareStrings(left, right, args);
+                    boolean r = compareStrings(eval, left, right, args);
                     return makeBool(eval, r);
                 }
             }
@@ -161,7 +162,7 @@ final class FusionCompare
 
                 if (left != null && right != null)
                 {
-                    boolean r = compareStrings(left, right, args);
+                    boolean r = compareStrings(eval, left, right, args);
                     return makeBool(eval, r);
                 }
             }
@@ -178,7 +179,7 @@ final class FusionCompare
                 }
             }
 
-            throw failure(args);
+            throw failure(eval, args);
         }
     }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionEval.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionEval.java
@@ -432,7 +432,7 @@ final class FusionEval
                 }
                 else
                 {
-                    throw argFailure("namespace", 1, args);
+                    throw argError(eval, "namespace", 1, args);
                 }
             }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionIo.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionIo.java
@@ -854,7 +854,7 @@ public final class FusionIo
         {
             checkArityExact(2, args);
 
-            Procedure thunk = checkProcArg(1, args);
+            Procedure thunk = checkProcArg(eval, 1, args);
             // TODO check thunk arity
             //  https://github.com/ion-fusion/fusion-java/issues/76
 
@@ -910,7 +910,7 @@ public final class FusionIo
             Object lob = args[0];
             if (! isLob(eval, lob) || isAnyNull(eval, lob).isTrue())
             {
-                throw argFailure("non-null blob or clob", 0, args);
+                throw argError(eval, "non-null blob or clob", 0, args);
             }
 
             byte[] bytes = unsafeLobBytesNoCopy(eval, lob);

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionIterator.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionIterator.java
@@ -10,6 +10,7 @@ import static dev.ionfusion.fusion.FusionList.unsafeListIterator;
 import static dev.ionfusion.fusion.FusionSexp.isSexp;
 import static dev.ionfusion.fusion.FusionSexp.unsafeSexpIterator;
 import static dev.ionfusion.fusion._private.FusionUtils.EMPTY_OBJECT_ARRAY;
+
 import com.amazon.ion.IonValue;
 import java.io.IOException;
 import java.util.Iterator;
@@ -20,10 +21,10 @@ import java.util.NoSuchElementException;
 class FusionIterator
     extends BaseValue
 {
-    static FusionIterator checkArg(Procedure who, int argNum, Object... args)
-        throws ArgumentException
+    static FusionIterator checkArg(Evaluator eval, Procedure who, int argNum, Object... args)
+        throws FusionException
     {
-        return who.checkArg(FusionIterator.class, "iterator", argNum, args);
+        return who.checkArg(eval, FusionIterator.class, "iterator", argNum, args);
     }
 
 
@@ -312,7 +313,7 @@ class FusionIterator
         Object doApply(Evaluator eval, Object arg)
             throws FusionException
         {
-            FusionIterator iter = FusionIterator.checkArg(this, 0, arg);
+            FusionIterator iter = FusionIterator.checkArg(eval, this, 0, arg);
             return iter.doHasNextTail(eval);
         }
     }
@@ -325,7 +326,7 @@ class FusionIterator
         Object doApply(Evaluator eval, Object arg)
             throws FusionException
         {
-            FusionIterator iter = FusionIterator.checkArg(this, 0, arg);
+            FusionIterator iter = FusionIterator.checkArg(eval, this, 0, arg);
             return iter.doNextTail(eval);
         }
     }

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionList.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionList.java
@@ -1251,7 +1251,7 @@ final class FusionList
             return arg;
         }
 
-        throw who.argFailure(expectation, argNum, args);
+        throw who.argError(eval, expectation, argNum, args);
     }
 
 
@@ -1282,7 +1282,7 @@ final class FusionList
         Object result = checkListArg(eval, who, expectation, argNum, args);
         if (isNullList(eval, result))
         {
-            throw who.argFailure(expectation, argNum, args);
+            throw who.argError(eval, expectation, argNum, args);
         }
         return result;
     }

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionLob.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionLob.java
@@ -172,7 +172,7 @@ public final class FusionLob
             return arg;
         }
 
-        throw who.argFailure(expectation, argNum, args);
+        throw who.argError(eval, expectation, argNum, args);
     }
 
 
@@ -203,7 +203,7 @@ public final class FusionLob
         BaseLob result = (BaseLob) checkLobArg(eval, who, expectation, argNum, args);
         if (result.isAnyNull())
         {
-            throw who.argFailure(expectation, argNum, args);
+            throw who.argError(eval, expectation, argNum, args);
         }
         return result;
     }
@@ -238,7 +238,7 @@ public final class FusionLob
                 }
             }
 
-            throw argFailure("algorithm name; \"SHA-256\" or \"SHA-512\"", 1, arg0, arg1);
+            throw argError(eval, "algorithm name; \"SHA-256\" or \"SHA-512\"", 1, arg0, arg1);
         }
     }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionNamespace.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionNamespace.java
@@ -48,7 +48,7 @@ final class FusionNamespace
             String language = checkRequiredStringArg(eval, this, 0, arg);
             if (! (language.startsWith("/") && 1 < language.length()))
             {
-                throw argFailure("absolute module path", 0, arg);
+                throw argError(eval, "absolute module path", 0, arg);
             }
 
             return makeNamespaceWithLanguage(eval, language, null);

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionNumber.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionNumber.java
@@ -1884,7 +1884,7 @@ public final class FusionNumber
             }
         }
 
-        throw who.argFailure("32-bit int", argNum, args);
+        throw who.argError(eval, "32-bit int", argNum, args);
     }
 
 
@@ -1904,7 +1904,7 @@ public final class FusionNumber
             return ((LongInt) arg).myContent;
         }
 
-        throw who.argFailure("64-bit int", argNum, args);
+        throw who.argError(eval, "64-bit int", argNum, args);
     }
 
 
@@ -1925,7 +1925,7 @@ public final class FusionNumber
             return ((BaseInt) arg).truncateToBigInteger();
         }
 
-        throw who.argFailure(expectation, argNum, args);
+        throw who.argError(eval, expectation, argNum, args);
     }
 
 
@@ -1956,7 +1956,7 @@ public final class FusionNumber
         BigInteger result = checkIntArg(eval, who, expectation, argNum, args);
         if (result == null)
         {
-            throw who.argFailure(expectation, argNum, args);
+            throw who.argError(eval, expectation, argNum, args);
         }
         return result;
     }
@@ -1983,7 +1983,7 @@ public final class FusionNumber
             return ((BaseDecimal) arg).toBigDecimal();
         }
 
-        throw who.argFailure(expectation, argNum, args);
+        throw who.argError(eval, expectation, argNum, args);
     }
 
     static BigDecimal checkNullableDecimalArg(Evaluator eval,
@@ -2012,7 +2012,7 @@ public final class FusionNumber
             checkDecimalArg(eval, who, expectation, argNum, args);
         if (result == null)
         {
-            throw who.argFailure(expectation, argNum, args);
+            throw who.argError(eval, expectation, argNum, args);
         }
         return result;
     }
@@ -2039,7 +2039,7 @@ public final class FusionNumber
             return (BaseFloat) arg;
         }
 
-        throw who.argFailure(expectation, argNum, args);
+        throw who.argError(eval, expectation, argNum, args);
     }
 
 
@@ -2069,7 +2069,7 @@ public final class FusionNumber
         BaseFloat f = checkFloatArg(eval, who, expectation, argNum, args);
         if (f.isAnyNull())
         {
-            throw who.argFailure(expectation, argNum, args);
+            throw who.argError(eval, expectation, argNum, args);
         }
         return f.primitiveDoubleValue();
     }
@@ -2096,7 +2096,7 @@ public final class FusionNumber
             return ((BaseNumber) arg).toBigDecimal();
         }
 
-        throw who.argFailure(expectation, argNum, args);
+        throw who.argError(eval, expectation, argNum, args);
     }
 
     static BigDecimal checkNullableNumberArgToJavaBigDecimal(Evaluator eval,
@@ -2125,7 +2125,7 @@ public final class FusionNumber
            checkNumberArgToJavaBigDecimal(eval, who, expectation, argNum, args);
         if (result == null)
         {
-            throw who.argFailure(expectation, argNum, args);
+            throw who.argError(eval, expectation, argNum, args);
         }
         return result;
     }
@@ -2206,13 +2206,13 @@ public final class FusionNumber
                         }
                     }
 
-                    throw argFailure("non-null int or decimal", i, args);
+                    throw argError(eval, "non-null int or decimal", i, args);
                 }
 
                 return accum;
             }
 
-            throw argFailure("non-null int or decimal", 0, args);
+            throw argError(eval, "non-null int or decimal", 0, args);
         }
     }
 
@@ -2248,13 +2248,13 @@ public final class FusionNumber
                         }
                     }
 
-                    throw argFailure("non-null int or decimal", i, args);
+                    throw argError(eval,"non-null int or decimal", i, args);
                 }
 
                 return accum;
             }
 
-            throw argFailure("non-null int or decimal", 0, args);
+            throw argError(eval, "non-null int or decimal", 0, args);
         }
     }
 
@@ -2293,14 +2293,14 @@ public final class FusionNumber
                             }
                         }
 
-                        throw argFailure("non-null int or decimal", i, args);
+                        throw argError(eval, "non-null int or decimal", i, args);
                     }
 
                     return accum;
                 }
             }
 
-            throw argFailure("non-null int or decimal", 0, args);
+            throw argError(eval, "non-null int or decimal", 0, args);
         }
     }
 
@@ -2376,7 +2376,7 @@ public final class FusionNumber
             {
                 final Object rawCoefficient = args[0];
                 assert isFloat(eval, rawCoefficient);
-                throw argFailure("unable to convert non-number float in coefficient", 0, args);
+                throw argError(eval, "unable to convert non-number float in coefficient", 0, args);
             }
 
             return makeDecimal(eval, coefficient.scaleByPowerOfTen(exponent));
@@ -2499,13 +2499,13 @@ public final class FusionNumber
 
             String val = checkNullableStringArg(eval, this, 0, args);
 
-            BigDecimal bigDecimal = (val != null ? parse(val, args) : null);
+            BigDecimal bigDecimal = (val != null ? parse(eval, val, args) : null);
 
             return makeDecimal(eval, bigDecimal);
         }
 
-        BigDecimal parse(String text, Object[] args)
-            throws ArgumentException
+        BigDecimal parse(Evaluator eval, String text, Object[] args)
+            throws FusionException
         {
             try
             {
@@ -2518,7 +2518,7 @@ public final class FusionNumber
             }
             catch (NumberFormatException e) { }
 
-            throw argFailure("valid decimal content", 0, args);
+            throw argError(eval, "valid decimal content", 0, args);
         }
     }
 
@@ -2545,7 +2545,7 @@ public final class FusionNumber
                 }
             }
 
-            throw new ArgumentException(this, "non-null int or decimal", 0, arg0);
+            throw argError(eval, "non-null int or decimal", 0, arg0);
         }
     }
 
@@ -2572,7 +2572,7 @@ public final class FusionNumber
                 }
             }
 
-            throw new ArgumentException(this, "non-null int or decimal", 0, arg0);
+            throw argError(eval, "non-null int or decimal", 0, arg0);
         }
     }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionSequence.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionSequence.java
@@ -141,7 +141,7 @@ final class FusionSequence
             return arg;
         }
 
-        throw who.argFailure(expectation, argNum, args);
+        throw who.argError(eval, expectation, argNum, args);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionString.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionString.java
@@ -465,7 +465,7 @@ public final class FusionString
             return ((BaseString) arg).stringValue();
         }
 
-        throw who.argFailure(expectation, argNum, args);
+        throw who.argError(eval, expectation, argNum, args);
     }
 
 
@@ -496,7 +496,7 @@ public final class FusionString
         String result = checkStringArg(eval, who, expectation, argNum, args);
         if (result == null)
         {
-            throw who.argFailure(expectation, argNum, args);
+            throw who.argError(eval, expectation, argNum, args);
         }
         return result;
     }
@@ -515,7 +515,7 @@ public final class FusionString
         String result = checkStringArg(eval, who, expectation, argNum, args);
         if (result == null || result.isEmpty())
         {
-            throw who.argFailure(expectation, argNum, args);
+            throw who.argError(eval, expectation, argNum, args);
         }
         return result;
     }
@@ -624,7 +624,7 @@ public final class FusionString
             }
             catch (CharacterCodingException e)
             {
-                throw argFailure("valid Unicode string", 0, arg);
+                throw argError(eval, "valid Unicode string", 0, arg);
             }
         }
     }

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionStruct.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionStruct.java
@@ -1489,7 +1489,7 @@ final class FusionStruct
             return arg;
         }
 
-        throw who.argFailure(expectation, argNum, args);
+        throw who.argError(eval, expectation, argNum, args);
     }
 
 
@@ -1881,7 +1881,7 @@ final class FusionStruct
                 {
                     String expectation =
                         "sequence of non-null strings or symbols";
-                    throw new ArgumentException(this, expectation, 0, args);
+                    throw argError(eval, expectation, 0, args);
                 }
 
                 Object valueObj = valueIterator.next();

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionSymbol.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionSymbol.java
@@ -584,7 +584,7 @@ final class FusionSymbol
             return ((BaseSymbol) arg).stringValue();
         }
 
-        throw who.argFailure(expectation, argNum, args);
+        throw who.argError(eval, expectation, argNum, args);
     }
 
 
@@ -615,7 +615,7 @@ final class FusionSymbol
         String result = checkSymbolArg(eval, who, expectation, argNum, args);
         if (result == null)
         {
-            throw who.argFailure(expectation, argNum, args);
+            throw who.argError(eval, expectation, argNum, args);
         }
         return result;
     }

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionSyntax.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionSyntax.java
@@ -159,7 +159,7 @@ final class FusionSyntax
                                       String    expectation,
                                       int       argNum,
                                       Object... args)
-        throws ArgumentException
+        throws FusionException
     {
         Object arg = args[argNum];
         if (arg instanceof SyntaxValue)
@@ -167,7 +167,7 @@ final class FusionSyntax
             return (SyntaxValue) arg;
         }
 
-        throw who.argFailure(expectation, argNum, args);
+        throw who.argError(eval, expectation, argNum, args);
     }
 
 
@@ -179,7 +179,7 @@ final class FusionSyntax
                                            String    expectation,
                                            int       argNum,
                                            Object... args)
-        throws ArgumentException
+        throws FusionException
     {
         Object arg = args[argNum];
         if (arg instanceof SyntaxSymbol)
@@ -187,7 +187,7 @@ final class FusionSyntax
             return (SyntaxSymbol) arg;
         }
 
-        throw who.argFailure(expectation, argNum, args);
+        throw who.argError(eval, expectation, argNum, args);
     }
 
 
@@ -228,7 +228,7 @@ final class FusionSyntax
             throws FusionException
         {
             checkArityExact(1, args);
-            SyntaxValue stx = checkSyntaxArg(0, args);
+            SyntaxValue stx = checkSyntaxArg(eval, 0, args);
             return stx.syntaxToDatum(eval);
         }
     }
@@ -242,7 +242,7 @@ final class FusionSyntax
             throws FusionException
         {
             checkArityExact(1, args);
-            SyntaxValue stx = checkSyntaxArg(0, args);
+            SyntaxValue stx = checkSyntaxArg(eval, 0, args);
             return stx.unwrap(eval);
         }
     }

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionText.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionText.java
@@ -110,14 +110,14 @@ final class FusionText
                                String    expectation,
                                int       argNum,
                                Object... args)
-        throws FusionException, ArgumentException
+        throws FusionException
     {
         Object arg = args[argNum];
         if (arg instanceof BaseText)
         {
             return ((BaseText) arg).stringValue();
         }
-        throw who.argFailure(expectation, argNum, args);
+        throw who.argError(eval, expectation, argNum, args);
     }
 
 
@@ -128,13 +128,13 @@ final class FusionText
                                        Procedure who,
                                        int       argNum,
                                        Object... args)
-        throws FusionException, ArgumentException
+        throws FusionException
     {
         String expectation = "non-null string or symbol";
         String result = checkTextArg(eval, who, expectation, argNum, args);
         if (result == null)
         {
-            throw who.argFailure(expectation, argNum, args);
+            throw who.argError(eval, expectation, argNum, args);
         }
         return result;
     }
@@ -149,13 +149,13 @@ final class FusionText
                                        Procedure who,
                                        int       argNum,
                                        Object... args)
-        throws FusionException, ArgumentException
+        throws FusionException
     {
         String expectation = "non-empty string or symbol";
         String result = checkTextArg(eval, who, expectation, argNum, args);
         if (result == null || result.isEmpty())
         {
-            throw who.argFailure(expectation, argNum, args);
+            throw who.argError(eval, expectation, argNum, args);
         }
         return result;
     }

--- a/runtime/src/main/java/dev/ionfusion/fusion/JavaInstanceOfProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/JavaInstanceOfProc.java
@@ -12,7 +12,7 @@ final class JavaInstanceOfProc
     Object doApply(Evaluator eval, Object arg0, Object arg1)
         throws FusionException
     {
-        Class<?> klass = checkArg(Class.class, "arg", 0, arg0);
+        Class<?> klass = checkArg(eval, Class.class, "arg", 0, arg0);
 
         return makeBool(eval, klass.isInstance(arg1));
     }

--- a/runtime/src/main/java/dev/ionfusion/fusion/Procedure.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Procedure.java
@@ -210,8 +210,8 @@ abstract class Procedure
 
 
     /**
-     * Creates, but does not throw, an exception that indicates a contract
-     * failure with a given argument.
+     * Creates, but does not throw, a Fusion {@code argument_error} indicating
+     * a contract failure with a given argument.
      *
      * @param expectation describes the expectation that was not met.  When
      * displayed, this string is prefixed by "procedure <i>p</i> expects",
@@ -223,17 +223,18 @@ abstract class Procedure
      *
      * @return a new exception.
      */
-    final ArgumentException argFailure(String expectation,
-                                       int badPos,
-                                       Object... actuals)
+    final FusionException argError(Evaluator eval,
+                                   String expectation,
+                                   int badPos,
+                                   Object... actuals)
     {
-        return new ArgumentException(this, expectation, badPos, actuals);
+        return new ArgumentException(identify(), expectation, badPos, actuals);
     }
 
 
-    final <T> T checkArg(Class<T> klass, String desc, int argNum,
+    final <T> T checkArg(Evaluator eval, Class<T> klass, String desc, int argNum,
                          Object... args)
-        throws ArgumentException
+        throws FusionException
     {
         try
         {
@@ -241,7 +242,7 @@ abstract class Procedure
         }
         catch (ClassCastException e)
         {
-            throw new ArgumentException(this, desc, argNum, args);
+            throw argError(eval, desc, argNum, args);
         }
     }
 
@@ -357,8 +358,8 @@ abstract class Procedure
 
 
     @Deprecated
-    final SyntaxValue checkSyntaxArg(int argNum, Object... args)
-        throws ArgumentException
+    final SyntaxValue checkSyntaxArg(Evaluator eval, int argNum, Object... args)
+        throws FusionException
     {
         try
         {
@@ -366,16 +367,17 @@ abstract class Procedure
         }
         catch (ClassCastException e)
         {
-            throw new ArgumentException(this, "Syntax value", argNum, args);
+            throw argError(eval, "Syntax value", argNum, args);
         }
     }
 
-    private <T extends SyntaxValue> T checkSyntaxArg(Class<T> klass,
+    private <T extends SyntaxValue> T checkSyntaxArg(Evaluator eval,
+                                                     Class<T> klass,
                                                      String typeName,
                                                      boolean nullable,
                                                      int argNum,
                                                      Object... args)
-        throws ArgumentException
+        throws FusionException
     {
         Object arg = args[argNum];
 
@@ -389,33 +391,35 @@ abstract class Procedure
         }
         catch (ClassCastException e) {}
 
-        throw new ArgumentException(this, typeName, argNum, args);
+        throw argError(eval, typeName, argNum, args);
     }
 
 
     @Deprecated
-    final SyntaxContainer checkSyntaxContainerArg(int argNum, Object... args)
-        throws ArgumentException
+    final SyntaxContainer checkSyntaxContainerArg(Evaluator eval, int argNum, Object... args)
+        throws FusionException
     {
-        return checkSyntaxArg(SyntaxContainer.class,
+        return checkSyntaxArg(eval,
+                              SyntaxContainer.class,
                               "syntax_list, sexp, or struct",
                               true /* nullable */, argNum, args);
     }
 
 
     @Deprecated
-    final SyntaxSequence checkSyntaxSequenceArg(int argNum, Object... args)
-        throws ArgumentException
+    final SyntaxSequence checkSyntaxSequenceArg(Evaluator eval, int argNum, Object... args)
+        throws FusionException
     {
-        return checkSyntaxArg(SyntaxSequence.class,
+        return checkSyntaxArg(eval,
+                              SyntaxSequence.class,
                               "syntax_list or syntax_sexp",
                               true /* nullable */, argNum, args);
     }
 
 
     /** Ensures that an argument is a {@link Procedure}. */
-    final Procedure checkProcArg(int argNum, Object... args)
-        throws ArgumentException
+    final Procedure checkProcArg(Evaluator eval, int argNum, Object... args)
+        throws FusionException
     {
         try
         {
@@ -423,7 +427,7 @@ abstract class Procedure
         }
         catch (ClassCastException e)
         {
-            throw new ArgumentException(this, "procedure", argNum, args);
+            throw argError(eval, "procedure", argNum, args);
         }
     }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/Records.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Records.java
@@ -257,7 +257,7 @@ final class Records
 
             // TODO Allow non-proc here, but the record always throws arity error.
             // That requires changing ArityFailure to not require an explicit arity.
-            throw argFailure("procedure", myProcIndex, args);
+            throw argError(eval, "procedure", myProcIndex, args);
         }
     }
 
@@ -300,26 +300,26 @@ final class Records
         {
             if (! myType.hasInstance(v))
             {
-                throw new ArgumentException(this, "instance of " + myType.myName,
+                throw argError(eval, "instance of " + myType.myName,
                                             0, v, index);
             }
 
             int i = checkIntArgToJavaInt(eval, this, 1, v, index);
             if (i < 0)
             {
-                throw new ArgumentException(this, "non-negative int",
+                throw argError(eval, "non-negative int",
                                             1, v, index);
             }
 
             int max = myType.myFieldCount - 1;
             if (max < 0)
             {
-                throw new ArgumentException(this, "no access to fields",
+                throw argError(eval, "no access to fields",
                                             -1, v, index);
             }
             if (max < i)
             {
-                throw new ArgumentException(this, "index up to " + max,
+                throw argError(eval, "index up to " + max,
                                             1, v, index);
             }
 
@@ -349,7 +349,7 @@ final class Records
             String name = checkRequiredSymbolArg(eval, this, 0, args);
             if (name.isEmpty())
             {
-                throw new ArgumentException(this, "non-empty symbol", 0, args);
+                throw argError(eval, "non-empty symbol", 0, args);
             }
 
             RecordType supertype = null;
@@ -360,13 +360,13 @@ final class Records
             else if (! isNullNull(eval, args[1]))
             {
                 String expected = "record type descriptor or null";
-                throw new ArgumentException(this, expected, 1, args);
+                throw argError(eval, expected, 1, args);
             }
 
             final int initFieldCount = checkIntArgToJavaInt(eval, this, 2, args);
             if (initFieldCount < 0)
             {
-                throw new ArgumentException(this, "non-negative int", 1, args);
+                throw argError(eval, "non-negative int", 1, args);
             }
 
             int argCount = args.length;
@@ -384,11 +384,11 @@ final class Records
 
                         if (procIndex < 0)
                         {
-                            throw argFailure("non-negative int", 3, args);
+                            throw argError(eval, "non-negative int", 3, args);
                         }
                         if (procIndex >= initFieldCount)
                         {
-                            throw argFailure("int less than field count", 3, args);
+                            throw argError(eval, "int less than field count", 3, args);
                         }
                         if (supertype != null)
                         {

--- a/runtime/src/main/java/dev/ionfusion/fusion/StringToIntProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/StringToIntProc.java
@@ -5,6 +5,7 @@ package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionNumber.makeInt;
 import static dev.ionfusion.fusion.FusionString.checkNullableStringArg;
+
 import java.math.BigInteger;
 
 final class StringToIntProc
@@ -18,14 +19,14 @@ final class StringToIntProc
 
         String val = checkNullableStringArg(eval, this, 0, args);
 
-        BigInteger bigInt = (val != null ? parse(val, args) : null);
+        BigInteger bigInt = (val != null ? parse(eval, val, args) : null);
 
         return makeInt(eval, bigInt);
     }
 
 
-    BigInteger parse(String text, Object[] args)
-        throws ArgumentException
+    BigInteger parse(Evaluator eval, String text, Object[] args)
+        throws FusionException
     {
         try
         {
@@ -38,6 +39,6 @@ final class StringToIntProc
         }
         catch (NumberFormatException e) { }
 
-        throw argFailure("valid int content", 0, args);
+        throw argError(eval, "valid int content", 0, args);
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxAppendProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxAppendProc.java
@@ -12,14 +12,14 @@ final class SyntaxAppendProc
         throws FusionException
     {
         checkArityAtLeast(1, args);
-        SyntaxSequence seq = checkSyntaxSequenceArg(0, args);
+        SyntaxSequence seq = checkSyntaxSequenceArg(eval, 0, args);
         for (int i = 1; i < args.length; i++)
         {
-            SyntaxSequence next = checkSyntaxSequenceArg(i, args);
+            SyntaxSequence next = checkSyntaxSequenceArg(eval, i, args);
             seq = seq.makeAppended(eval, next);
             if (seq == null)
             {
-                throw new ArgumentException(this, "proper sequence", i-1, args);
+                throw argError(eval, "proper sequence", i-1, args);
             }
         }
         return seq;

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxColumnProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxColumnProc.java
@@ -13,7 +13,7 @@ class SyntaxColumnProc
     Object doApply(Evaluator eval, Object arg)
         throws FusionException
     {
-        SyntaxValue stx = checkSyntaxArg(0, arg);
+        SyntaxValue stx = checkSyntaxArg(eval, 0, arg);
         SourceLocation location = stx.getLocation();
         if (location != null)
         {

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxGetProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxGetProc.java
@@ -17,7 +17,7 @@ final class SyntaxGetProc
         throws FusionException
     {
         checkArityAtLeast(1, args);
-        SyntaxContainer stx = checkSyntaxContainerArg(0, args);
+        SyntaxContainer stx = checkSyntaxContainerArg(eval, 0, args);
         SyntaxValue value = stx;
 
         final int lastArg = args.length - 1;

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxLineProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxLineProc.java
@@ -13,7 +13,7 @@ class SyntaxLineProc
     Object doApply(Evaluator eval, Object arg)
         throws FusionException
     {
-        SyntaxValue stx = checkSyntaxArg(0, arg);
+        SyntaxValue stx = checkSyntaxArg(eval, 0, arg);
         SourceLocation location = stx.getLocation();
         if (location != null)
         {

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSizeProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSizeProc.java
@@ -12,7 +12,7 @@ final class SyntaxSizeProc
     Object doApply(Evaluator eval, Object arg)
         throws FusionException
     {
-        SyntaxSequence c = checkSyntaxSequenceArg(0, arg);
+        SyntaxSequence c = checkSyntaxSequenceArg(eval, 0, arg);
         return makeInt(eval, c.size());
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSourceProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSourceProc.java
@@ -14,7 +14,7 @@ class SyntaxSourceProc
     Object doApply(Evaluator eval, Object arg)
         throws FusionException
     {
-        SyntaxValue stx = checkSyntaxArg(0, arg);
+        SyntaxValue stx = checkSyntaxArg(eval, 0, arg);
         SourceLocation location = stx.getLocation();
         if (location != null)
         {

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSubseqProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSubseqProc.java
@@ -13,7 +13,7 @@ final class SyntaxSubseqProc
         throws FusionException
     {
         checkArityExact(2, args);
-        SyntaxSequence sequence = checkSyntaxSequenceArg(0, args);
+        SyntaxSequence sequence = checkSyntaxSequenceArg(eval, 0, args);
         int from = checkIntArgToJavaInt(eval, this, 1, args);
         int size = sequence.size();
 
@@ -22,7 +22,7 @@ final class SyntaxSubseqProc
         sequence = sequence.makeSubseq(eval, from);
         if (sequence == null)
         {
-            throw new ArgumentException(this, "proper sequence", 0, args);
+            throw argError(eval, "proper sequence", 0, args);
         }
         return sequence;
     }

--- a/runtime/src/main/java/dev/ionfusion/fusion/WrongSyntaxProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/WrongSyntaxProc.java
@@ -16,7 +16,7 @@ final class WrongSyntaxProc
         throws FusionException
     {
         checkArityAtLeast(1, args);
-        SyntaxValue stx = checkSyntaxArg(0, args);
+        SyntaxValue stx = checkSyntaxArg(eval, 0, args);
 
         String name = null; // TODO infer name
         String message = safeDisplayManyToString(eval, args, 1);

--- a/runtime/src/test/java/dev/ionfusion/fusion/ListTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/ListTest.java
@@ -6,13 +6,15 @@ package dev.ionfusion.fusion;
 import static dev.ionfusion.fusion.FusionList.checkActualListArg;
 import static dev.ionfusion.fusion.FusionList.unsafeListElement;
 import static dev.ionfusion.fusion.FusionList.unsafeListSize;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import dev.ionfusion.fusion.FusionList.UnsafeListSizeProc;
+
 import com.amazon.ion.IonList;
 import com.amazon.ion.IonValue;
+import dev.ionfusion.fusion.FusionList.UnsafeListSizeProc;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -341,6 +343,6 @@ public class ListTest
                                                   new UnsafeListSizeProc(),
                                                   0,
                                                   nullList));
-        assertTrue(e.getMessage().contains("non-null list"));
+        assertThat(e.getMessage(), containsString("non-null list"));
     }
 }


### PR DESCRIPTION
* Rename `argFailure` to `argError` to align with the Fusion name `argument_error`.
* When possible, use that method instead of constructor calls.
* Ensure that an `Evaluator` is always present, so we can support running Fusion code to compose the exception message.

## Notes

The last bullet is the critical point: today, the `getMessage()` method of `FusionException` subclasses renders the message lazily (when the stack trace is dumped), but there's no `Evaluator` around so `null` is passed around.  This has always been problematic and risky, and prevents any control of message display (including how values are displayed) from Fusion code.

To fix this, we'll eagerly construct the messages. I don't think this is best practice in general (could be wasted work) but I don't see a reasonable alternative.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
