### PR TITLE
Refactor `LocalEnvironment` construction.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/DefineValuesForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/DefineValuesForm.java
@@ -11,6 +11,7 @@ import static dev.ionfusion.fusion.FusionSexp.unsafePairTail;
 import static dev.ionfusion.fusion.FusionString.isString;
 import static dev.ionfusion.fusion.FusionSyntax.unsafeSyntaxUnwrap;
 import static dev.ionfusion.fusion.GlobalState.DEFINE_VALUES;
+import static dev.ionfusion.fusion.SyntaxSymbol.ensureUniqueIdentifiers;
 
 /**
  * Implementation of the fundamental definition syntax form.
@@ -148,7 +149,7 @@ final class DefineValuesForm
 
         // Check for duplicate identifiers
         SyntaxSymbol[] ids = argSexp.extract(eval, SyntaxSymbol.class);
-        SyntaxSymbol.ensureUniqueIdentifiers(ids, formChecker.form());
+        ensureUniqueIdentifiers(eval, ids, formChecker.form());
         return ids;
     }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/LambdaForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/LambdaForm.java
@@ -5,6 +5,7 @@ package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionSexp.immutableSexp;
 import static dev.ionfusion.fusion.FusionString.isString;
+import static dev.ionfusion.fusion.SyntaxSymbol.ensureUniqueIdentifiers;
 import static dev.ionfusion.fusion._private.FusionUtils.EMPTY_STRING_ARRAY;
 
 /**
@@ -58,7 +59,8 @@ final class LambdaForm
         SyntaxWrap localWrap = null;
         if (args.length != 0)
         {
-            env = new LocalEnvironment(env, args, stx);
+            ensureUniqueIdentifiers(eval, args, stx);
+            env = new LocalEnvironment(env, args);
             localWrap = new EnvironmentWrap(env);
         }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/LetValuesForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/LetValuesForm.java
@@ -4,6 +4,7 @@
 package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.ResultFailure.makeResultError;
+import static dev.ionfusion.fusion.SyntaxSymbol.ensureUniqueIdentifiers;
 
 import dev.ionfusion.runtime.base.SourceLocation;
 import java.util.ArrayList;
@@ -62,7 +63,8 @@ final class LetValuesForm
         else
         {
             boundNames = boundNameList.toArray(SyntaxSymbol.EMPTY_ARRAY);
-            bodyEnv = new LocalEnvironment(env, boundNames, stx);
+            ensureUniqueIdentifiers(eval, boundNames, stx);
+            bodyEnv = new LocalEnvironment(env, boundNames);
             localWrap = new EnvironmentWrap(bodyEnv);
         }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/LetrecForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/LetrecForm.java
@@ -4,6 +4,7 @@
 package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionValue.UNDEF;
+import static dev.ionfusion.fusion.SyntaxSymbol.ensureUniqueIdentifiers;
 
 import dev.ionfusion.runtime.base.SourceLocation;
 import java.util.Arrays;
@@ -33,8 +34,9 @@ final class LetrecForm
             checkPair.arityExact(2);
             boundNames[i] = checkPair.requiredIdentifier("bound name", 0);
         }
+        ensureUniqueIdentifiers(eval, boundNames, stx);
 
-        Environment bodyEnv = new LocalEnvironment(env, boundNames, stx);
+        Environment bodyEnv = new LocalEnvironment(env, boundNames);
         SyntaxWrap localWrap = new EnvironmentWrap(bodyEnv);
 
         // Expand the bound-value expressions

--- a/runtime/src/main/java/dev/ionfusion/fusion/LocalEnvironment.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/LocalEnvironment.java
@@ -5,7 +5,6 @@ package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.BindingSite.makeLocalBindingSite;
 import static dev.ionfusion.fusion.FusionVoid.voidValue;
-import static dev.ionfusion.fusion.SyntaxSymbol.ensureUniqueIdentifiers;
 import static dev.ionfusion.fusion._private.FusionUtils.EMPTY_STRING_ARRAY;
 
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
@@ -130,15 +129,9 @@ final class LocalEnvironment
 
     /**
      * Expand-time environment construction.
-     *
-     * @throws FusionException if there's a duplicate identifier.
      */
-    LocalEnvironment(Environment enclosure,
-                     SyntaxSymbol[] identifiers,
-                     SyntaxValue formForErrors)
-        throws FusionException
+    LocalEnvironment(Environment enclosure, SyntaxSymbol[] identifiers)
     {
-        assert formForErrors != null;
         myEnclosure = enclosure;
         myNamespace = enclosure.namespace();
         myDepth = 1 + enclosure.getDepth();
@@ -147,11 +140,6 @@ final class LocalEnvironment
         //   85% of local envs have 1 entry, 12% have 2.
         //   99% have 3 or fewer entries and none have more than 5.
         int count = identifiers.length;
-        if (count > 1)
-        {
-            ensureUniqueIdentifiers(identifiers, formForErrors);
-        }
-
         myBindings = new LocalBinding[count];
         for (int i = 0; i < count; i++)
         {

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSymbol.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSymbol.java
@@ -358,17 +358,21 @@ final class SyntaxSymbol
 
     /**
      * Verifies that a set of identifiers are unique with respect to
-     * {@link #boundIdentifierEqual)}.
+     * {@link #boundIdentifierEqual}.
      *
+     * @param eval
      * @param identifiers must not be null.
      * @param formForErrors the syntax form to be implicated in error messages.
      *
      * @throws SyntaxException if a duplicate is found.
      */
-    static void ensureUniqueIdentifiers(SyntaxSymbol[] identifiers,
+    static void ensureUniqueIdentifiers(Evaluator      eval,
+                                        SyntaxSymbol[] identifiers,
                                         SyntaxValue    formForErrors)
         throws SyntaxException
     {
+        if (identifiers.length <= 1) return;
+
         // TODO Avoid a hashmap when count==2, do a simple comparison.
         BoundIdMap<SyntaxSymbol> ids = new BoundIdMap<>();
         for (SyntaxSymbol id : identifiers)


### PR DESCRIPTION
This avoids it needing evaluation to print error messages.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
