### PR TITLE
Remove redundant `throws IonizeFailure` declarations.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/BaseValue.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/BaseValue.java
@@ -122,10 +122,10 @@ abstract class BaseValue
      * @param out the output stream; not null.
      *
      * @throws IOException Propagated from the output stream.
-     * @throws IonizeFailure if the data cannot be ionized.
+     * @throws FusionException if the data cannot be ionized.
      */
     void ionize(Evaluator eval, IonWriter out)
-        throws IOException, IonException, FusionException, IonizeFailure
+        throws IOException, IonException, FusionException
     {
         throw new IonizeFailure(this);
     }
@@ -203,12 +203,12 @@ abstract class BaseValue
 
 
     /**
-     * @throws IonizeFailure (when {@code throwOnConversionFailure})
+     * @throws FusionException (when {@code throwOnConversionFailure})
      * if this value cannot be ionized.
      */
     IonValue copyToIonValue(ValueFactory factory,
                             boolean throwOnConversionFailure)
-        throws FusionException, IonizeFailure
+        throws FusionException
     {
         if (throwOnConversionFailure)
         {
@@ -338,7 +338,7 @@ abstract class BaseValue
      */
     static IonValue copyToIonValue(Object value, ValueFactory factory,
                                    boolean throwOnConversionFailure)
-        throws FusionException, IonizeFailure
+        throws FusionException
     {
         return FusionValue.copyToIonValue(value,
                                           factory,

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionBlob.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionBlob.java
@@ -75,14 +75,14 @@ public final class FusionBlob
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             return factory.newNullBlob();
         }
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.writeNull(IonType.BLOB);
         }
@@ -132,14 +132,14 @@ public final class FusionBlob
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             return factory.newBlob(myContent);
         }
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.writeBlob(myContent);
         }
@@ -222,7 +222,7 @@ public final class FusionBlob
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             IonValue iv = myValue.copyToIonValue(factory,
                                                  throwOnConversionFailure);
@@ -232,7 +232,7 @@ public final class FusionBlob
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.setTypeAnnotations(getAnnotationsAsJavaStrings());
             myValue.ionize(eval, out);

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionBool.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionBool.java
@@ -98,14 +98,14 @@ public final class FusionBool
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             return factory.newNullBool();
         }
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.writeNull(IonType.BOOL);
         }
@@ -155,14 +155,14 @@ public final class FusionBool
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             return factory.newBool(true);
         }
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.writeBool(true);
         }
@@ -211,14 +211,14 @@ public final class FusionBool
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             return factory.newBool(false);
         }
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.writeBool(false);
         }
@@ -298,7 +298,7 @@ public final class FusionBool
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             IonValue iv = myValue.copyToIonValue(factory,
                                                  throwOnConversionFailure);
@@ -308,7 +308,7 @@ public final class FusionBool
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.setTypeAnnotations(getAnnotationsAsJavaStrings());
             myValue.ionize(eval, out);

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionClob.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionClob.java
@@ -76,14 +76,14 @@ public final class FusionClob
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             return factory.newNullClob();
         }
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.writeNull(IonType.CLOB);
         }
@@ -133,14 +133,14 @@ public final class FusionClob
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             return factory.newClob(myContent);
         }
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.writeClob(myContent);
         }
@@ -223,7 +223,7 @@ public final class FusionClob
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             IonValue iv = myValue.copyToIonValue(factory,
                                                  throwOnConversionFailure);
@@ -233,7 +233,7 @@ public final class FusionClob
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.setTypeAnnotations(getAnnotationsAsJavaStrings());
             myValue.ionize(eval, out);

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionIo.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionIo.java
@@ -218,9 +218,8 @@ public final class FusionIo
      * @param out the output stream; not null.
      * @param value must not be null.
      *
-     * @throws IonizeFailure if some part of the value cannot be ionized.
-     * @throws FusionException if there's an exception thrown by the output
-     * stream.
+     * @throws FusionException if some part of the value cannot be ionized, or
+     * if there's an exception thrown by the output stream.
      */
     static void ionize(Evaluator eval, IonWriter out, Object value)
         throws FusionException

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionNull.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionNull.java
@@ -69,14 +69,14 @@ public final class FusionNull
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             return factory.newNull();
         }
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.writeNull();
         }
@@ -117,7 +117,7 @@ public final class FusionNull
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             IonValue iv = factory.newNull();
             iv.setTypeAnnotations(getAnnotationsAsJavaStrings());
@@ -126,7 +126,7 @@ public final class FusionNull
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.setTypeAnnotations(getAnnotationsAsJavaStrings());
             out.writeNull();

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionNumber.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionNumber.java
@@ -298,14 +298,14 @@ public final class FusionNumber
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             return factory.newNullInt();
         }
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.writeNull(IonType.INT);
         }
@@ -370,14 +370,14 @@ public final class FusionNumber
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             return factory.newInt(myContent);
         }
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.writeInt(myContent);
         }
@@ -438,14 +438,14 @@ public final class FusionNumber
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             return factory.newInt(myContent);
         }
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.writeInt(myContent);
         }
@@ -544,7 +544,7 @@ public final class FusionNumber
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             IonValue iv = myValue.copyToIonValue(factory,
                                                  throwOnConversionFailure);
@@ -554,7 +554,7 @@ public final class FusionNumber
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.setTypeAnnotations(getAnnotationsAsJavaStrings());
             myValue.ionize(eval, out);
@@ -686,14 +686,14 @@ public final class FusionNumber
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             return factory.newNullDecimal();
         }
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.writeNull(IonType.DECIMAL);
         }
@@ -812,14 +812,14 @@ public final class FusionNumber
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             return factory.newDecimal(myContent);
         }
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.writeDecimal(myContent);
         }
@@ -914,7 +914,7 @@ public final class FusionNumber
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             IonValue iv = myValue.copyToIonValue(factory,
                                                  throwOnConversionFailure);
@@ -924,7 +924,7 @@ public final class FusionNumber
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.setTypeAnnotations(getAnnotationsAsJavaStrings());
             myValue.ionize(eval, out);
@@ -1058,14 +1058,14 @@ public final class FusionNumber
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             return factory.newNullFloat();
         }
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.writeNull(IonType.FLOAT);
         }
@@ -1221,14 +1221,14 @@ public final class FusionNumber
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             return factory.newFloat(myContent);
         }
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.writeFloat(myContent);
         }
@@ -1379,7 +1379,7 @@ public final class FusionNumber
         @Override
         IonValue copyToIonValue(ValueFactory factory,
                                 boolean throwOnConversionFailure)
-            throws FusionException, IonizeFailure
+            throws FusionException
         {
             IonValue iv = myValue.copyToIonValue(factory,
                                                  throwOnConversionFailure);
@@ -1389,7 +1389,7 @@ public final class FusionNumber
 
         @Override
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure
+            throws IOException, IonException, FusionException
         {
             out.setTypeAnnotations(getAnnotationsAsJavaStrings());
             myValue.ionize(eval, out);

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionStruct.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionStruct.java
@@ -476,7 +476,7 @@ final class FusionStruct
         extends AnnotatableValue<Self>
     {
         void ionize(Evaluator eval, IonWriter out)
-            throws IOException, IonException, FusionException, IonizeFailure;
+            throws IOException, IonException, FusionException;
 
         void write(Evaluator eval, Appendable out)
             throws IOException, FusionException;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionValue.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionValue.java
@@ -325,7 +325,7 @@ public final class FusionValue
     static IonValue copyToIonValue(Object       value,
                                    ValueFactory factory,
                                    boolean      throwOnConversionFailure)
-        throws FusionException, IonizeFailure
+        throws FusionException
     {
         if (value instanceof BaseValue)
         {

--- a/runtime/src/main/java/dev/ionfusion/fusion/SimpleSyntaxValue.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SimpleSyntaxValue.java
@@ -109,7 +109,7 @@ class SimpleSyntaxValue
 
     @Override
     void ionize(Evaluator eval, IonWriter writer)
-        throws IOException, IonException, FusionException, IonizeFailure
+        throws IOException, IonException, FusionException
     {
         myDatum.ionize(eval, writer);
     }

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxKeyword.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxKeyword.java
@@ -102,7 +102,7 @@ final class SyntaxKeyword
 
     @Override
     void ionize(Evaluator eval, IonWriter writer)
-        throws IOException, IonException, FusionException, IonizeFailure
+        throws IOException, IonException, FusionException
     {
         // TODO __ ??
         super.ionize(eval, writer);

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxStruct.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxStruct.java
@@ -208,7 +208,7 @@ final class SyntaxStruct
 
     @Override
     void ionize(Evaluator eval, IonWriter writer)
-        throws IOException, IonException, FusionException, IonizeFailure
+        throws IOException, IonException, FusionException
     {
         myStruct.ionize(eval, writer);
     }


### PR DESCRIPTION
## Description

This wasn't particularly useful.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
