### PR TITLE
Enable some Java linting in Gradle builds.

### DIFF
--- a/buildSrc/src/main/kotlin/buildlogic.java-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.java-common-conventions.gradle.kts
@@ -30,6 +30,13 @@ java {
     }
 }
 
+// Enable some linting.  TODO Work toward -Xlint:all
+tasks.withType<JavaCompile>() {
+    options.compilerArgumentProviders.add {
+        listOf("-Xlint:serial")
+    }
+}
+
 tasks.named<Test>("test") {
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()

--- a/runtime/src/main/java/dev/ionfusion/fusion/AmbiguousBindingFailure.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/AmbiguousBindingFailure.java
@@ -9,6 +9,7 @@ import static com.amazon.ion.util.IonTextUtils.printQuotedSymbol;
  * Indicates an import or definition of an identifier that is already bound
  * and cannot be redefined.
  */
+@SuppressWarnings("serial")
 final class AmbiguousBindingFailure
     extends SyntaxException
 {

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionStruct.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionStruct.java
@@ -426,6 +426,7 @@ final class FusionStruct
             throws FusionException;
     }
 
+    @SuppressWarnings("serial")
     static class TunneledFusionException
         extends RuntimeException
     {
@@ -863,9 +864,10 @@ final class FusionStruct
             throw new IllegalStateException("Cannot wrap mutable struct as syntax");
         }
 
-        private static final class VisitFailure extends RuntimeException
-        {
-        }
+        @SuppressWarnings("serial")
+        private static final class VisitFailure
+            extends RuntimeException
+        { }
 
         /**
          * TODO This needs to do cycle detection.

--- a/runtime/src/main/java/dev/ionfusion/fusion/ModuleNotFoundException.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ModuleNotFoundException.java
@@ -7,6 +7,7 @@ package dev.ionfusion.fusion;
 /**
  * Indicates failure to locate a required module.
  */
+@SuppressWarnings("serial")
 public final class ModuleNotFoundException
     extends FusionErrorException
 {


### PR DESCRIPTION
This is quite minimal, but ideally we'll work toward `-Xlint:all`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
