### PR TITLE
Add factory method for `ArgumentException`.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/ArgumentException.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ArgumentException.java
@@ -26,11 +26,12 @@ final class ArgumentException
             }
         };
 
-    static ArgumentException makeSanitizedException(ArgumentException e) {
+    static ArgumentException makeSanitizedException(Evaluator eval, ArgumentException e)
+    {
         Object[] values = new Object[e.myActuals.length];
         Arrays.fill(values, REDACTED_VALUE);
-        return new ArgumentException(
-            e.getName(), e.getExpectation(), e.getBadPos(), values);
+        return makeArgumentError(eval, e.getName(), e.getExpectation(),
+                                 e.getBadPos(), values);
     }
 
     private final String   myName;
@@ -39,13 +40,24 @@ final class ArgumentException
     private final Object[] myActuals;
 
 
+
     /**
      * @param badPos the zero-based index of the problematic value.
      *   -1 means a specific position isn't implicated.
      * @param actuals must not be null or zero-length.
      */
-    ArgumentException(String name, String expectation,
-                      int badPos, Object... actuals)
+    public static ArgumentException makeArgumentError(Evaluator eval, String name, String expectation, int badPos, Object... actuals)
+    {
+        return new ArgumentException(name, expectation, badPos, actuals);
+    }
+
+    /**
+     * @param badPos the zero-based index of the problematic value.
+     *   -1 means a specific position isn't implicated.
+     * @param actuals must not be null or zero-length.
+     */
+    private ArgumentException(String name, String expectation,
+                              int badPos, Object... actuals)
     {
         super("arg type failure");
         assert name != null && actuals.length != 0;
@@ -57,17 +69,6 @@ final class ArgumentException
         myExpectation = expectation;
         myBadPos = badPos;
         myActuals = actuals;
-    }
-
-    /**
-     * @param badPos the zero-based index of the problematic value.
-     *   -1 means a specific position isn't implicated.
-     * @param actual must not be null.
-     */
-    ArgumentException(String name, String expectation,
-                      int badPos, Object actual)
-    {
-        this(name, expectation, badPos, new Object[] { actual });
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionIterator.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionIterator.java
@@ -3,6 +3,7 @@
 
 package dev.ionfusion.fusion;
 
+import static dev.ionfusion.fusion.ArgumentException.makeArgumentError;
 import static dev.ionfusion.fusion.FusionBool.boolToJavaBoolean;
 import static dev.ionfusion.fusion.FusionBool.makeBool;
 import static dev.ionfusion.fusion.FusionList.isList;
@@ -49,7 +50,7 @@ class FusionIterator
             return unsafeSexpIterator(eval, value);
         }
 
-        throw new ArgumentException("iterate", "iterable", 0, value);
+        throw makeArgumentError(eval, "iterate", "iterable", 0, value);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionSexp.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionSexp.java
@@ -3,6 +3,7 @@
 
 package dev.ionfusion.fusion;
 
+import static dev.ionfusion.fusion.ArgumentException.makeArgumentError;
 import static dev.ionfusion.fusion.FusionBool.falseBool;
 import static dev.ionfusion.fusion.FusionBool.makeBool;
 import static dev.ionfusion.fusion.FusionBool.trueBool;
@@ -489,16 +490,16 @@ final class FusionSexp
                 back = ((BaseSequence) sequences[i]).sexpAppend(eval, back);
                 if (back == null)
                 {
-                    throw new ArgumentException("append", "proper sequence",
-                                                i+1, sequences[i]);
+                    throw makeArgumentError(eval, "append", "proper sequence",
+                                            i+1, sequences[i]);
                 }
             }
 
             BaseSexp result = sexpAppend(eval, back);
             if (result == null)
             {
-                throw new ArgumentException("append", "proper sequence",
-                                            0, this);
+                throw makeArgumentError(eval, "append", "proper sequence",
+                                        0, this);
             }
             return result;
         }
@@ -741,7 +742,7 @@ final class FusionSexp
                 return size;
             }
 
-            throw new ArgumentException("size", "proper sexp", 0, this);
+            throw makeArgumentError(eval, "size", "proper sexp", 0, this);
         }
 
         @Override
@@ -1172,8 +1173,8 @@ final class FusionSexp
             }
             catch (ClassCastException e)
             {
-                throw new ArgumentException("iterator_next", "proper sexp",
-                                            0, this);
+                throw makeArgumentError(eval, "iterator_next", "proper sexp",
+                                        0, this);
             }
         }
     }

--- a/runtime/src/main/java/dev/ionfusion/fusion/Procedure.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Procedure.java
@@ -3,6 +3,8 @@
 
 package dev.ionfusion.fusion;
 
+import static dev.ionfusion.fusion.ArgumentException.makeArgumentError;
+
 import com.amazon.ion.util.IonTextUtils;
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import java.io.IOException;
@@ -218,7 +220,7 @@ abstract class Procedure
                                    int badPos,
                                    Object... actuals)
     {
-        return new ArgumentException(identify(), expectation, badPos, actuals);
+        return makeArgumentError(eval, identify(), expectation, badPos, actuals);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/RaiseArgumentErrorProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/RaiseArgumentErrorProc.java
@@ -3,9 +3,11 @@
 
 package dev.ionfusion.fusion;
 
+import static dev.ionfusion.fusion.ArgumentException.makeArgumentError;
 import static dev.ionfusion.fusion.FusionNumber.checkIntArgToJavaInt;
 import static dev.ionfusion.fusion.FusionString.checkRequiredStringArg;
 import static dev.ionfusion.fusion.FusionText.checkRequiredTextArg;
+
 import java.util.Arrays;
 
 
@@ -34,6 +36,6 @@ final class RaiseArgumentErrorProc
             badPos = -1;
         }
 
-        throw new ArgumentException(name, expected, badPos, actuals);
+        throw makeArgumentError(eval, name, expected, badPos, actuals);
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/Syntax.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Syntax.java
@@ -4,6 +4,8 @@
 package dev.ionfusion.fusion;
 
 
+import static dev.ionfusion.fusion.ArgumentException.makeArgumentError;
+
 import dev.ionfusion.runtime.base.SourceLocation;
 
 /**
@@ -86,10 +88,11 @@ final class Syntax
         {
             if (whosCalling == null) whosCalling = "datum_to_syntax";
 
-            throw new ArgumentException(whosCalling,
-                                        "syntax object or ionizable data",
-                                        -1,
-                                        datum);
+            throw makeArgumentError(eval,
+                                    whosCalling,
+                                    "syntax object or ionizable data",
+                                    -1,
+                                    datum);
         }
 
         return stx;

--- a/runtime/src/test/java/dev/ionfusion/fusion/ArgumentExceptionTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/ArgumentExceptionTest.java
@@ -3,7 +3,9 @@
 
 package dev.ionfusion.fusion;
 
+import static dev.ionfusion.fusion.ArgumentException.makeArgumentError;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -18,10 +20,10 @@ public class ArgumentExceptionTest
     public void testSanitizedFactoryMethod()
         throws Exception
     {
-        ArgumentException exception = new ArgumentException(
-            "testSanitized", "nop", 0, "super secret data");
+        ArgumentException exception = makeArgumentError(evaluator(),
+                                                        "testSanitized", "nop", 0, "super secret data");
         ArgumentException sanitized =
-            ArgumentException.makeSanitizedException(exception);
+            ArgumentException.makeSanitizedException(evaluator(), exception);
 
         assertEquals(exception.getName(), sanitized.getName());
         assertEquals(exception.getExpectation(), sanitized.getExpectation());
@@ -39,11 +41,11 @@ public class ArgumentExceptionTest
     public void testSanitizedFactoryMethodWithMultiple()
         throws Exception
     {
-        ArgumentException exception = new ArgumentException(
-            "testSanitized", "nop", -1, "super secret data 1",
-            "super secret data 2", "super secret data 3");
+        ArgumentException exception = makeArgumentError(evaluator(),
+                                                        "testSanitized", "nop", -1, "super secret data 1",
+                                                        "super secret data 2", "super secret data 3");
         ArgumentException sanitized =
-            ArgumentException.makeSanitizedException(exception);
+            ArgumentException.makeSanitizedException(evaluator(), exception);
 
         assertEquals(exception.getName(), sanitized.getName());
         assertEquals(exception.getExpectation(), sanitized.getExpectation());


### PR DESCRIPTION
The name `makeArgumentError` aligns with the corresponding Fusion procedure.

## Description

Note that I'll likely rename the exception `class`es to align with the Fusion names, but in a later pass when they show up less frequently.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
