### PR TITLE
Wire `Evaluator` through `FusionCollection.size()`.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/BeginForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/BeginForm.java
@@ -20,7 +20,7 @@ final class BeginForm
         // TODO handle splicing in internal-defn context
         //  https://github.com/ion-fusion/fusion-java/issues/67
 
-        int size = stx.size();
+        int size = stx.size(eval);
 
         SyntaxValue[] expandedChildren = new SyntaxValue[size];
         expandedChildren[0] = stx.get(eval, 0);

--- a/runtime/src/main/java/dev/ionfusion/fusion/Compiler.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Compiler.java
@@ -211,7 +211,7 @@ class Compiler
     CompiledForm[] compileExpressions(Environment env, BaseSexp<?> exprs)
         throws FusionException
     {
-        int size = exprs.size();
+        int size = exprs.size(myEval);
         CompiledForm[] forms = new CompiledForm[size];
         for (int i = 0; i < size; i++)
         {
@@ -310,7 +310,7 @@ class Compiler
     CompiledForm compileDefineValues(final Environment env, SyntaxSexp stx)
         throws FusionException
     {
-        int arity = stx.size();
+        int arity = stx.size(myEval);
         SyntaxValue valueSource = stx.get(myEval, arity - 1);
         final CompiledForm valuesForm = compileExpression(env, valueSource);
 
@@ -376,7 +376,7 @@ class Compiler
     CompiledForm compileDefineSyntax(final Environment env, SyntaxSexp stx)
         throws FusionException
     {
-        int arity = stx.size();
+        int arity = stx.size(myEval);
         SyntaxValue valueSource = stx.get(myEval, arity-1);
         final CompiledForm valueForm = compileExpression(env, valueSource);
 
@@ -625,7 +625,7 @@ class Compiler
 
         boolean allConstant = true;
 
-        int len = stx.size();
+        int len = stx.size(myEval);
         CompiledForm[] children = new CompiledForm[len];
         for (int i = 0; i < len; i++)
         {

--- a/runtime/src/main/java/dev/ionfusion/fusion/DefineValuesForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/DefineValuesForm.java
@@ -106,7 +106,7 @@ final class DefineValuesForm
                     check.subformSeq("documentation sequence", 2);
 
                 int idCount = boundIds.length;
-                if (docs.form().size() != idCount)
+                if (docs.form().size(eval) != idCount)
                 {
                     throw docs.failure("expected " + idCount + " doc strings");
                 }
@@ -139,7 +139,7 @@ final class DefineValuesForm
             formChecker.subformSexp("sexp of identifiers to bind", 1);
 
         SyntaxSexp argSexp = (SyntaxSexp) subformChecker.form();
-        int size = argSexp.size();
+        int size = argSexp.size(eval);
         for (int i = 0; i < size; i++)
         {
             // Prepare the identifiers so they resolve to their own binding.

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionCollection.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionCollection.java
@@ -52,7 +52,7 @@ final class FusionCollection
             return myAnnotations;
         }
 
-        abstract int size()
+        abstract int size(Evaluator eval)
             throws FusionException;
     }
 
@@ -78,7 +78,7 @@ final class FusionCollection
     static int unsafeCollectionSize(Evaluator eval, Object collection)
         throws FusionException
     {
-        return ((BaseCollection) collection).size();
+        return ((BaseCollection) collection).size(eval);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionList.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionList.java
@@ -452,6 +452,11 @@ final class FusionList
         }
 
         @Override
+        final int size(Evaluator eval)
+        {
+            return size();
+        }
+
         int size()
         {
             return myValues.length;
@@ -703,7 +708,7 @@ final class FusionList
             int newLen = myLen;
             for (Object arg : args)
             {
-                newLen += ((BaseSequence) arg).size();
+                newLen += ((BaseSequence) arg).size(eval);
             }
 
             if (newLen == myLen) return this; // Nothing to append
@@ -714,7 +719,7 @@ final class FusionList
             for (Object arg : args)
             {
                 BaseSequence v = (BaseSequence) arg;
-                int argLen = v.size();
+                int argLen = v.size(eval);
 
                 v.unsafeCopy(eval, 0, copy, pos, argLen);
                 pos += argLen;
@@ -1036,7 +1041,7 @@ final class FusionList
             int newLen = mySize;
             for (Object arg : args)
             {
-                newLen += ((BaseSequence) arg).size();
+                newLen += ((BaseSequence) arg).size(eval);
             }
 
             // Note that mySize <= myValues.length
@@ -1051,7 +1056,7 @@ final class FusionList
                 for (Object arg : args)
                 {
                     BaseSequence v = (BaseSequence) arg;
-                    int argLen = v.size();
+                    int argLen = v.size(eval);
 
                     v.unsafeCopy(eval, 0, newValues, pos, argLen);
                     pos += argLen;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionSexp.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionSexp.java
@@ -282,7 +282,7 @@ final class FusionSexp
     static int unsafeSexpSize(Evaluator eval, Object sexp)
         throws FusionException
     {
-        return ((BaseSexp) sexp).size();
+        return ((BaseSexp) sexp).size(eval);
     }
 
 
@@ -435,7 +435,7 @@ final class FusionSexp
         }
 
         @Override
-        int size() throws FusionException { return 0; }
+        int size(Evaluator eval) throws FusionException { return 0; }
 
         @Override
         Object elt(Evaluator eval, int pos)
@@ -524,7 +524,7 @@ final class FusionSexp
                                        SourceLocation loc)
             throws FusionException
         {
-            assert size() == 0;
+            assert size(eval) == 0;
 
             SyntaxValue stx = SyntaxSexp.make(eval, loc, this);
             return Syntax.applyContext(eval, context, stx);
@@ -721,7 +721,7 @@ final class FusionSexp
 
 
         @Override
-        int size()
+        int size(Evaluator eval)
             throws FusionException
         {
             int size = 1;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionStruct.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionStruct.java
@@ -605,6 +605,12 @@ final class FusionStruct
 
 
         @Override
+        public int size(Evaluator eval)
+        {
+            return 0;
+        }
+
+        @Override
         public int size()
         {
             return 0;
@@ -809,6 +815,12 @@ final class FusionStruct
         MapBasedStruct makeSimilar(MultiHashTrie<String, Object> map)
         {
             return makeSimilar(map, myAnnotations);
+        }
+
+        @Override
+        public final int size(Evaluator eval)
+        {
+            return size();
         }
 
         @Override

--- a/runtime/src/main/java/dev/ionfusion/fusion/LambdaForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/LambdaForm.java
@@ -48,7 +48,7 @@ final class LambdaForm
         {
             SyntaxChecker checkFormals =
                 check.subformSexp("formal arguments", 1);
-            args = determineArgs(checkFormals);
+            args = determineArgs(eval, checkFormals);
         }
 
         // When there's no args, we can avoid an empty binding rib at runtime.
@@ -98,11 +98,12 @@ final class LambdaForm
     }
 
 
-    private static SyntaxSymbol[] determineArgs(SyntaxChecker checkArgs)
+    private static SyntaxSymbol[] determineArgs(Evaluator eval,
+                                                SyntaxChecker checkArgs)
         throws FusionException
     {
         SyntaxSexp argSexp = (SyntaxSexp) checkArgs.form();
-        int size = argSexp.size();
+        int size = argSexp.size(eval);
         if (size == 0) return SyntaxSymbol.EMPTY_ARRAY;
 
         SyntaxSymbol[] args = new SyntaxSymbol[size];
@@ -116,14 +117,14 @@ final class LambdaForm
     //========================================================================
 
 
-    private static int countFormals(SyntaxValue formalsDecl)
+    private static int countFormals(Evaluator eval, SyntaxValue formalsDecl)
         throws FusionException
     {
         // (lambda rest ___)
         if (formalsDecl instanceof SyntaxSymbol) return 1;
 
         // (lambda (formal ...) ___)
-        return ((SyntaxSexp) formalsDecl).size();
+        return ((SyntaxSexp) formalsDecl).size(eval);
     }
 
 
@@ -131,7 +132,7 @@ final class LambdaForm
                                               SyntaxSexp formalsDecl)
         throws FusionException
     {
-        int size = formalsDecl.size();
+        int size = formalsDecl.size(eval);
         if (size == 0) return EMPTY_STRING_ARRAY;
 
         String[] args = new String[size];
@@ -151,7 +152,7 @@ final class LambdaForm
         Evaluator eval = comp.getEvaluator();
 
         SyntaxValue formalsDecl = stx.get(eval, 1);
-        if (countFormals(formalsDecl) != 0)
+        if (countFormals(eval, formalsDecl) != 0)
         {
             // Dummy environment to keep track of depth
             env = new LocalEnvironment(env);

--- a/runtime/src/main/java/dev/ionfusion/fusion/LetValuesForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/LetValuesForm.java
@@ -22,7 +22,7 @@ final class LetValuesForm
             check.subformSeq("sequence of bindings", 1);
         SyntaxSequence bindingForms = checkBindings.form();
 
-        final int numBindingForms = bindingForms.size();
+        final int numBindingForms = bindingForms.size(eval);
 
         // Gather the bound names
         ArrayList<SyntaxSymbol> boundNameList =
@@ -36,7 +36,8 @@ final class LetValuesForm
             SyntaxChecker checkBoundNames =
                 checkPair.subformSexp("binding name sequence", 0);
 
-            for (int j = 0; j < checkBoundNames.form().size(); j++)
+            int size = checkBoundNames.form().size(eval);
+            for (int j = 0; j < size; j++)
             {
                 SyntaxSymbol name =
                     checkBoundNames.requiredIdentifier("binding name", j);
@@ -73,7 +74,8 @@ final class LetValuesForm
 
             SyntaxSexp names = (SyntaxSexp) binding.get(eval, 0);
             SyntaxValue[] wrappedNames = names.extract(eval);
-            for (int j = 0; j < names.size(); j++)
+            int size = names.size(eval);
+            for (int j = 0; j < size; j++)
             {
                 // Wrap the bound names so they resolve to their own binding.
                 SyntaxSymbol name = boundNames[bindingPos];
@@ -127,7 +129,7 @@ final class LetValuesForm
         SyntaxSequence bindingForms = (SyntaxSequence) expr.get(eval, 1);
 
         // The number of bindings is >= the number of binding forms.
-        final int numBindingForms = bindingForms.size();
+        final int numBindingForms = bindingForms.size(eval);
 
         int[] valueCounts = new int[numBindingForms];
         CompiledForm[]   valueForms = new CompiledForm  [numBindingForms];
@@ -140,7 +142,7 @@ final class LetValuesForm
             SyntaxSexp binding = (SyntaxSexp) bindingForms.get(eval, i);
 
             SyntaxSexp names = (SyntaxSexp) binding.get(eval, 0);
-            int size = names.size();
+            int size = names.size(eval);
             bindingCount += size;
             valueCounts[i] = size;
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/LetrecForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/LetrecForm.java
@@ -24,7 +24,7 @@ final class LetrecForm
             check.subformSeq("sequence of bindings", 1);
         SyntaxSequence bindingForms = checkBindings.form();
 
-        final int numBindings = bindingForms.size();
+        final int numBindings = bindingForms.size(eval);
         SyntaxSymbol[] boundNames = new SyntaxSymbol[numBindings];
         for (int i = 0; i < numBindings; i++)
         {
@@ -87,7 +87,7 @@ final class LetrecForm
 
         SyntaxSequence bindingForms = (SyntaxSequence) stx.get(eval, 1);
 
-        final int numBindings = bindingForms.size();
+        final int numBindings = bindingForms.size(eval);
 
         CompiledForm  [] valueForms = new CompiledForm  [numBindings];
         SourceLocation[] valueLocns = new SourceLocation[numBindings];

--- a/runtime/src/main/java/dev/ionfusion/fusion/LoadHandler.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/LoadHandler.java
@@ -123,7 +123,7 @@ final class LoadHandler
         try
         {
             SyntaxSexp moduleDeclaration = (SyntaxSexp) firstTopLevel;
-            if (moduleDeclaration.size() > 1)
+            if (moduleDeclaration.size(eval) > 1)
             {
                 SyntaxSymbol moduleSym = (SyntaxSymbol)
                     moduleDeclaration.get(eval, 0);

--- a/runtime/src/main/java/dev/ionfusion/fusion/ModuleForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ModuleForm.java
@@ -69,7 +69,7 @@ final class ModuleForm
 
         // Ensure there's a name and language. We check for a body below, but
         // want a different error message for that situation.
-        if (source.size() < 3)
+        if (source.size(eval) < 3)
         {
             throw check.failure("Malformed module declaration");
         }
@@ -117,7 +117,7 @@ final class ModuleForm
         }
 
 
-        if (source.size() < 4)
+        if (source.size(eval) < 4)
         {
             throw check.failure("Module has no body");
         }
@@ -215,7 +215,7 @@ final class ModuleForm
                 {
                     // Splice 'begin' into the module-begin sequence
                     SyntaxSymbol beginId = (SyntaxSymbol) sexp.get(eval, 0);
-                    int last = sexp.size() - 1;
+                    int last = sexp.size(eval) - 1;
                     for (int i = last; i != 0;  i--)
                     {
                         SyntaxValue expr = sexp.get(eval, i);

--- a/runtime/src/main/java/dev/ionfusion/fusion/ParameterizeForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ParameterizeForm.java
@@ -22,7 +22,7 @@ final class ParameterizeForm
             check.subformSeq("sequence of parameterizations", 1);
         SyntaxSequence bindingForms = checkBindings.form();
 
-        final int numBindings = bindingForms.size();
+        final int numBindings = bindingForms.size(eval);
         SyntaxValue[] expandedForms = new SyntaxValue[numBindings];
         for (int i = 0; i < numBindings; i++)
         {
@@ -72,7 +72,7 @@ final class ParameterizeForm
 
         SyntaxSequence bindingForms = (SyntaxSequence) stx.get(eval, 1);
 
-        final int numBindings = bindingForms.size();
+        final int numBindings = bindingForms.size(eval);
 
         CompiledForm[] parameterForms = new CompiledForm[numBindings];
         CompiledForm[] valueForms     = new CompiledForm[numBindings];

--- a/runtime/src/main/java/dev/ionfusion/fusion/ProvideForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ProvideForm.java
@@ -37,10 +37,11 @@ final class ProvideForm
 
         Namespace moduleNamespace = (Namespace) env;
 
-        ArrayList<SyntaxValue> expanded = new ArrayList<>(form.size());
+        int size = form.size(eval);
+        ArrayList<SyntaxValue> expanded = new ArrayList<>(size);
         expanded.add(form.get(eval, 0));
 
-        for (int i = 1; i < form.size(); i++)
+        for (int i = 1; i < size; i++)
         {
             SyntaxValue spec = form.get(eval, i);
             Object datum = spec.unwrap(eval);

--- a/runtime/src/main/java/dev/ionfusion/fusion/QuasiBaseForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/QuasiBaseForm.java
@@ -68,7 +68,7 @@ abstract class QuasiBaseForm
     {
         final Evaluator eval = expander.getEvaluator();
 
-        int size = stx.size();
+        int size = stx.size(eval);
         if (size == 0) return stx;
 
         SyntaxValue[] children = stx.extract(eval);
@@ -123,7 +123,7 @@ abstract class QuasiBaseForm
     {
         final Evaluator eval = expander.getEvaluator();
 
-        int size = stx.size();
+        int size = stx.size(eval);
         if (size == 0) return stx;
 
         Object list = stx.unwrap(eval);
@@ -210,7 +210,7 @@ abstract class QuasiBaseForm
     {
         Evaluator eval = comp.getEvaluator();
 
-        int size = stx.size();
+        int size = stx.size(eval);
         if (size == 0) return constant(eval, stx);
 
         // Look for an (unquote ...) or (unsyntax ...) form
@@ -260,7 +260,7 @@ abstract class QuasiBaseForm
         throws FusionException
     {
         Evaluator eval = comp.getEvaluator();
-        int size = stx.size();
+        int size = stx.size(eval);
         if (size == 0) return constant(eval, stx);
 
         boolean same = true;

--- a/runtime/src/main/java/dev/ionfusion/fusion/RequireForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/RequireForm.java
@@ -58,7 +58,7 @@ final class RequireForm
 
         int arity = check.arityAtLeast(2);
 
-        ArrayList<SyntaxValue> expanded = new ArrayList<>(stx.size());
+        ArrayList<SyntaxValue> expanded = new ArrayList<>(stx.size(eval));
         expanded.add(stx.get(eval, 0));
 
         for (int i = 1; i < arity; i++)
@@ -255,7 +255,7 @@ final class RequireForm
         // would happen if resolving at runtime gave a different result.
 
         ModuleIdentity baseModule = env.namespace().getResolutionBase();
-        int arity = stx.size();
+        int arity = stx.size(eval);
 
         SyntaxChecker check = new SyntaxChecker(eval, REQUIRE, stx);
 
@@ -310,7 +310,7 @@ final class RequireForm
                     // Resolver has type-checked the module-path for us.
                     SyntaxText context = (SyntaxText) pathStx;
 
-                    int idCount = sexp.size() - 2;
+                    int idCount = sexp.size(eval) - 2;
                     RequireRenameMapping[] mappings =
                         new RequireRenameMapping[idCount];
                     for (int i = 0; i < idCount; i++)

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntacticForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntacticForm.java
@@ -39,7 +39,7 @@ abstract class SyntacticForm
     {
         final Evaluator eval = expander.getEvaluator();
 
-        int size = stx.size();
+        int size = stx.size(eval);
 
         SyntaxValue[] expandedChildren = new SyntaxValue[size];
         expandedChildren[0] = stx.get(eval, 0);

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxChecker.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxChecker.java
@@ -72,7 +72,7 @@ class SyntaxChecker
     void arityExact(int count)
         throws FusionException
     {
-        if (myForm.size() != count)
+        if (myForm.size(myEvaluator) != count)
         {
             throw failure("expected " + (count-1) + " subforms");
         }
@@ -86,7 +86,7 @@ class SyntaxChecker
     final int arityAtLeast(int count)
         throws FusionException
     {
-        int size = myForm.size();
+        int size = myForm.size(myEvaluator);
         if (size < count)
         {
             throw failure("expect at least " + (count-1) + " subforms");
@@ -272,7 +272,7 @@ class SyntaxChecker
         void arityExact(int count)
             throws FusionException
         {
-            if (myForm.size() != count)
+            if (myForm.size(myEvaluator) != count)
             {
                 String message =
                     "expected " + count + " subforms in " + myFormName;

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxGetProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxGetProc.java
@@ -27,7 +27,7 @@ final class SyntaxGetProc
             {
                 int index = checkIntArgToJavaInt(eval, this, i, args);
                 SyntaxSequence s = (SyntaxSequence) stx;
-                if (s.size() <= index)
+                if (s.size(eval) <= index)
                 {
                     return voidValue(eval);
                 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxList.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxList.java
@@ -178,7 +178,7 @@ final class SyntaxList
 
 
     @Override
-    final int size()
+    final int size(Evaluator eval)
     {
         return myImmutableList.size();
     }
@@ -212,8 +212,8 @@ final class SyntaxList
     SyntaxSequence makeAppended(Evaluator eval, SyntaxSequence that)
         throws FusionException
     {
-        int thisLength = this.size();
-        int thatLength = that.size();
+        int thisLength = this.size(eval);
+        int thatLength = that.size(eval);
         int newLength  = thisLength + thatLength;
 
         if (newLength == 0) return this;
@@ -272,10 +272,9 @@ final class SyntaxList
     SyntaxValue doExpand(Expander expander, Environment env)
         throws FusionException
     {
-        int len = size();
-        if (len == 0) return this;
-
         Evaluator eval = expander.getEvaluator();
+        int len = size(eval);
+        if (len == 0) return this;
 
         Object list = unwrap(eval);
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSequence.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSequence.java
@@ -20,7 +20,7 @@ abstract class SyntaxSequence
     }
 
 
-    abstract int size()
+    abstract int size(Evaluator eval)
         throws FusionException;
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSexp.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSexp.java
@@ -302,10 +302,10 @@ final class SyntaxSexp
 
 
     @Override
-    int size()
+    int size(Evaluator eval)
         throws FusionException
     {
-        return mySexp.size();
+        return mySexp.size(eval);
     }
 
 
@@ -512,7 +512,7 @@ final class SyntaxSexp
     {
         Evaluator eval = expander.getEvaluator();
 
-        int len = size();
+        int len = size(eval);
         if (len == 0)
         {
             String message =
@@ -567,7 +567,8 @@ final class SyntaxSexp
                                     IdentityHashMap<Binding, Object> stops)
         throws FusionException
     {
-        int len = size();
+        Evaluator eval = expander.getEvaluator();
+        int len = size(eval);
         if (len == 0)
         {
             String message =
@@ -575,7 +576,6 @@ final class SyntaxSexp
             throw new SyntaxException(null, message, this);
         }
 
-        Evaluator eval = expander.getEvaluator();
         SyntaxValue first = get(eval, 0); // calls pushAnyWraps()
         if (first instanceof SyntaxSymbol)
         {

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSizeProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSizeProc.java
@@ -13,6 +13,6 @@ final class SyntaxSizeProc
         throws FusionException
     {
         SyntaxSequence c = checkSyntaxSequenceArg(eval, 0, arg);
-        return makeInt(eval, c.size());
+        return makeInt(eval, c.size(eval));
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxStruct.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxStruct.java
@@ -179,12 +179,11 @@ final class SyntaxStruct
     SyntaxValue doExpand(final Expander expander, final Environment env)
         throws FusionException
     {
+        final Evaluator eval = expander.getEvaluator();
         if (myStruct.size() == 0)
         {
             return this;
         }
-
-        final Evaluator eval = expander.getEvaluator();
 
         StructFieldVisitor visitor = new StructFieldVisitor() {
             @Override

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSubseqProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSubseqProc.java
@@ -15,7 +15,7 @@ final class SyntaxSubseqProc
         checkArityExact(2, args);
         SyntaxSequence sequence = checkSyntaxSequenceArg(eval, 0, args);
         int from = checkIntArgToJavaInt(eval, this, 1, args);
-        int size = sequence.size();
+        int size = sequence.size(eval);
 
         if (size < from) from = size;
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/_Private_HelpForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/_Private_HelpForm.java
@@ -76,7 +76,7 @@ public final class _Private_HelpForm
         final Evaluator eval = expander.getEvaluator();
 
         SyntaxChecker check = check(eval, stx);
-        int arity = stx.size();
+        int arity = stx.size(eval);
 
         SyntaxValue[] children = stx.extract(eval);
 


### PR DESCRIPTION
This is unused, but will be needed to throw an exn when the pair-chain does not terminate properly.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
