### PR TITLE
Reduce sexp traversal in some compilation paths.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/AssertForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/AssertForm.java
@@ -5,8 +5,11 @@ package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionIo.safeDisplay;
 import static dev.ionfusion.fusion.FusionIo.safeWriteToString;
+import static dev.ionfusion.fusion.FusionSexp.unsafePairHead;
+import static dev.ionfusion.fusion.FusionSexp.unsafePairTail;
 import static dev.ionfusion.fusion.FusionVoid.voidValue;
 
+import dev.ionfusion.fusion.FusionSexp.BaseSexp;
 import dev.ionfusion.runtime.base.SourceLocation;
 
 final class AssertForm
@@ -26,10 +29,13 @@ final class AssertForm
         throws FusionException
     {
         Evaluator eval = comp.getEvaluator();
-        SyntaxValue testFormSyntax = stx.get(eval, 1);
+        BaseSexp<?> forms = (BaseSexp<?>) unsafePairTail(eval, stx.unwrap(eval));
+
+        SyntaxValue testFormSyntax = (SyntaxValue) unsafePairHead(eval, forms);
         CompiledForm testForm = comp.compileExpression(env, testFormSyntax);
 
-        CompiledForm[] messageForms = comp.compileExpressions(env, stx, 2);
+        BaseSexp<?> message = (BaseSexp<?>) unsafePairTail(eval, forms);
+        CompiledForm[] messageForms = comp.compileExpressions(env, message);
 
         SourceLocation location = testFormSyntax.getLocation();
         String expression = safeWriteToString(eval, testFormSyntax);

--- a/runtime/src/main/java/dev/ionfusion/fusion/BeginForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/BeginForm.java
@@ -41,6 +41,6 @@ final class BeginForm
     CompiledForm compile(Compiler comp, Environment env, SyntaxSexp stx)
         throws FusionException
     {
-        return comp.compileBegin(env, stx, 1, stx.size());
+        return comp.compileBegin(env, stx, 1);
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/Expander.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Expander.java
@@ -100,12 +100,10 @@ final class Expander
         if (! (stx instanceof SyntaxSexp)) return stx;
 
         SyntaxSexp sexp = (SyntaxSexp) stx;
-        if (sexp.size() == 0) return stx;
+        if (sexp.hasNoChildren()) return stx;
 
-        SyntaxValue first = sexp.get(myEval, 0);
-        if (! (first instanceof SyntaxSymbol)) return stx;
-
-        SyntaxSymbol maybeMacro = (SyntaxSymbol) first;
+        SyntaxSymbol maybeMacro = sexp.firstIdentifier(myEval);
+        if (maybeMacro == null) return stx;
 
         SyntacticForm form = maybeMacro.resolveSyntaxMaybe(env);
         if (form instanceof MacroForm)

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionEval.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionEval.java
@@ -4,6 +4,9 @@
 package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionIo.isEof;
+import static dev.ionfusion.fusion.FusionSexp.isPair;
+import static dev.ionfusion.fusion.FusionSexp.unsafePairHead;
+import static dev.ionfusion.fusion.FusionSexp.unsafePairTail;
 import static dev.ionfusion.fusion.FusionSyntax.isSyntax;
 import static dev.ionfusion.fusion.FusionVoid.voidValue;
 import static dev.ionfusion.fusion.GlobalState.MODULE;
@@ -111,10 +114,8 @@ final class FusionEval
                 if (beginStx != null)
                 {
                     // Splice 'begin' elements into the top-level sequence.
-                    for (int i = beginStx.size() - 1; i != 0;  i--)
-                    {
-                        forms.push(beginStx.get(eval, i));
-                    }
+                    Object body = unsafePairTail(eval, beginStx.unwrap(eval));
+                    pushSexpElements(eval, forms, body);
                     stx = null;
                 }
                 else
@@ -141,6 +142,20 @@ final class FusionEval
         {
             e.addContext(topLocation);
             throw e;
+        }
+    }
+
+    /**
+     * Push the sexp elements on the stack, in reverse order.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static void pushSexpElements(Evaluator eval, LinkedList stack, Object sexp)
+        throws FusionException
+    {
+        if (isPair(eval, sexp))
+        {
+            pushSexpElements(eval, stack, unsafePairTail(eval, sexp));
+            stack.push(unsafePairHead(eval, sexp));
         }
     }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSexp.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSexp.java
@@ -366,7 +366,7 @@ final class SyntaxSexp
 
 
     @Override
-    Object unwrap(Evaluator eval)
+    BaseSexp<?> unwrap(Evaluator eval)
         throws FusionException
     {
         pushWraps(eval);

--- a/runtime/src/main/java/dev/ionfusion/fusion/_Private_HelpForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/_Private_HelpForm.java
@@ -3,6 +3,9 @@
 
 package dev.ionfusion.fusion;
 
+import static dev.ionfusion.fusion.FusionSexp.unsafePairTail;
+
+import dev.ionfusion.fusion.FusionSexp.BaseSexp;
 import dev.ionfusion.fusion.ModuleNamespace.CompiledImportedVariableReference;
 import dev.ionfusion.fusion.TopLevelNamespace.CompiledTopLevelVariableReference;
 import dev.ionfusion.fusion._private.doc.model.BindingDoc;
@@ -106,7 +109,10 @@ public final class _Private_HelpForm
     CompiledForm compile(Compiler comp, Environment env, SyntaxSexp stx)
         throws FusionException
     {
-        CompiledForm[] children = comp.compileExpressions(env, stx, 1);
+        Evaluator eval = comp.getEvaluator();
+        BaseSexp<?> forms = (BaseSexp<?>) unsafePairTail(eval, stx.unwrap(eval));
+
+        CompiledForm[] children = comp.compileExpressions(env, forms);
         return new CompiledHelp(children);
     }
 


### PR DESCRIPTION
Use of indexed `get` on sexps is not the best.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
