### PR TITLE
Remove unused Fusion iterator that injects values.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionIterator.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionIterator.java
@@ -59,7 +59,6 @@ class FusionIterator
      * Builds a Fusion iterator from a Java iterator, without injecting its
      * elements.
      *
-     * @see #injectIterator(Evaluator, Iterator)
      * @see #injectIonIterator(Evaluator, Iterator)
      */
     static FusionIterator iterate(Evaluator eval, Iterator<?> iterator)
@@ -68,24 +67,9 @@ class FusionIterator
     }
 
 
-
-    /**
-     * Builds a Fusion iterator from a Java iterator, lazily injecting each
-     * value.
-     *
-     * @see #iterate(Evaluator, Iterator)
-     * @see #injectIonIterator(Evaluator, Iterator)
-     */
-    static Object injectIterator(Evaluator eval, Iterator<?> iterator)
-    {
-        return new InjectingIteratorAdaptor(iterator);
-    }
-
-
     /**
      * Builds a Fusion iterator from an IonValue iterator, lazily injecting
-     * each {@code IonValue}.  This is slightly more efficient than
-     * {@link FusionIterator#injectIterator(Evaluator, Iterator)}.
+     * each {@code IonValue}.
      */
     static Object injectIonIterator(Evaluator eval,
                                     Iterator<IonValue> iterator)
@@ -233,30 +217,6 @@ class FusionIterator
             {
                 throw new ContractException("iterator_next: no such element");
             }
-        }
-    }
-
-
-    /** Custom class avoid some dynamic dispatch. */
-    private static final class InjectingIteratorAdaptor
-        extends IteratorAdaptor
-    {
-        InjectingIteratorAdaptor(Iterator<?> iter)
-        {
-            super(iter);
-        }
-
-        @Override
-        public Object next(Evaluator eval)
-            throws FusionException
-        {
-            Object orig = myIterator.next();
-            Object injected = eval.injectMaybe(orig);
-            if (injected == null)
-            {
-                throw makeResultError(eval, "iterator_next", "injectable Java type", orig);
-            }
-            return injected;
         }
     }
 

--- a/runtime/src/test/java/dev/ionfusion/fusion/IteratorTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/IteratorTest.java
@@ -3,11 +3,6 @@
 
 package dev.ionfusion.fusion;
 
-import static dev.ionfusion.fusion.FusionIterator.injectIonIterator;
-import static dev.ionfusion.fusion.FusionIterator.injectIterator;
-import com.amazon.ion.IonList;
-import dev.ionfusion.runtime.embed.TopLevel;
-import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 
@@ -74,51 +69,5 @@ public class IteratorTest
 
         expectContractExn("(iterator_map_splicing 1 empty_iterator)");
         expectContractExn("(iterator_map_splicing value_iterator [])");
-    }
-
-
-    //========================================================================
-    // Injection APIs
-
-    private static final String ITER_HAS_NEXT = "(iterator_has_next iter)";
-    private static final String ITER_NEXT = "(iterator_next iter)";
-
-    @Test
-    public void testIteratorInjecting()
-        throws Exception
-    {
-        ArrayList<Object> list = new ArrayList<>();
-        list.add("str");
-        list.add(12);
-        list.add(null);
-
-        TopLevel top = topLevel();
-        top.define("iter", injectIterator(null, list.iterator()));
-        assertString("str", ITER_NEXT);
-        assertEval(12, ITER_NEXT);
-        assertVoid(ITER_NEXT);
-        assertEval(false, ITER_HAS_NEXT);
-    }
-
-    @Test
-    public void testIonIteratorInjecting()
-        throws Exception
-    {
-        IonList list = (IonList) system().singleValue("['''str''', 12, null]");
-
-        TopLevel top = topLevel();
-        top.define("iter", injectIterator(null, list.iterator()));
-        assertEval(true, ITER_HAS_NEXT);
-        assertString("str", ITER_NEXT);
-        assertEval(12, ITER_NEXT);
-        assertEval("null.null", ITER_NEXT);
-        assertEval(false, ITER_HAS_NEXT);
-
-        top.define("iter", injectIonIterator(null, list.iterator()));
-        assertEval(true, ITER_HAS_NEXT);
-        assertString("str", ITER_NEXT);
-        assertEval(12, ITER_NEXT);
-        assertEval("null.null", ITER_NEXT);
-        assertEval(false, ITER_HAS_NEXT);
     }
 }


### PR DESCRIPTION
## Notes

I'd really like to git rid of all of this Fusion iterator stuff, at least Java-side.  This is very old and not functional (and thus not recommended).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
