### PR TITLE
Avoid `FusionException` for builder configuration problems.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/CoverageConfiguration.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/CoverageConfiguration.java
@@ -80,12 +80,12 @@ final class CoverageConfiguration
      * @return a set of absolute module paths, or null if the {@code propertyName}
      * doesn't have an entry in the {@code props}.
      *
-     * @throws FusionException if an entry is not an absolute module path.
+     * @throws IOException if an entry is not an absolute module path.
      */
     private static Set<String> readModuleSet(File       configFile,
                                              Properties props,
                                              String     propertyName)
-        throws FusionException
+        throws IOException
     {
         String mods = props.getProperty(propertyName);
         if (mods == null) return null;
@@ -106,7 +106,7 @@ final class CoverageConfiguration
                     "Configuration error in " + configFile
                     + ": " + propertyName
                     + " contains an invalid absolute module path: " + mod;
-                throw new FusionException(message);
+                throw new IOException(message);
             }
         }
 
@@ -115,7 +115,7 @@ final class CoverageConfiguration
 
 
     CoverageConfiguration(File dataDir)
-        throws FusionException, IOException
+        throws IOException
     {
         File myConfigFile = new File(dataDir, CONFIG_FILE_NAME);
         if (myConfigFile.exists())
@@ -143,7 +143,7 @@ final class CoverageConfiguration
                             "Configuration error in " + myConfigFile
                             + ": " + PROPERTY_INCLUDED_SOURCES
                             + " contains an invalid directory: " + source;
-                        throw new FusionException(message);
+                        throw new IOException(message);
                     }
                 }
             }
@@ -251,7 +251,7 @@ final class CoverageConfiguration
          * @throws FusionException if an entry is not an absolute module path.
          */
         public SimpleModuleIdentitySelector(File configFile, Properties props)
-            throws FusionException
+            throws IOException
         {
             myIncludedModules =
                 readModuleSet(configFile, props, PROPERTY_INCLUDED_MODULES);

--- a/runtime/src/main/java/dev/ionfusion/fusion/CoverageDatabase.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/CoverageDatabase.java
@@ -566,5 +566,10 @@ class CoverageDatabase
                 }
             }
         }
+        catch (IOException e)
+        {
+            String msg = "Error reading coverage data at " + myStorageFile;
+            throw new IOException(msg, e);
+        }
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/_Private_CoverageCollector.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/_Private_CoverageCollector.java
@@ -4,6 +4,7 @@
 package dev.ionfusion.fusion;
 
 import dev.ionfusion.runtime.base.SourceLocation;
+import java.io.IOException;
 
 /**
  * EXPERIMENTAL extension point for collecting code-coverage statistics.
@@ -55,5 +56,5 @@ public interface _Private_CoverageCollector
     //      Perhaps close() would be better?  save()?
     // This appears to be unused.
     void flushMetrics()
-        throws FusionException;
+        throws IOException;
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/_Private_CoverageCollectorImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/_Private_CoverageCollectorImpl.java
@@ -56,7 +56,7 @@ public final class _Private_CoverageCollectorImpl
 
 
     private _Private_CoverageCollectorImpl(File dataDir)
-        throws FusionException, IOException
+        throws IOException
     {
         myConfig   = new CoverageConfiguration(dataDir);
         myDatabase = new CoverageDatabase(dataDir.toPath());
@@ -199,7 +199,6 @@ public final class _Private_CoverageCollectorImpl
      * Called before each access to the {@link #ourCollectorCache}.
      */
     private static synchronized void initCache()
-        throws FusionException
     {
         if (ourCollectorCache == null)
         {
@@ -218,18 +217,11 @@ public final class _Private_CoverageCollectorImpl
                 }
             };
 
-            try
-            {
-                Runtime.getRuntime().addShutdownHook(ourShutdownHook);
-            }
-            catch (IllegalStateException e)
-            {
-                throw new FusionException("The JMV is shutting down.");
-            }
+            Runtime.getRuntime().addShutdownHook(ourShutdownHook);
         }
         else if (ourShutdownHasStarted)
         {
-            throw new FusionException("The JMV is shutting down.");
+            throw new IllegalStateException("The JVM is shutting down.");
         }
     }
 
@@ -266,7 +258,7 @@ public final class _Private_CoverageCollectorImpl
             }
             catch (IllegalStateException e)
             {
-                // The JMV is shutting down. Nothing to do.
+                // The JVM is shutting down. Nothing to do.
             }
 
             Flusher.stop();
@@ -314,20 +306,13 @@ public final class _Private_CoverageCollectorImpl
 
     public static synchronized
     _Private_CoverageCollectorImpl fromDirectory(File dataDir)
-        throws FusionException
+        throws IOException
     {
         initCache();
 
         // Canonicalize the dataDir, so different paths to the same directory
         // don't lead to collectors overwriting each other's database.
-        try
-        {
-            dataDir = dataDir.getCanonicalFile();
-        }
-        catch (IOException e)
-        {
-            throw new FusionException("Error getting canonical path", e);
-        }
+        dataDir = dataDir.getCanonicalFile();
 
         _Private_CoverageCollectorImpl collector;
 
@@ -348,7 +333,7 @@ public final class _Private_CoverageCollectorImpl
             }
             catch (IOException e)
             {
-                throw new FusionException("Error writing coverage data", e);
+                throw new IOException("Error writing coverage data", e);
             }
             // ref is now useless. Fall through and create a new one.
         }
@@ -359,7 +344,7 @@ public final class _Private_CoverageCollectorImpl
         }
         catch (IOException e)
         {
-            throw new FusionException("Error reading coverage data", e);
+            throw new IOException("Error reading coverage data", e);
         }
 
         addToCache(dataDir, new CollectorRef(collector));
@@ -368,7 +353,7 @@ public final class _Private_CoverageCollectorImpl
     }
 
     public static _Private_CoverageCollectorImpl fromDirectory(String dataDir)
-        throws FusionException
+        throws IOException
     {
         return fromDirectory(new File(dataDir));
     }
@@ -408,7 +393,7 @@ public final class _Private_CoverageCollectorImpl
 
     @Override
     public void flushMetrics()
-        throws FusionException
+        throws IOException
     {
         try
         {
@@ -416,7 +401,7 @@ public final class _Private_CoverageCollectorImpl
         }
         catch (IOException e)
         {
-            throw new FusionException("Error writing coverage data", e);
+            throw new IOException("Error writing Fusion coverage data", e);
         }
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/_private/FusionUtils.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/_private/FusionUtils.java
@@ -3,10 +3,8 @@
 
 package dev.ionfusion.fusion._private;
 
-import static dev.ionfusion.fusion._Private_Trampoline.newFusionException;
 import static java.nio.file.Files.newInputStream;
 
-import dev.ionfusion.fusion.FusionException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -115,10 +113,10 @@ public final class FusionUtils
     /**
      * Reads properties from a URL.
      *
-     * @throws FusionException if there's a problem reading the resource.
+     * @throws IOException if there's a problem reading the resource.
      */
     public static Properties readProperties(URL resource)
-        throws FusionException
+        throws IOException
     {
         try (InputStream stream = resource.openStream())
         {
@@ -130,7 +128,7 @@ public final class FusionUtils
         {
             String message =
                 "Error reading properties from resource " + resource;
-            throw newFusionException(message, e);
+            throw new IOException(message, e);
         }
     }
 
@@ -140,10 +138,10 @@ public final class FusionUtils
      *
      * @param file must be a readable properties file.
      *
-     * @throws FusionException if there's a problem reading the file.
+     * @throws IOException if there's a problem reading the file.
      */
     public static Properties readProperties(File file)
-        throws FusionException
+        throws IOException
     {
         try (InputStream stream = newInputStream(file.toPath()))
         {
@@ -153,9 +151,8 @@ public final class FusionUtils
         }
         catch (IOException e)
         {
-            String message =
-                "Error reading properties from file " + file;
-            throw newFusionException(message, e);
+            String message = "Error reading properties from file " + file;
+            throw new IOException(message, e);
         }
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/FusionExecutor.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/FusionExecutor.java
@@ -10,6 +10,7 @@ import dev.ionfusion.fusion.ExitException;
 import dev.ionfusion.fusion.FusionException;
 import dev.ionfusion.runtime.embed.FusionRuntime;
 import dev.ionfusion.runtime.embed.TopLevel;
+import java.io.IOException;
 import java.io.PrintWriter;
 
 /**
@@ -31,7 +32,7 @@ abstract class FusionExecutor
 
 
     FusionRuntime runtime()
-        throws FusionException, UsageException
+        throws IOException, FusionException, UsageException
     {
         return myGlobalOptions.runtime();
     }

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/GlobalOptions.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/GlobalOptions.java
@@ -192,7 +192,7 @@ final class GlobalOptions
     }
 
     FusionRuntime runtime()
-        throws FusionException, UsageException
+        throws IOException, FusionException, UsageException
     {
         // Lazily loading a runtime that can be global across commands.
         if (myRuntime == null)

--- a/runtime/src/test/java/dev/ionfusion/fusion/CoreTestCase.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/CoreTestCase.java
@@ -30,6 +30,7 @@ import com.amazon.ion.system.IonSystemBuilder;
 import dev.ionfusion.runtime.embed.FusionRuntime;
 import dev.ionfusion.runtime.embed.TopLevel;
 import dev.ionfusion.testing.StdioTestCase;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.file.Path;
@@ -107,7 +108,14 @@ public class CoreTestCase
     {
         if (myRuntime == null)
         {
-            myRuntime = runtimeBuilder().build();
+            try
+            {
+                myRuntime = runtimeBuilder().build();
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException(e);
+            }
         }
         return myRuntime;
     }

--- a/runtime/src/test/java/dev/ionfusion/fusion/FusionRuntimeBuilderTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/FusionRuntimeBuilderTest.java
@@ -45,7 +45,7 @@ public class FusionRuntimeBuilderTest
 
 
     private FusionRuntime build(FusionRuntimeBuilder b)
-        throws FusionException
+        throws Exception
     {
         b = b.withBootstrapRepository(fusionBootstrapDirectory().toFile());
         return b.build();
@@ -252,7 +252,7 @@ public class FusionRuntimeBuilderTest
 
     @Test
     public void testBuildingDefaultIonCatalog()
-        throws FusionException
+        throws Exception
     {
         FusionRuntimeBuilder b = standard();
         FusionRuntime r = build(b);
@@ -286,7 +286,7 @@ public class FusionRuntimeBuilderTest
 
     private void checkCurrentOutputPort(OutputStream expected,
                                         FusionRuntimeBuilder b)
-        throws FusionException
+        throws Exception
     {
         TopLevel t = build(b).makeTopLevel(GlobalState.KERNEL_MODULE_NAME);
         Object actual = t.eval("(current_output_port)");
@@ -334,7 +334,7 @@ public class FusionRuntimeBuilderTest
 
 
     private void checkCurrentDirectory(String expectedDir, FusionRuntimeBuilder b)
-        throws FusionException
+        throws Exception
     {
         TopLevel t = build(b).getDefaultTopLevel();
         t.requireModule("/fusion/io");
@@ -460,7 +460,7 @@ public class FusionRuntimeBuilderTest
     }
 
     private _Private_CoverageCollector makeCollector(Path dir)
-        throws FusionException
+        throws Exception
     {
         FusionRuntime r =
             runtimeBuilder().copy()

--- a/runtime/src/test/java/dev/ionfusion/fusion/TestSetup.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/TestSetup.java
@@ -1,7 +1,10 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion;import java.nio.file.Path;
+package dev.ionfusion.fusion;
+
+import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class TestSetup
@@ -77,7 +80,14 @@ public class TestSetup
         // This has no effect in an IDE, since this file is not on its copy of
         // the test classpath.  In scripted builds, this provides the coverage
         // configuration. Historically, it also provided the bootstrap repo.
-        b = b.withConfigProperties(TestSetup.class, "/fusion.properties");
+        try
+        {
+            b = b.withConfigProperties(TestSetup.class, "/fusion.properties");
+        }
+        catch (IOException e)
+        {
+            throw new FusionException(e);
+        }
 
         return b;
     }


### PR DESCRIPTION
I want to reserve that exception for issues thrown during Fusion evaluation.

## Notes
I can't find a standard Java exception to distinguish a proper I/O failure with "something is wrong in this file".  I'm thinking about adding something like `ConfigException`, but not sure if that's worth it.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
