### PR TITLE
Move coverage tooling outside the runtime implementation.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionRuntimeBuilder.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionRuntimeBuilder.java
@@ -3,12 +3,13 @@
 
 package dev.ionfusion.fusion;
 
-import static dev.ionfusion.fusion._Private_CoverageCollectorImpl.fromDirectory;
 import static dev.ionfusion.fusion._private.FusionUtils.readProperties;
+import static dev.ionfusion.runtime._private.cover.CoverageCollectorImpl.fromDirectory;
 import static dev.ionfusion.runtime.base.ModuleIdentity.isValidAbsoluteModulePath;
 
 import com.amazon.ion.IonCatalog;
 import com.amazon.ion.system.SimpleCatalog;
+import dev.ionfusion.runtime._private.cover.CoverageCollectorImpl;
 import dev.ionfusion.runtime.embed.FusionRuntime;
 import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.File;
@@ -926,7 +927,7 @@ public class FusionRuntimeBuilder
             //   Note that the property exists so tests can inject a mock.
             if (b.myCoverageDataDirectory != null)
             {
-                _Private_CoverageCollectorImpl c =
+                CoverageCollectorImpl c =
                     fromDirectory(b.myCoverageDataDirectory);
 
                 // Register the active repositories with the collector.

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/Cover.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/Cover.java
@@ -3,7 +3,6 @@
 
 package dev.ionfusion.fusion.cli;
 
-import dev.ionfusion.fusion._Private_CoverageWriter;
 import java.io.File;
 import java.io.PrintWriter;
 
@@ -76,8 +75,7 @@ class Cover
         public int execute(PrintWriter out, PrintWriter err)
             throws Exception
         {
-            _Private_CoverageWriter renderer =
-                new _Private_CoverageWriter(myDataDir);
+            CoverageReportWriter renderer = new CoverageReportWriter(myDataDir);
 
             renderer.renderFullReport(myReportDir);
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/CoverageReportWriter.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/CoverageReportWriter.java
@@ -1,10 +1,10 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion;
+package dev.ionfusion.fusion.cli;
 
-import static dev.ionfusion.fusion.CoverageDatabase.SRCLOC_COMPARE;
 import static dev.ionfusion.fusion._Private_Trampoline.discoverModulesInRepository;
+import static dev.ionfusion.runtime._private.cover.CoverageDatabase.SRCLOC_COMPARE;
 import static dev.ionfusion.runtime.base.SourceName.FUSION_SOURCE_EXTENSION;
 import static java.math.RoundingMode.HALF_EVEN;
 import static java.nio.file.Files.walkFileTree;
@@ -16,8 +16,11 @@ import com.amazon.ion.Span;
 import com.amazon.ion.SpanProvider;
 import com.amazon.ion.Timestamp;
 import com.amazon.ion.system.IonReaderBuilder;
+import dev.ionfusion.fusion.FusionException;
 import dev.ionfusion.fusion._private.HtmlWriter;
 import dev.ionfusion.fusion._private.StreamWriter;
+import dev.ionfusion.runtime._private.cover.CoverageConfiguration;
+import dev.ionfusion.runtime._private.cover.CoverageDatabase;
 import dev.ionfusion.runtime.base.ModuleIdentity;
 import dev.ionfusion.runtime.base.SourceLocation;
 import dev.ionfusion.runtime.base.SourceName;
@@ -41,7 +44,7 @@ import java.util.Set;
 /**
  *
  */
-public final class _Private_CoverageWriter
+public final class CoverageReportWriter
 {
     private final static String CSS =
         "body { color:black }" +
@@ -172,7 +175,7 @@ public final class _Private_CoverageWriter
     private boolean coverageState;
 
 
-    public _Private_CoverageWriter(File dataDir)
+    public CoverageReportWriter(File dataDir)
         throws FusionException, IOException
     {
         myDatabase = new CoverageDatabase(dataDir.toPath());

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollectorImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollectorImpl.java
@@ -1,8 +1,9 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion;
+package dev.ionfusion.runtime._private.cover;
 
+import dev.ionfusion.fusion._Private_CoverageCollector;
 import dev.ionfusion.runtime.base.SourceLocation;
 import dev.ionfusion.runtime.embed.FusionRuntime;
 import java.io.File;
@@ -23,7 +24,7 @@ import java.util.Set;
  * unit testing where each test case uses a fresh {@link FusionRuntime}.
  * <p>
  * At present, only file-based sources are instrumented. This includes sources
- * loaded from a file-based {@link ModuleRepository} as well as scripts from
+ * loaded from a file-based {@code ModuleRepository} as well as scripts from
  * other locations.
  * <p>
  * Instances of this class are interned in a weak-reference cache, keyed by
@@ -42,7 +43,7 @@ import java.util.Set;
  *
  * @see CoverageConfiguration
  */
-public final class _Private_CoverageCollectorImpl
+public final class CoverageCollectorImpl
     implements _Private_CoverageCollector
 {
     // TODO Remove _Private_ prefix from this class; it's not used outside of
@@ -55,7 +56,7 @@ public final class _Private_CoverageCollectorImpl
     private final CoverageDatabase myDatabase;
 
 
-    private _Private_CoverageCollectorImpl(File dataDir)
+    private CoverageCollectorImpl(File dataDir)
         throws IOException
     {
         myConfig   = new CoverageConfiguration(dataDir);
@@ -69,19 +70,19 @@ public final class _Private_CoverageCollectorImpl
      * TODO: Can we streamline this to {@code ReferenceQueue<Closeable>}?
      */
     private static final
-    ReferenceQueue<_Private_CoverageCollectorImpl> ourReferenceQueue =
+    ReferenceQueue<CoverageCollectorImpl> ourReferenceQueue =
         new ReferenceQueue<>();
 
 
     // TODO A soft reference might be even better, to retain the collector as
     //      long as possible.
     private static final class CollectorRef
-        extends WeakReference<_Private_CoverageCollectorImpl>
+        extends WeakReference<CoverageCollectorImpl>
     {
         private File             myFile;
         private CoverageDatabase myDatabase;
 
-        CollectorRef(_Private_CoverageCollectorImpl referent)
+        CollectorRef(CoverageCollectorImpl referent)
         {
             super(referent, ourReferenceQueue);
 
@@ -207,7 +208,7 @@ public final class _Private_CoverageCollectorImpl
 
         if (ourShutdownHook == null)
         {
-            ourShutdownHook = new Thread(_Private_CoverageCollectorImpl::emptyCache);
+            ourShutdownHook = new Thread(CoverageCollectorImpl::emptyCache);
 
             Runtime.getRuntime().addShutdownHook(ourShutdownHook);
         }
@@ -296,8 +297,7 @@ public final class _Private_CoverageCollectorImpl
         }
     }
 
-    public static synchronized
-    _Private_CoverageCollectorImpl fromDirectory(File dataDir)
+    public static synchronized CoverageCollectorImpl fromDirectory(File dataDir)
         throws IOException
     {
         initCache();
@@ -306,7 +306,7 @@ public final class _Private_CoverageCollectorImpl
         // don't lead to collectors overwriting each other's database.
         dataDir = dataDir.getCanonicalFile();
 
-        _Private_CoverageCollectorImpl collector;
+        CoverageCollectorImpl collector;
 
         CollectorRef ref = ourCollectorCache.get(dataDir);
         if (ref != null)
@@ -332,7 +332,7 @@ public final class _Private_CoverageCollectorImpl
 
         try
         {
-            collector = new _Private_CoverageCollectorImpl(dataDir);
+            collector = new CoverageCollectorImpl(dataDir);
         }
         catch (IOException e)
         {
@@ -344,7 +344,7 @@ public final class _Private_CoverageCollectorImpl
         return collector;
     }
 
-    public static _Private_CoverageCollectorImpl fromDirectory(String dataDir)
+    public static CoverageCollectorImpl fromDirectory(String dataDir)
         throws IOException
     {
         return fromDirectory(new File(dataDir));
@@ -355,7 +355,7 @@ public final class _Private_CoverageCollectorImpl
     // Managing the coverage data
 
 
-    void noteRepository(File repoDir)
+    public void noteRepository(File repoDir)
     {
         myDatabase.noteRepository(repoDir);
     }

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageConfiguration.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageConfiguration.java
@@ -1,7 +1,7 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion;
+package dev.ionfusion.runtime._private.cover;
 
 import static dev.ionfusion.fusion._private.FusionUtils.readProperties;
 import static dev.ionfusion.runtime.base.ModuleIdentity.isValidAbsoluteModulePath;
@@ -54,7 +54,7 @@ import java.util.function.Predicate;
  * synthetic, unresolvable module paths that cannot be selected via the
  * module-based properties above.
  */
-final class CoverageConfiguration
+public final class CoverageConfiguration
 {
     private static final String CONFIG_FILE_NAME          = "config.properties";
     private static final String PROPERTY_INCLUDED_MODULES = "IncludedModules";
@@ -114,7 +114,7 @@ final class CoverageConfiguration
     }
 
 
-    CoverageConfiguration(File dataDir)
+    public CoverageConfiguration(File dataDir)
         throws IOException
     {
         File myConfigFile = new File(dataDir, CONFIG_FILE_NAME);
@@ -161,7 +161,7 @@ final class CoverageConfiguration
     /**
      * @return not null.
      */
-    Set<Path> getIncludedSourceDirs()
+    public Set<Path> getIncludedSourceDirs()
     {
         return myIncludedSourceDirs;
     }
@@ -182,7 +182,7 @@ final class CoverageConfiguration
      *
      * @param file may be null.
      */
-    boolean fileIsSelected(Path file)
+    public boolean fileIsSelected(Path file)
     {
         return (file != null) && myIncludedSourceDirs.stream().anyMatch(file::startsWith);
     }
@@ -236,7 +236,7 @@ final class CoverageConfiguration
          * @param configFile where the {@code props} came from; used only for error messages.
          * @param props must not be null.
          *
-         * @throws FusionException if an entry is not an absolute module path.
+         * @throws IOException if an entry is not an absolute module path.
          */
         public SimpleModuleIdentitySelector(File configFile, Properties props)
             throws IOException

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
@@ -1,7 +1,7 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion;
+package dev.ionfusion.runtime._private.cover;
 
 import static com.amazon.ion.IonType.LIST;
 import static com.amazon.ion.IonType.STRING;
@@ -39,13 +39,13 @@ import java.util.Set;
  * {@code CoverageDatabase} instance, should access the directory until the
  * database is flushed via {@link #write()}.  This implies that instances need
  * to be interned or otherwise deduplicated, based on physical directory.
- * At present, {@link _Private_CoverageCollectorImpl} implements these
+ * At present, {@link CoverageCollectorImpl} implements these
  * constraints.
  * <p>
  * TODO: The flushing protocol would be more obvious if this class implemented
  *       {@link java.io.Closeable}.
  */
-class CoverageDatabase
+public class CoverageDatabase
 {
     private static final class SourceNameComparator
         implements Comparator<SourceName>
@@ -80,7 +80,7 @@ class CoverageDatabase
         }
     }
 
-    static final Comparator<SourceLocation> SRCLOC_COMPARE =
+    public static final Comparator<SourceLocation> SRCLOC_COMPARE =
         new SourceLocationComparator();
 
 
@@ -124,7 +124,7 @@ class CoverageDatabase
     }
 
 
-    synchronized Set<File> getRepositories()
+    public synchronized Set<File> getRepositories()
     {
         return myRepositories;
     }
@@ -171,7 +171,7 @@ class CoverageDatabase
 
 
     /** Has a location been covered? */
-    synchronized boolean locationCovered(SourceLocation loc)
+    public synchronized boolean locationCovered(SourceLocation loc)
     {
         Boolean covered = myLocations.get(loc);
         return (covered != null && covered);
@@ -179,7 +179,7 @@ class CoverageDatabase
 
 
     // TODO Collect this eagerly
-    synchronized Set<SourceName> sourceNames()
+    public synchronized Set<SourceName> sourceNames()
     {
         Set<SourceName> names = new HashSet<>();
 
@@ -211,13 +211,13 @@ class CoverageDatabase
     /**
      * @return not null.
      */
-    synchronized Set<SourceLocation> locations()
+    public synchronized Set<SourceLocation> locations()
     {
         return myLocations.keySet();
     }
 
 
-    synchronized SourceLocation[] sortedLocations(SourceName name)
+    public synchronized SourceLocation[] sortedLocations(SourceName name)
     {
         ArrayList<SourceLocation> locsList = new ArrayList<>();
 


### PR DESCRIPTION
The mechanism for storing and analyzing the data is decoupled from the implementation by a data-collection interface that should eventually become part of the embedding API.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
