### PR TITLE
Wire `Evaluator` through `copyToIonValue` paths.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/BaseValue.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/BaseValue.java
@@ -206,7 +206,7 @@ abstract class BaseValue
      * @throws FusionException (when {@code throwOnConversionFailure})
      * if this value cannot be ionized.
      */
-    IonValue copyToIonValue(ValueFactory factory,
+    IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                             boolean throwOnConversionFailure)
         throws FusionException
     {
@@ -294,12 +294,12 @@ abstract class BaseValue
      * @throws FusionException if something goes wrong during ionization.
      *
      * @see FusionRuntime#ionizeMaybe(Object, ValueFactory)
-     * @see FusionValue#copyToIonValueMaybe(Object, ValueFactory)
+     * @see FusionValue#copyToIonValueMaybe(Evaluator, Object, ValueFactory)
      */
-    static IonValue copyToIonValueMaybe(Object value, ValueFactory factory)
+    static IonValue copyToIonValueMaybe(Evaluator eval, Object value, ValueFactory factory)
         throws FusionException
     {
-        return FusionValue.copyToIonValue(value, factory, false);
+        return FusionValue.copyToIonValue(eval, value, factory, false);
     }
 
 
@@ -313,12 +313,12 @@ abstract class BaseValue
      *
      * @throws FusionException if the value cannot be converted to Ion.
      *
-     * @see FusionValue#copyToIonValue(Object, ValueFactory)
+     * @see FusionValue#copyToIonValue(Evaluator, Object, ValueFactory)
      */
-    static IonValue copyToIonValue(Object value, ValueFactory factory)
+    static IonValue copyToIonValue(Evaluator eval, Object value, ValueFactory factory)
         throws FusionException
     {
-        return FusionValue.copyToIonValue(value, factory, true);
+        return FusionValue.copyToIonValue(eval, value, factory, true);
     }
 
 
@@ -334,13 +334,13 @@ abstract class BaseValue
      * @throws FusionException if the value cannot be converted to Ion.
      *
      * @see FusionRuntime#ionize(Object, ValueFactory)
-     * @see FusionValue#copyToIonValue(Object, ValueFactory, boolean)
+     * @see FusionValue#copyToIonValue(Evaluator, Object, ValueFactory, boolean)
      */
-    static IonValue copyToIonValue(Object value, ValueFactory factory,
+    static IonValue copyToIonValue(Evaluator eval, Object value, ValueFactory factory,
                                    boolean throwOnConversionFailure)
         throws FusionException
     {
-        return FusionValue.copyToIonValue(value,
+        return FusionValue.copyToIonValue(eval, value,
                                           factory,
                                           throwOnConversionFailure);
     }

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionBlob.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionBlob.java
@@ -73,7 +73,7 @@ public final class FusionBlob
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -130,7 +130,7 @@ public final class FusionBlob
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -220,11 +220,11 @@ public final class FusionBlob
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
-            IonValue iv = myValue.copyToIonValue(factory,
+            IonValue iv = myValue.copyToIonValue(eval, factory,
                                                  throwOnConversionFailure);
             iv.setTypeAnnotations(getAnnotationsAsJavaStrings());
             return iv;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionBool.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionBool.java
@@ -96,7 +96,7 @@ public final class FusionBool
         Boolean asJavaBoolean() { return null; }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -153,7 +153,7 @@ public final class FusionBool
 
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -209,7 +209,7 @@ public final class FusionBool
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -296,11 +296,11 @@ public final class FusionBool
         Boolean asJavaBoolean() { return myValue.asJavaBoolean(); }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
-            IonValue iv = myValue.copyToIonValue(factory,
+            IonValue iv = myValue.copyToIonValue(eval, factory,
                                                  throwOnConversionFailure);
             iv.setTypeAnnotations(getAnnotationsAsJavaStrings());
             return iv;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionClob.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionClob.java
@@ -74,7 +74,7 @@ public final class FusionClob
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -131,7 +131,7 @@ public final class FusionClob
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -221,11 +221,11 @@ public final class FusionClob
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
-            IonValue iv = myValue.copyToIonValue(factory,
+            IonValue iv = myValue.copyToIonValue(eval, factory,
                                                  throwOnConversionFailure);
             iv.setTypeAnnotations(getAnnotationsAsJavaStrings());
             return iv;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionList.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionList.java
@@ -364,10 +364,12 @@ final class FusionList
     /**
      * @param list must be a list; it is not type-checked!
      */
-    static IonList unsafeCopyToIonList(Object list, ValueFactory factory)
+    static IonList unsafeCopyToIonList(Evaluator eval,
+                                       Object list,
+                                       ValueFactory factory)
         throws FusionException
     {
-        return unsafeCopyToIonList(list, factory, true);
+        return unsafeCopyToIonList(eval, list, factory, true);
     }
 
 
@@ -376,11 +378,12 @@ final class FusionList
      *
      * @return null if the list and its elements cannot be ionized.
      */
-    static IonList unsafeCopyToIonListMaybe(Object list,
+    static IonList unsafeCopyToIonListMaybe(Evaluator eval,
+                                            Object list,
                                             ValueFactory factory)
         throws FusionException
     {
-        return unsafeCopyToIonList(list, factory, false);
+        return unsafeCopyToIonList(eval, list, factory, false);
     }
 
 
@@ -389,13 +392,14 @@ final class FusionList
      *
      * @return null if the list and its elements cannot be ionized.
      */
-    static IonList unsafeCopyToIonList(Object list,
+    static IonList unsafeCopyToIonList(Evaluator eval,
+                                       Object list,
                                        ValueFactory factory,
                                        boolean throwOnConversionFailure)
         throws FusionException
     {
         BaseList base = (BaseList) list;
-        return base.copyToIonValue(factory, throwOnConversionFailure);
+        return base.copyToIonValue(eval, factory, throwOnConversionFailure);
     }
 
 
@@ -662,7 +666,8 @@ final class FusionList
          *  UNLESS throwOnConversionFailure
          */
         @Override
-        IonList copyToIonValue(ValueFactory factory,
+        IonList copyToIonValue(Evaluator eval,
+                               ValueFactory factory,
                                boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -670,7 +675,7 @@ final class FusionList
             IonValue[] ions = new IonValue[len];
             for (int i = 0; i < len; i++)
             {
-                IonValue ion = copyToIonValue(myValues[i], factory,
+                IonValue ion = copyToIonValue(eval, myValues[i], factory,
                                               throwOnConversionFailure);
                 if (ion == null)
                 {
@@ -953,7 +958,8 @@ final class FusionList
         }
 
         @Override
-        IonList copyToIonValue(ValueFactory factory,
+        IonList copyToIonValue(Evaluator eval,
+                               ValueFactory factory,
                                boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -1158,7 +1164,8 @@ final class FusionList
         }
 
         @Override
-        IonList copyToIonValue(ValueFactory factory,
+        IonList copyToIonValue(Evaluator eval,
+                               ValueFactory factory,
                                boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -1181,7 +1188,7 @@ final class FusionList
             }
             // else our elements have already been injected, copy as normal.
 
-            return super.copyToIonValue(factory, throwOnConversionFailure);
+            return super.copyToIonValue(eval, factory, throwOnConversionFailure);
         }
 
         @Override

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionNull.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionNull.java
@@ -67,7 +67,8 @@ public final class FusionNull
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval,
+                                ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -115,7 +116,8 @@ public final class FusionNull
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval,
+                                ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionNumber.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionNumber.java
@@ -296,7 +296,7 @@ public final class FusionNumber
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -368,7 +368,7 @@ public final class FusionNumber
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -436,7 +436,7 @@ public final class FusionNumber
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -542,11 +542,11 @@ public final class FusionNumber
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
-            IonValue iv = myValue.copyToIonValue(factory,
+            IonValue iv = myValue.copyToIonValue(eval, factory,
                                                  throwOnConversionFailure);
             iv.setTypeAnnotations(getAnnotationsAsJavaStrings());
             return iv;
@@ -684,7 +684,7 @@ public final class FusionNumber
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -810,7 +810,7 @@ public final class FusionNumber
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -912,11 +912,11 @@ public final class FusionNumber
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
-            IonValue iv = myValue.copyToIonValue(factory,
+            IonValue iv = myValue.copyToIonValue(eval, factory,
                                                  throwOnConversionFailure);
             iv.setTypeAnnotations(getAnnotationsAsJavaStrings());
             return iv;
@@ -1056,7 +1056,7 @@ public final class FusionNumber
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -1219,7 +1219,7 @@ public final class FusionNumber
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -1377,11 +1377,11 @@ public final class FusionNumber
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
-            IonValue iv = myValue.copyToIonValue(factory,
+            IonValue iv = myValue.copyToIonValue(eval, factory,
                                                  throwOnConversionFailure);
             iv.setTypeAnnotations(getAnnotationsAsJavaStrings());
             return iv;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionSexp.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionSexp.java
@@ -388,23 +388,26 @@ final class FusionSexp
     /**
      * @param sexp must be a proper sexp; it is not type-checked!
      */
-    static IonSexp unsafeCopyToIonSexp(Object sexp,
+    static IonSexp unsafeCopyToIonSexp(Evaluator eval,
+                                       Object sexp,
                                        ValueFactory factory,
                                        boolean throwOnConversionFailure)
         throws FusionException
     {
         BaseSexp base = (BaseSexp) sexp;
-        return base.copyToIonValue(factory, throwOnConversionFailure);
+        return base.copyToIonValue(eval, factory, throwOnConversionFailure);
     }
 
     /**
      * @param sexp must be a proper sexp; it is not type-checked!
      */
-    static IonSexp unsafeCopyToIonSexp(Object sexp, ValueFactory factory)
+    static IonSexp unsafeCopyToIonSexp(Evaluator eval,
+                                       Object sexp,
+                                       ValueFactory factory)
         throws FusionException
     {
         BaseSexp base = (BaseSexp) sexp;
-        return base.copyToIonValue(factory, true);
+        return base.copyToIonValue(eval, factory, true);
     }
 
     /**
@@ -412,12 +415,13 @@ final class FusionSexp
      *
      * @return null if the sexp and its contents cannot be ionized.
      */
-    static IonSexp unsafeCopyToIonSexpMaybe(Object sexp,
+    static IonSexp unsafeCopyToIonSexpMaybe(Evaluator eval,
+                                            Object sexp,
                                             ValueFactory factory)
         throws FusionException
     {
         BaseSexp base = (BaseSexp) sexp;
-        return base.copyToIonValue(factory, false);
+        return base.copyToIonValue(eval, factory, false);
     }
 
 
@@ -531,7 +535,7 @@ final class FusionSexp
         }
 
         @Override
-        abstract IonSexp copyToIonValue(ValueFactory factory,
+        abstract IonSexp copyToIonValue(Evaluator eval, ValueFactory factory,
                                         boolean throwOnConversionFailure)
             throws FusionException;
     }
@@ -597,8 +601,8 @@ final class FusionSexp
         }
 
         @Override
-        IonSexp copyToIonValue(ValueFactory factory,
-                              boolean throwOnConversionFailure)
+        IonSexp copyToIonValue(Evaluator eval, ValueFactory factory,
+                               boolean throwOnConversionFailure)
             throws FusionException
         {
             IonSexp sexp = factory.newNullSexp();
@@ -662,8 +666,8 @@ final class FusionSexp
         }
 
         @Override
-        IonSexp copyToIonValue(ValueFactory factory,
-                              boolean throwOnConversionFailure)
+        IonSexp copyToIonValue(Evaluator eval, ValueFactory factory,
+                               boolean throwOnConversionFailure)
             throws FusionException
         {
             IonSexp sexp = factory.newEmptySexp();
@@ -960,8 +964,8 @@ final class FusionSexp
         }
 
         @Override
-        IonSexp copyToIonValue(ValueFactory factory,
-                              boolean throwOnConversionFailure)
+        IonSexp copyToIonValue(Evaluator eval, ValueFactory factory,
+                               boolean throwOnConversionFailure)
             throws FusionException
         {
             IonSexp is = factory.newEmptySexp();
@@ -970,7 +974,7 @@ final class FusionSexp
             ImmutablePair pair = this;
             while (true)
             {
-                IonValue ion = copyToIonValue(pair.myHead, factory,
+                IonValue ion = copyToIonValue(eval, pair.myHead, factory,
                                               throwOnConversionFailure);
                 if (ion == null) return null;
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionString.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionString.java
@@ -166,7 +166,7 @@ public final class FusionString
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
         {
             return factory.newNullString();
@@ -206,7 +206,7 @@ public final class FusionString
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
         {
             return factory.newString(myContent);
@@ -293,11 +293,11 @@ public final class FusionString
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
-            IonValue iv = myValue.copyToIonValue(factory,
+            IonValue iv = myValue.copyToIonValue(eval, factory,
                                                  throwOnConversionFailure);
             iv.setTypeAnnotations(getAnnotationsAsJavaStrings());
             return iv;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionStruct.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionStruct.java
@@ -789,7 +789,7 @@ final class FusionStruct
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -1136,7 +1136,7 @@ final class FusionStruct
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -1149,7 +1149,7 @@ final class FusionStruct
                 String fieldName = entry.getKey();
 
                 Object value = entry.getValue();
-                IonValue ion = copyToIonValue(value, factory,
+                IonValue ion = copyToIonValue(eval, value, factory,
                                               throwOnConversionFailure);
                 if (ion == null) return null;
                 is.add(fieldName, ion);
@@ -1368,7 +1368,7 @@ final class FusionStruct
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
@@ -1378,7 +1378,7 @@ final class FusionStruct
                 return factory.clone(s);
             }
 
-            return super.copyToIonValue(factory, throwOnConversionFailure);
+            return super.copyToIonValue(eval, factory, throwOnConversionFailure);
         }
     }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionSymbol.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionSymbol.java
@@ -215,7 +215,7 @@ final class FusionSymbol
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
         {
             return factory.newNullSymbol();
@@ -283,7 +283,7 @@ final class FusionSymbol
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
         {
             return factory.newSymbol(myContent);
@@ -395,11 +395,11 @@ final class FusionSymbol
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
-            IonValue iv = myValue.copyToIonValue(factory,
+            IonValue iv = myValue.copyToIonValue(eval, factory,
                                                  throwOnConversionFailure);
             iv.setTypeAnnotations(getAnnotationsAsJavaStrings());
             return iv;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionTimestamp.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionTimestamp.java
@@ -107,7 +107,7 @@ final class FusionTimestamp
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
         {
             return factory.newNullTimestamp();
@@ -179,7 +179,7 @@ final class FusionTimestamp
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
         {
             return factory.newTimestamp(myContent);
@@ -267,11 +267,11 @@ final class FusionTimestamp
         }
 
         @Override
-        IonValue copyToIonValue(ValueFactory factory,
+        IonValue copyToIonValue(Evaluator eval, ValueFactory factory,
                                 boolean throwOnConversionFailure)
             throws FusionException
         {
-            IonValue iv = myValue.copyToIonValue(factory,
+            IonValue iv = myValue.copyToIonValue(eval, factory,
                                                  throwOnConversionFailure);
             iv.setTypeAnnotations(getAnnotationsAsJavaStrings());
             return iv;

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionValue.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionValue.java
@@ -285,10 +285,10 @@ public final class FusionValue
      *
      * @see FusionRuntime#ionizeMaybe(Object, ValueFactory)
      */
-    static IonValue copyToIonValueMaybe(Object value, ValueFactory factory)
+    static IonValue copyToIonValueMaybe(Evaluator eval, Object value, ValueFactory factory)
         throws FusionException
     {
-        return copyToIonValue(value, factory, false);
+        return copyToIonValue(eval, value, factory, false);
     }
 
 
@@ -302,10 +302,10 @@ public final class FusionValue
      *
      * @throws FusionException if the value cannot be converted to Ion.
      */
-    static IonValue copyToIonValue(Object value, ValueFactory factory)
+    static IonValue copyToIonValue(Evaluator eval, Object value, ValueFactory factory)
         throws FusionException
     {
-        return copyToIonValue(value, factory, true);
+        return copyToIonValue(eval, value, factory, true);
     }
 
 
@@ -322,7 +322,8 @@ public final class FusionValue
      *
      * @see FusionRuntime#ionize(Object, ValueFactory)
      */
-    static IonValue copyToIonValue(Object       value,
+    static IonValue copyToIonValue(Evaluator    eval,
+                                   Object       value,
                                    ValueFactory factory,
                                    boolean      throwOnConversionFailure)
         throws FusionException
@@ -330,7 +331,7 @@ public final class FusionValue
         if (value instanceof BaseValue)
         {
             BaseValue fv = (BaseValue) value;
-            return fv.copyToIonValue(factory, throwOnConversionFailure);
+            return fv.copyToIonValue(eval, factory, throwOnConversionFailure);
         }
 
         if (throwOnConversionFailure)

--- a/runtime/src/main/java/dev/ionfusion/fusion/StandardRuntime.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/StandardRuntime.java
@@ -201,7 +201,7 @@ final class StandardRuntime
     public IonValue ionize(Object fusionValue, ValueFactory factory)
         throws FusionException
     {
-        return FusionValue.copyToIonValue(fusionValue, factory);
+        return FusionValue.copyToIonValue(myTopLevel.getEvaluator(), fusionValue, factory);
     }
 
 
@@ -209,7 +209,7 @@ final class StandardRuntime
     public IonValue ionizeMaybe(Object fusionValue, ValueFactory factory)
         throws FusionException
     {
-        return FusionValue.copyToIonValueMaybe(fusionValue, factory);
+        return FusionValue.copyToIonValueMaybe(myTopLevel.getEvaluator(), fusionValue, factory);
     }
 
 

--- a/runtime/src/test/java/dev/ionfusion/fusion/FusionValueTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/FusionValueTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.amazon.ion.IonInt;
 import com.amazon.ion.IonValue;
 import dev.ionfusion.runtime.embed.TopLevel;
@@ -33,11 +34,11 @@ public class FusionValueTest
     {
         Object fv = eval("12");
         checkLong(12, fv);
-        IonValue iv = FusionValue.copyToIonValue(fv, system());
+        IonValue iv = FusionValue.copyToIonValue(evaluator(), fv, system());
         assertEquals(12, ((IonInt)iv).intValue());
 
         fv = eval("(lambda () 12)");
-        assertSame(null, FusionValue.copyToIonValueMaybe(fv, system()));
+        assertSame(null, FusionValue.copyToIonValueMaybe(evaluator(), fv, system()));
     }
 
     @Test
@@ -46,7 +47,7 @@ public class FusionValueTest
     {
         Object fv = eval("(lambda () 12)");
         assertThrows(FusionException.class,
-                     () ->  FusionValue.copyToIonValue(fv, system()));
+                     () ->  FusionValue.copyToIonValue(evaluator(), fv, system()));
     }
 
     @Test


### PR DESCRIPTION
## Description

Again, so we can pre-render exceptions using the Evaluator.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
