### PR TITLE
Create new `runtime.embed` package.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/BaseValue.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/BaseValue.java
@@ -18,6 +18,7 @@ import com.amazon.ion.util.IonTextUtils;
 import dev.ionfusion.fusion.FusionBool.BaseBool;
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.embed.FusionRuntime;
 import java.io.IOException;
 
 /**

--- a/runtime/src/main/java/dev/ionfusion/fusion/FileSystemSpecialist.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FileSystemSpecialist.java
@@ -3,6 +3,7 @@
 
 package dev.ionfusion.fusion;
 
+import dev.ionfusion.runtime.embed.FusionRuntime;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionBlob.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionBlob.java
@@ -15,6 +15,7 @@ import com.amazon.ion.util.IonTextUtils;
 import dev.ionfusion.fusion.FusionBool.BaseBool;
 import dev.ionfusion.fusion.FusionLob.BaseLob;
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.IOException;
 import java.util.Arrays;
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionBool.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionBool.java
@@ -14,6 +14,7 @@ import com.amazon.ion.IonWriter;
 import com.amazon.ion.ValueFactory;
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.IOException;
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionClob.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionClob.java
@@ -15,6 +15,7 @@ import com.amazon.ion.util.IonTextUtils;
 import dev.ionfusion.fusion.FusionBool.BaseBool;
 import dev.ionfusion.fusion.FusionLob.BaseLob;
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.IOException;
 import java.util.Arrays;
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionEval.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionEval.java
@@ -13,6 +13,7 @@ import static dev.ionfusion.fusion.Syntax.datumToSyntax;
 import com.amazon.ion.IonReader;
 import dev.ionfusion.runtime.base.SourceLocation;
 import dev.ionfusion.runtime.base.SourceName;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.util.LinkedList;
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionIo.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionIo.java
@@ -11,11 +11,13 @@ import static dev.ionfusion.fusion.FusionString.checkRequiredStringArg;
 import static dev.ionfusion.fusion.FusionString.makeString;
 import static dev.ionfusion.fusion.FusionVoid.voidValue;
 import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.amazon.ion.IonException;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.system.IonTextWriterBuilder;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionLob.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionLob.java
@@ -11,6 +11,7 @@ import static dev.ionfusion.fusion.SimpleSyntaxValue.makeSyntax;
 
 import dev.ionfusion.fusion.FusionBool.BaseBool;
 import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionNull.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionNull.java
@@ -13,6 +13,7 @@ import com.amazon.ion.ValueFactory;
 import dev.ionfusion.fusion.FusionBool.BaseBool;
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.IOException;
 
 /**

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionNumber.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionNumber.java
@@ -24,6 +24,7 @@ import com.amazon.ion.util.IonTextUtils;
 import dev.ionfusion.fusion.FusionBool.BaseBool;
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionProcedure.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionProcedure.java
@@ -5,6 +5,8 @@ package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionBool.makeBool;
 
+import dev.ionfusion.runtime.embed.TopLevel;
+
 /**
  * Utilities for Fusion procedures.
  */

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionRuntimeBuilder.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionRuntimeBuilder.java
@@ -9,6 +9,8 @@ import static dev.ionfusion.runtime.base.ModuleIdentity.isValidAbsoluteModulePat
 
 import com.amazon.ion.IonCatalog;
 import com.amazon.ion.system.SimpleCatalog;
+import dev.ionfusion.runtime.embed.FusionRuntime;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.File;
 import java.io.OutputStream;
 import java.net.URL;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionString.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionString.java
@@ -34,6 +34,7 @@ import dev.ionfusion.fusion.FusionBool.BaseBool;
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.fusion.FusionText.BaseText;
 import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionSymbol.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionSymbol.java
@@ -18,6 +18,7 @@ import com.amazon.ion.util.IonTextUtils;
 import dev.ionfusion.fusion.FusionBool.BaseBool;
 import dev.ionfusion.fusion._private.InternMap;
 import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.IOException;
 import java.util.Arrays;
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionText.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionText.java
@@ -7,6 +7,7 @@ import static dev.ionfusion.fusion.FusionBool.falseBool;
 import static dev.ionfusion.fusion.FusionBool.trueBool;
 
 import dev.ionfusion.fusion.FusionBool.BaseBool;
+import dev.ionfusion.runtime.embed.TopLevel;
 
 
 /**

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionTimestamp.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionTimestamp.java
@@ -35,6 +35,7 @@ import dev.ionfusion.fusion.FusionBool.BaseBool;
 import dev.ionfusion.fusion.FusionNumber.BaseDecimal;
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.IOException;
 import java.math.BigDecimal;
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionValue.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionValue.java
@@ -9,6 +9,8 @@ import static dev.ionfusion.fusion._private.FusionUtils.EMPTY_STRING_ARRAY;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.ValueFactory;
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
+import dev.ionfusion.runtime.embed.FusionRuntime;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.IOException;
 
 /**

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionVoid.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionVoid.java
@@ -7,6 +7,7 @@ import static dev.ionfusion.fusion.FusionBool.falseBool;
 import static dev.ionfusion.fusion.FusionBool.makeBool;
 
 import dev.ionfusion.fusion.FusionBool.BaseBool;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.IOException;
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/ModuleBuilderImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ModuleBuilderImpl.java
@@ -9,6 +9,7 @@ import com.amazon.ion.IonValue;
 import dev.ionfusion.fusion.Namespace.NsDefinedBinding;
 import dev.ionfusion.fusion._private.doc.model.BindingDoc.Kind;
 import dev.ionfusion.runtime.base.ModuleIdentity;
+import dev.ionfusion.runtime.embed.ModuleBuilder;
 import java.util.Collection;
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/StandardRuntime.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/StandardRuntime.java
@@ -14,6 +14,10 @@ import com.amazon.ion.IonValue;
 import com.amazon.ion.ValueFactory;
 import com.amazon.ion.system.IonSystemBuilder;
 import dev.ionfusion.runtime.base.ModuleIdentity;
+import dev.ionfusion.runtime.embed.FusionRuntime;
+import dev.ionfusion.runtime.embed.ModuleBuilder;
+import dev.ionfusion.runtime.embed.SandboxBuilder;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.OutputStream;
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/StandardTopLevel.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/StandardTopLevel.java
@@ -13,6 +13,7 @@ import static dev.ionfusion.runtime.base.ModuleIdentity.isValidAbsoluteModulePat
 import com.amazon.ion.IonReader;
 import dev.ionfusion.runtime.base.ModuleIdentity;
 import dev.ionfusion.runtime.base.SourceName;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.File;
 import java.io.IOException;
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/_Private_CoverageCollectorImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/_Private_CoverageCollectorImpl.java
@@ -4,6 +4,7 @@
 package dev.ionfusion.fusion;
 
 import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.embed.FusionRuntime;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.ReferenceQueue;

--- a/runtime/src/main/java/dev/ionfusion/fusion/_Private_Trampoline.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/_Private_Trampoline.java
@@ -5,6 +5,7 @@ package dev.ionfusion.fusion;
 
 import dev.ionfusion.fusion._private.doc.model.ModuleDocs;
 import dev.ionfusion.runtime.base.ModuleIdentity;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 import java.util.function.Predicate;

--- a/runtime/src/main/java/dev/ionfusion/fusion/_private/doc/tool/RepoEntity.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/_private/doc/tool/RepoEntity.java
@@ -8,9 +8,9 @@ import static dev.ionfusion.fusion._Private_Trampoline.instantiateModuleDocs;
 import static dev.ionfusion.fusion._Private_Trampoline.loadModule;
 
 import dev.ionfusion.fusion.FusionException;
-import dev.ionfusion.fusion.TopLevel;
 import dev.ionfusion.fusion._private.doc.model.ModuleDocs;
 import dev.ionfusion.runtime.base.ModuleIdentity;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/runtime/src/main/java/dev/ionfusion/fusion/_private/doc/tool/SiteBuilder.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/_private/doc/tool/SiteBuilder.java
@@ -6,7 +6,6 @@ package dev.ionfusion.fusion._private.doc.tool;
 import static java.nio.file.Files.isDirectory;
 
 import dev.ionfusion.fusion.FusionException;
-import dev.ionfusion.fusion.TopLevel;
 import dev.ionfusion.fusion._private.StreamWriter;
 import dev.ionfusion.fusion._private.doc.model.MarkdownArticle;
 import dev.ionfusion.fusion._private.doc.site.FileCopyTemplate;
@@ -15,6 +14,7 @@ import dev.ionfusion.fusion._private.doc.site.Template;
 import dev.ionfusion.fusion._private.doc.tool.layout.StreamingTemplate;
 import dev.ionfusion.fusion._private.doc.tool.mustache.MustacheTemplate;
 import dev.ionfusion.runtime.base.ModuleIdentity;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Predicate;

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/Document.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/Document.java
@@ -6,9 +6,9 @@ package dev.ionfusion.fusion.cli;
 import static java.nio.file.Files.isDirectory;
 
 import com.amazon.ion.Timestamp;
-import dev.ionfusion.fusion.FusionRuntime;
 import dev.ionfusion.fusion._private.doc.tool.SiteBuilder;
 import dev.ionfusion.runtime.base.ModuleIdentity;
+import dev.ionfusion.runtime.embed.FusionRuntime;
 import java.io.File;
 import java.io.PrintWriter;
 import java.nio.file.Path;

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/Eval.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/Eval.java
@@ -3,7 +3,7 @@
 
 package dev.ionfusion.fusion.cli;
 
-import dev.ionfusion.fusion.TopLevel;
+import dev.ionfusion.runtime.embed.TopLevel;
 
 
 class Eval

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/FusionExecutor.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/FusionExecutor.java
@@ -8,8 +8,8 @@ import static dev.ionfusion.fusion.FusionVoid.isVoid;
 
 import dev.ionfusion.fusion.ExitException;
 import dev.ionfusion.fusion.FusionException;
-import dev.ionfusion.fusion.FusionRuntime;
-import dev.ionfusion.fusion.TopLevel;
+import dev.ionfusion.runtime.embed.FusionRuntime;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.PrintWriter;
 
 /**

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/GlobalOptions.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/GlobalOptions.java
@@ -3,11 +3,11 @@
 
 package dev.ionfusion.fusion.cli;
 
+import com.amazon.ion.IonException;
 import dev.ionfusion.fusion.FusionException;
-import dev.ionfusion.fusion.FusionRuntime;
 import dev.ionfusion.fusion.FusionRuntimeBuilder;
 import dev.ionfusion.fusion._Private_Trampoline;
-import com.amazon.ion.IonException;
+import dev.ionfusion.runtime.embed.FusionRuntime;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/Load.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/Load.java
@@ -3,7 +3,7 @@
 
 package dev.ionfusion.fusion.cli;
 
-import dev.ionfusion.fusion.TopLevel;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.File;
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/Repl.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/Repl.java
@@ -4,10 +4,11 @@
 package dev.ionfusion.fusion.cli;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.amazon.ion.IonException;
 import dev.ionfusion.fusion.ExitException;
 import dev.ionfusion.fusion.FusionException;
-import dev.ionfusion.fusion.TopLevel;
-import com.amazon.ion.IonException;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.BufferedReader;
 import java.io.Console;
 import java.io.IOException;

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/Require.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/Require.java
@@ -3,7 +3,7 @@
 
 package dev.ionfusion.fusion.cli;
 
-import dev.ionfusion.fusion.TopLevel;
+import dev.ionfusion.runtime.embed.TopLevel;
 
 
 class Require

--- a/runtime/src/main/java/dev/ionfusion/runtime/embed/FusionRuntime.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/embed/FusionRuntime.java
@@ -1,11 +1,13 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion;
+package dev.ionfusion.runtime.embed;
 
 import com.amazon.ion.IonCatalog;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.ValueFactory;
+import dev.ionfusion.fusion.FusionException;
+import dev.ionfusion.fusion.FusionRuntimeBuilder;
 
 /**
  * Primary entry point for embedding Fusion within a Java program.

--- a/runtime/src/main/java/dev/ionfusion/runtime/embed/ModuleBuilder.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/embed/ModuleBuilder.java
@@ -1,7 +1,9 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion;
+package dev.ionfusion.runtime.embed;
+
+import dev.ionfusion.fusion.FusionException;
 
 /**
  * Constructs "built-in" modules via Java code.

--- a/runtime/src/main/java/dev/ionfusion/runtime/embed/SandboxBuilder.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/embed/SandboxBuilder.java
@@ -1,7 +1,10 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion;
+package dev.ionfusion.runtime.embed;
+
+import dev.ionfusion.fusion.FusionException;
+import dev.ionfusion.fusion.FusionRuntimeBuilder;
 
 /**
  * Constructs {@link TopLevel} namespaces for evaluating code with limited

--- a/runtime/src/main/java/dev/ionfusion/runtime/embed/TopLevel.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/embed/TopLevel.java
@@ -1,9 +1,12 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion;
+package dev.ionfusion.runtime.embed;
 
 import com.amazon.ion.IonReader;
+import dev.ionfusion.fusion.ExitException;
+import dev.ionfusion.fusion.FusionException;
+import dev.ionfusion.fusion.FusionInterruptedException;
 import dev.ionfusion.runtime.base.SourceName;
 import java.io.File;
 

--- a/runtime/src/main/java/overview.html
+++ b/runtime/src/main/java/overview.html
@@ -31,13 +31,13 @@ extensions will probably break when that happens.
 
 The primary purpose of these APIs is to enable embedding the Fusion
 evaluator into Java applications. The central component for doing so is the
-{@link dev.ionfusion.fusion.FusionRuntime}. The runtime is a heavyweight object,
+{@link dev.ionfusion.runtime.embed.FusionRuntime}. The runtime is a heavyweight object,
 and the vast majority of applications should create exactly one runtime at
 launch or on demand. To acquire a runtime, you'll use a
 {@link dev.ionfusion.fusion.FusionRuntimeBuilder}.
 
 From the runtime, you can then acquire one or more
-{@link dev.ionfusion.fusion.TopLevel}s. Each {@code TopLevel} instace contains
+{@link dev.ionfusion.runtime.embed.TopLevel}s. Each {@code TopLevel} instace contains
 its own namespace in which bindings (that is, variables) can be {@code define}d
 and code can be evaluated.
 
@@ -78,9 +78,9 @@ Unless documented otherwise, these Java APIs do not provide thread-safety
 guarantees, nor does the Fusion language itself. If you need to evaluate
 Fusion code from multiple threads, you will need to provide your own
 synchronization. In most cases this will involve preventing threads from
-simultaneous use of the same {@link dev.ionfusion.fusion.TopLevel}.
+simultaneous use of the same {@link dev.ionfusion.runtime.embed.TopLevel}.
 <p>
-All evaluation APIs such as {@link dev.ionfusion.fusion.TopLevel#eval(String)}
+All evaluation APIs such as {@link dev.ionfusion.runtime.embed.TopLevel#eval(String)}
 can be cancelled by calling {@link java.lang.Thread#interrupt()} on the
 evaluation thread. The evaluator periodically checks the thread interrupt
 status, and cancels the computation when it is set. The evaluation API then
@@ -162,7 +162,7 @@ This applies to all data referenced by the injected object.
 <p>
 Injection is idempotent: injecting a Fusion value results in the same value.
 Unless otherwise specified, APIs that will inject Java objects (for example,
-{@link dev.ionfusion.fusion.TopLevel#call TopLevel.call()}) will also
+{@link dev.ionfusion.runtime.embed.TopLevel#call TopLevel.call()}) will also
 accept Fusion values that were previously injected or that were returned as
 a result of evaluating Fusion code.  However, injection involves a potentially
 expensive "type switch" and you'll get better performance by avoiding no-op

--- a/runtime/src/test/java/ScriptedTests.java
+++ b/runtime/src/test/java/ScriptedTests.java
@@ -5,7 +5,7 @@ import static dev.ionfusion.fusion.TestSetup.makeRuntimeBuilder;
 import static dev.ionfusion.fusion.TestSetup.testRepositoryDirectory;
 import static dev.ionfusion.fusion.TestSetup.testScriptDirectory;
 
-import dev.ionfusion.fusion.FusionRuntime;
+import dev.ionfusion.runtime.embed.FusionRuntime;
 import dev.ionfusion.testing.TreeWalker;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;

--- a/runtime/src/test/java/dev/ionfusion/fusion/BlobTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/BlobTest.java
@@ -7,6 +7,8 @@ import static dev.ionfusion.fusion.FusionBlob.isBlob;
 import static dev.ionfusion.fusion.FusionLob.isLob;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import dev.ionfusion.runtime.embed.TopLevel;
+
 /**
  *
  */

--- a/runtime/src/test/java/dev/ionfusion/fusion/ClobTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/ClobTest.java
@@ -7,6 +7,8 @@ import static dev.ionfusion.fusion.FusionClob.isClob;
 import static dev.ionfusion.fusion.FusionLob.isLob;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import dev.ionfusion.runtime.embed.TopLevel;
+
 /**
  *
  */

--- a/runtime/src/test/java/dev/ionfusion/fusion/CoreTestCase.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/CoreTestCase.java
@@ -27,6 +27,8 @@ import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonText;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.system.IonSystemBuilder;
+import dev.ionfusion.runtime.embed.FusionRuntime;
+import dev.ionfusion.runtime.embed.TopLevel;
 import dev.ionfusion.testing.StdioTestCase;
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/runtime/src/test/java/dev/ionfusion/fusion/CoverageTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/CoverageTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import dev.ionfusion.runtime.base.SourceLocation;
 import dev.ionfusion.runtime.base.SourceName;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.Test;

--- a/runtime/src/test/java/dev/ionfusion/fusion/FusionIoTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/FusionIoTest.java
@@ -16,6 +16,7 @@ import com.amazon.ion.IonList;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.IonWriter;
+import dev.ionfusion.runtime.embed.TopLevel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/runtime/src/test/java/dev/ionfusion/fusion/FusionRuntimeBuilderTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/FusionRuntimeBuilderTest.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.amazon.ion.IonCatalog;
 import com.amazon.ion.system.SimpleCatalog;
+import dev.ionfusion.runtime.embed.FusionRuntime;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;

--- a/runtime/src/test/java/dev/ionfusion/fusion/FusionValueTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/FusionValueTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.amazon.ion.IonInt;
 import com.amazon.ion.IonValue;
+import dev.ionfusion.runtime.embed.TopLevel;
 import org.junit.jupiter.api.Test;
 
 public class FusionValueTest

--- a/runtime/src/test/java/dev/ionfusion/fusion/InjectionTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/InjectionTest.java
@@ -27,6 +27,7 @@ import com.amazon.ion.IonSymbol;
 import com.amazon.ion.IonTimestamp;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.Timestamp;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import org.junit.jupiter.api.Test;

--- a/runtime/src/test/java/dev/ionfusion/fusion/InterruptionTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/InterruptionTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.amazon.ion.IonReader;
+import dev.ionfusion.runtime.embed.ModuleBuilder;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;

--- a/runtime/src/test/java/dev/ionfusion/fusion/IteratorTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/IteratorTest.java
@@ -6,6 +6,7 @@ package dev.ionfusion.fusion;
 import static dev.ionfusion.fusion.FusionIterator.injectIonIterator;
 import static dev.ionfusion.fusion.FusionIterator.injectIterator;
 import com.amazon.ion.IonList;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 

--- a/runtime/src/test/java/dev/ionfusion/fusion/ListTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/ListTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.amazon.ion.IonList;
 import com.amazon.ion.IonValue;
 import dev.ionfusion.fusion.FusionList.UnsafeListSizeProc;
+import dev.ionfusion.runtime.embed.TopLevel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/runtime/src/test/java/dev/ionfusion/fusion/LobTestCase.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/LobTestCase.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import dev.ionfusion.runtime.embed.TopLevel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/runtime/src/test/java/dev/ionfusion/fusion/ModuleTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/ModuleTest.java
@@ -5,6 +5,8 @@ package dev.ionfusion.fusion;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.ionfusion.runtime.embed.TopLevel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/runtime/src/test/java/dev/ionfusion/fusion/RuntimeTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/RuntimeTest.java
@@ -25,6 +25,7 @@ import com.amazon.ion.system.IonBinaryWriterBuilder;
 import com.amazon.ion.system.SimpleCatalog;
 import dev.ionfusion.runtime.base.ModuleIdentity;
 import dev.ionfusion.runtime.base.SourceName;
+import dev.ionfusion.runtime.embed.ModuleBuilder;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;

--- a/runtime/src/test/java/dev/ionfusion/fusion/SandboxTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/SandboxTest.java
@@ -12,6 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import dev.ionfusion.runtime.embed.SandboxBuilder;
+import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.File;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;

--- a/runtime/src/test/java/dev/ionfusion/fusion/TopLevelTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/TopLevelTest.java
@@ -5,6 +5,8 @@ package dev.ionfusion.fusion;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.ionfusion.runtime.embed.TopLevel;
 import org.junit.jupiter.api.Test;
 
 /**


### PR DESCRIPTION
Move `FusionRuntime`, `ModuleBuilder`, `SandboxBuilder`, and `TopLevel` into it.

Note that `FusionRuntimeBuilder` currently has a lot of implementation dependencies, so it cannot move anywhere yet.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
