### PR TITLE
Add factory methods for syntax errors.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/AmbiguousBindingFailure.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/AmbiguousBindingFailure.java
@@ -13,23 +13,41 @@ import static com.amazon.ion.util.IonTextUtils.printQuotedSymbol;
 final class AmbiguousBindingFailure
     extends SyntaxException
 {
-    public AmbiguousBindingFailure(String whatForm, String identifier)
+    private AmbiguousBindingFailure(String message)
     {
-        super(whatForm,
-              "The identifier " + printQuotedSymbol(identifier) +
-              " is already defined or imported from elsewhere");
+        super(message);
+    }
+
+
+    /**
+     * @param location may be null.
+     */
+    static AmbiguousBindingFailure makeAmbiguousBindingError(String whatForm,
+                                                             String identifier,
+                                                             SyntaxValue location)
+    {
+        String details = "The identifier " + printQuotedSymbol(identifier) +
+                         " is already defined or imported from elsewhere";
+        String message = composeMessage(whatForm, details);
+
+        AmbiguousBindingFailure e = new AmbiguousBindingFailure(message);
+        if (location != null)
+        {
+            e.addContext(location.getLocation());
+        }
+        return e;
     }
 
     /**
-     * @param expr may be null.
+     * @param location is not part of the error message, but supplies the
+     * innermost stack location; may be null.
      */
-    public AmbiguousBindingFailure(String whatForm, String identifier,
-                                   SyntaxValue expr)
+    static AmbiguousBindingFailure makeAmbiguousBindingError(String whatForm,
+                                                             SyntaxSymbol identifier,
+                                                             SyntaxValue location)
     {
-        this(whatForm, identifier);
-        if (expr != null)
-        {
-            addContext(expr.getLocation());
-        }
+        return makeAmbiguousBindingError(whatForm,
+                                         identifier.stringValue(),
+                                         location);
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/Compiler.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Compiler.java
@@ -20,6 +20,8 @@ import static dev.ionfusion.fusion.FusionValue.isAnyNull;
 import static dev.ionfusion.fusion.FusionVoid.isVoid;
 import static dev.ionfusion.fusion.FusionVoid.voidValue;
 import static dev.ionfusion.fusion.LetValuesForm.compilePlainLet;
+import static dev.ionfusion.fusion.SyntaxException.makeSyntaxError;
+import static dev.ionfusion.fusion.UnboundIdentifierException.makeUnboundError;
 import static dev.ionfusion.fusion._private.FusionUtils.EMPTY_OBJECT_ARRAY;
 
 import dev.ionfusion.fusion.FusionSexp.BaseSexp;
@@ -269,8 +271,7 @@ class Compiler
                     "procedure expects " + lambda.myArgNames.length +
                     " arguments but application has " + argForms.length +
                     " expressions";
-                 throw new SyntaxException("procedure application", message,
-                                           stx);
+                 throw makeSyntaxError(myEval, "procedure application", message, stx);
             }
 
             SourceLocation[] argLocs = extractArgLocations(stx,
@@ -440,7 +441,7 @@ class Compiler
             @Override
             Object visit(FreeBinding b) throws FusionException
             {
-                throw new UnboundIdentifierException(identifier);
+                throw makeUnboundError(identifier);
             }
 
             @Override
@@ -544,7 +545,7 @@ class Compiler
             Object visit(LocalBinding b) throws FusionException
             {
                 String message = "#%top not implemented for local binding.";
-                throw new SyntaxException("#%top", message, id);
+                throw makeSyntaxError(myEval, "#%top", message, id);
             }
 
             @Override
@@ -557,14 +558,14 @@ class Compiler
             Object visit(ModuleDefinedBinding b) throws FusionException
             {
                 String message = "#%top not implemented for module binding.";
-                throw new SyntaxException("#%top", message, id);
+                throw makeSyntaxError(myEval, "#%top", message, id);
             }
 
             @Override
             Object visit(RequiredBinding b) throws FusionException
             {
                 String message = "#%top not implemented for imported binding.";
-                throw new SyntaxException("#%top", message, id);
+                throw makeSyntaxError(myEval, "#%top", message, id);
             }
         };
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/Expander.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Expander.java
@@ -4,6 +4,7 @@
 package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionValue.isAnnotated;
+import static dev.ionfusion.fusion.SyntaxException.makeSyntaxError;
 
 /**
  * "Registers" used during macro expansion
@@ -75,7 +76,7 @@ final class Expander
             String message =
                 "Annotations not supported in raw syntax. You probably " +
                 "want to quote this.";
-            throw new SyntaxException(null, message, stx);
+            throw makeSyntaxError(myEval, null, message, stx);
         }
 
         return stx.doExpand(this, env);

--- a/runtime/src/main/java/dev/ionfusion/fusion/LoadHandler.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/LoadHandler.java
@@ -7,6 +7,7 @@ import static dev.ionfusion.fusion.FusionEval.callCurrentEval;
 import static dev.ionfusion.fusion.FusionString.makeString;
 import static dev.ionfusion.fusion.GlobalState.MODULE;
 import static dev.ionfusion.fusion.StandardReader.readSyntax;
+import static dev.ionfusion.fusion.SyntaxException.makeSyntaxError;
 
 import com.amazon.ion.IonException;
 import com.amazon.ion.IonReader;
@@ -104,8 +105,7 @@ final class LoadHandler
         if (reader.getType() == null && reader.next() == null)
         {
             String message = "Module source has no top-level forms";
-            SyntaxException e =
-                new SyntaxException(null /* syntax form */, message);
+            SyntaxException e = makeSyntaxError(message);
             e.addContext(SourceLocation.forName(sourceName));
             throw e;
         }
@@ -114,8 +114,7 @@ final class LoadHandler
         if (reader.next() != null)
         {
             String message = "Module source has more than one top-level form";
-            SyntaxException e =
-                new SyntaxException(null /* syntax form */, message);
+            SyntaxException e = makeSyntaxError(message);
             e.addContext(SourceLocation.forCurrentSpan(reader, sourceName));
             throw e;
         }
@@ -136,7 +135,7 @@ final class LoadHandler
         catch (ClassCastException e) { /* fall through */ }
 
         String message = "Top-level form isn't (module ...)";
-        throw new SyntaxException(null /* syntax form */, message, firstTopLevel);
+        throw makeSyntaxError(eval, null /* syntax form */, message, firstTopLevel);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/MacroForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/MacroForm.java
@@ -4,6 +4,7 @@
 package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionIo.safeWriteToString;
+import static dev.ionfusion.fusion.SyntaxException.makeSyntaxError;
 
 /**
  * Runtime representation of Fusion macros, performing syntax expansion.
@@ -71,6 +72,8 @@ final class MacroForm
     private SyntaxValue doExpandOnce(Expander expander, SyntaxSexp stx)
         throws FusionException
     {
+        Evaluator eval = expander.getEvaluator();
+
         Object expanded;
         try
         {
@@ -84,7 +87,7 @@ final class MacroForm
             // http://docs.racket-lang.org/reference/syntax-model.html#(part._expand-steps)
 
             // But BEWARE: this is called during partial expansion!
-            expanded = expander.getEvaluator().callNonTail(myTransformer, stx);
+            expanded = eval.callNonTail(myTransformer, stx);
         }
         catch (FusionException e)
         {
@@ -100,9 +103,8 @@ final class MacroForm
         {
             String message =
                 "Transformer returned non-syntax result: " +
-                safeWriteToString(expander.getEvaluator(), expanded);
-            throw new SyntaxException(myTransformer.identify(), message,
-                                      stx);
+                safeWriteToString(eval, expanded);
+            throw makeSyntaxError(eval, myTransformer.identify(), message, stx);
         }
     }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/ModuleForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ModuleForm.java
@@ -13,6 +13,7 @@ import static dev.ionfusion.fusion.FusionString.unsafeStringToJavaString;
 import static dev.ionfusion.fusion.FusionSyntax.unsafeSyntaxUnwrap;
 import static dev.ionfusion.fusion.FusionVoid.voidValue;
 import static dev.ionfusion.fusion.GlobalState.PROVIDE;
+import static dev.ionfusion.fusion.SyntaxException.makeSyntaxError;
 import static dev.ionfusion.runtime.base.ModuleIdentity.isValidAbsoluteModulePath;
 import static dev.ionfusion.runtime.base.ModuleIdentity.isValidModuleName;
 import static dev.ionfusion.runtime.base.ModuleIdentity.isValidModulePath;
@@ -429,9 +430,7 @@ final class ModuleForm
     {
         if (! isValidModuleName(moduleNameSymbol.stringValue()))
         {
-            throw new SyntaxException("declared module name",
-                                      "Expected a valid module name",
-                                      moduleNameSymbol);
+            throw makeSyntaxError(eval, "module", "invalid module name", moduleNameSymbol);
         }
 
         // When the module name resolver loads a module from a repository, as

--- a/runtime/src/main/java/dev/ionfusion/fusion/ModuleNameResolver.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ModuleNameResolver.java
@@ -9,6 +9,7 @@ import static dev.ionfusion.fusion.FusionSexp.unsafePairTail;
 import static dev.ionfusion.fusion.FusionSexp.unsafeSexpToJavaList;
 import static dev.ionfusion.fusion.FusionText.isText;
 import static dev.ionfusion.fusion.FusionText.unsafeTextToJavaString;
+import static dev.ionfusion.fusion.SyntaxException.makeSyntaxError;
 import static dev.ionfusion.runtime.base.ModuleIdentity.isValidAbsoluteModulePath;
 import static dev.ionfusion.runtime.base.ModuleIdentity.isValidModulePath;
 
@@ -132,7 +133,7 @@ final class ModuleNameResolver
             return resolveModulePath(eval, baseModule, path, load, pathStx);
         }
 
-        throw new SyntaxException("module path", "unrecognized form", pathStx);
+        throw makeSyntaxError(eval, "module path", "unrecognized form", pathStx);
     }
 
 
@@ -180,7 +181,7 @@ final class ModuleNameResolver
         if (! isValidModulePath(modulePath))
         {
             String message = "Invalid module path: " + printString(modulePath);
-            throw new SyntaxException(null, message, stxForErrors);
+            throw makeSyntaxError(eval, null, message, stxForErrors);
         }
 
         ModuleRegistry reg = eval.findCurrentNamespace().getRegistry();

--- a/runtime/src/main/java/dev/ionfusion/fusion/ModuleNamespace.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ModuleNamespace.java
@@ -3,8 +3,10 @@
 
 package dev.ionfusion.fusion;
 
+import static dev.ionfusion.fusion.AmbiguousBindingFailure.makeAmbiguousBindingError;
 import static dev.ionfusion.fusion.BindingSite.makeExportBindingSite;
 import static dev.ionfusion.fusion.GlobalState.REQUIRE;
+import static dev.ionfusion.fusion.UnboundIdentifierException.makeUnboundError;
 
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.runtime.base.ModuleIdentity;
@@ -201,9 +203,8 @@ final class ModuleNamespace
                                   SyntaxValue formForErrors)
             throws AmbiguousBindingFailure
         {
-            String name = identifier.stringValue();
-            throw new AmbiguousBindingFailure("module-level definition",
-                                              name, formForErrors);
+            throw makeAmbiguousBindingError("module-level definition",
+                                            identifier, formForErrors);
         }
 
         @Override
@@ -213,9 +214,7 @@ final class ModuleNamespace
             throws AmbiguousBindingFailure
         {
             if (this.sameTarget(provided)) return this;
-
-            String name = localId.stringValue();
-            throw new AmbiguousBindingFailure(REQUIRE, name, formForErrors);
+            throw makeAmbiguousBindingError(REQUIRE, localId, formForErrors);
         }
 
         @Override
@@ -324,8 +323,7 @@ final class ModuleNamespace
             throws AmbiguousBindingFailure
         {
             // A definition already exists, we can't redefine.
-            String name = identifier.stringValue();
-            throw new AmbiguousBindingFailure(null, name, formForErrors);
+            throw makeAmbiguousBindingError(null, identifier, formForErrors);
         }
 
         @Override
@@ -335,8 +333,7 @@ final class ModuleNamespace
             throws AmbiguousBindingFailure
         {
             // A definition already exists, we can't require the same id.
-            String name = localId.stringValue();
-            throw new AmbiguousBindingFailure(null, name, formForErrors);
+            throw makeAmbiguousBindingError(null, localId, formForErrors);
         }
 
         @Override
@@ -622,7 +619,7 @@ final class ModuleNamespace
             BaseSymbol name = ns.getDefinedName(myAddress);
             SyntaxSymbol id = SyntaxSymbol.make(myLocation, name);
 
-            throw new UnboundIdentifierException(id);
+            throw makeUnboundError(id);
         }
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/Namespace.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Namespace.java
@@ -10,6 +10,7 @@ import static dev.ionfusion.fusion.FusionSymbol.makeSymbol;
 import static dev.ionfusion.fusion.FusionVoid.voidValue;
 import static dev.ionfusion.fusion.NamedValue.inferObjectName;
 import static dev.ionfusion.fusion.ResultFailure.makeResultError;
+import static dev.ionfusion.fusion.UnboundIdentifierException.makeUnboundError;
 
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.fusion.ModuleNamespace.ModuleDefinedBinding;
@@ -743,7 +744,7 @@ abstract class Namespace
                 //   the unbound id so it reports the entire require form (when
                 //   this gets wrapped.
                 SyntaxSymbol sym = SyntaxSymbol.make(null, exportedId);
-                throw new UnboundIdentifierException(sym);
+                throw makeUnboundError(sym);
             }
 
             installRequiredBinding(eval, mapping.myLocalIdentifier, provided);

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxChecker.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxChecker.java
@@ -4,6 +4,7 @@
 package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionValue.isAnyNull;
+import static dev.ionfusion.fusion.SyntaxException.makeSyntaxError;
 
 
 /**
@@ -56,12 +57,12 @@ class SyntaxChecker
 
     SyntaxException failure(String message)
     {
-        return new SyntaxException(myFormName, message, myForm);
+        return makeSyntaxError(myEvaluator, myFormName, message, myForm);
     }
 
     SyntaxException failure(String message, SyntaxValue subform)
     {
-        SyntaxException e = new SyntaxException(myFormName, message, subform);
+        SyntaxException e = makeSyntaxError(myEvaluator, myFormName, message, subform);
         e.addContext(myForm.getLocation());
         return e;
     }
@@ -254,7 +255,7 @@ class SyntaxChecker
         SyntaxException failure(String message)
         {
             SyntaxException e =
-                new SyntaxException(myBaseForm.myFormName, message, myForm);
+                makeSyntaxError(myEvaluator, myBaseForm.myFormName, message, myForm);
             e.addContext(myBaseForm.myForm.getLocation());
             return e;
         }
@@ -263,7 +264,7 @@ class SyntaxChecker
         SyntaxException failure(String message, SyntaxValue subform)
         {
             SyntaxException e =
-                new SyntaxException(myBaseForm.myFormName, message, subform);
+                makeSyntaxError(myEvaluator, myBaseForm.myFormName, message, subform);
             e.addContext(myBaseForm.myForm.getLocation());
             return e;
         }

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxKeyword.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxKeyword.java
@@ -3,6 +3,7 @@
 
 package dev.ionfusion.fusion;
 
+import static dev.ionfusion.fusion.SyntaxException.makeSyntaxError;
 import static dev.ionfusion.fusion._private.FusionUtils.EMPTY_OBJECT_ARRAY;
 
 import com.amazon.ion.IonException;
@@ -83,10 +84,10 @@ final class SyntaxKeyword
 
 
     @Override
-    SyntaxValue doExpand(Expander eval, Environment env)
+    SyntaxValue doExpand(Expander expander, Environment env)
         throws SyntaxException
     {
-        throw new SyntaxException(null, "Keywords are not expressions", this);
+        throw makeSyntaxError(expander.getEvaluator(), null, "Keywords are not expressions", this);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSexp.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSexp.java
@@ -15,6 +15,7 @@ import static dev.ionfusion.fusion.FusionSexp.unsafePairDot;
 import static dev.ionfusion.fusion.FusionSexp.unsafePairHead;
 import static dev.ionfusion.fusion.FusionSexp.unsafePairTail;
 import static dev.ionfusion.fusion.FusionSexp.unsafeSexpSize;
+import static dev.ionfusion.fusion.SyntaxException.makeSyntaxError;
 
 import com.amazon.ion.IonWriter;
 import dev.ionfusion.fusion.FusionSexp.BaseSexp;
@@ -517,7 +518,7 @@ final class SyntaxSexp
         {
             String message =
                 "not a valid syntactic form. You probably want to quote this.";
-            throw new SyntaxException(null, message, this);
+            throw makeSyntaxError(eval, null, message, this);
         }
 
         SyntacticForm form = syntaxForm(eval, env);
@@ -573,7 +574,7 @@ final class SyntaxSexp
         {
             String message =
                 "not a valid syntactic form. You probably want to quote this.";
-            throw new SyntaxException(null, message, this);
+            throw makeSyntaxError(eval, null, message, this);
         }
 
         SyntaxValue first = get(eval, 0); // calls pushAnyWraps()

--- a/runtime/src/main/java/dev/ionfusion/fusion/TopForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/TopForm.java
@@ -4,6 +4,8 @@
 package dev.ionfusion.fusion;
 
 
+import static dev.ionfusion.fusion.UnboundIdentifierException.makeUnboundError;
+
 /**
  * Implementation of {@code #%top}, which is introduced when identifiers are
  * macro-expanded in a scope where the identifier is not bound.
@@ -80,7 +82,7 @@ final class TopForm
                 }
             }
 
-            throw new UnboundIdentifierException(id);
+            throw makeUnboundError(id);
         }
 
         children[1] = id;

--- a/runtime/src/main/java/dev/ionfusion/fusion/TopLevelNamespace.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/TopLevelNamespace.java
@@ -6,6 +6,7 @@ package dev.ionfusion.fusion;
 import static dev.ionfusion.fusion.FusionVoid.voidValue;
 import static dev.ionfusion.fusion.NamedValue.inferObjectName;
 import static dev.ionfusion.fusion.ResultFailure.makeResultError;
+import static dev.ionfusion.fusion.UnboundIdentifierException.makeUnboundError;
 
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.fusion.ModuleNamespace.ProvidedBinding;
@@ -423,7 +424,7 @@ final class TopLevelNamespace
                         NsDefinedBinding binding = ns.resolveDefinition(myId);
                         if (binding == null)
                         {
-                            throw new UnboundIdentifierException(myId);
+                            throw makeUnboundError(myId);
                         }
 
                         myAddress = binding.myAddress;

--- a/runtime/src/main/java/dev/ionfusion/fusion/UnboundIdentifierException.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/UnboundIdentifierException.java
@@ -3,7 +3,7 @@
 
 package dev.ionfusion.fusion;
 
-import com.amazon.ion.util.IonTextUtils;
+import static com.amazon.ion.util.IonTextUtils.printQuotedSymbol;
 
 /**
  * Indicates a reference to an unbound identifier.
@@ -16,19 +16,26 @@ public final class UnboundIdentifierException
 
 
     /**
-     * @param identifier must not be null.
+     * @param name must not be null.
      */
-    UnboundIdentifierException(SyntaxSymbol identifier)
+    private UnboundIdentifierException(String message, String name)
     {
-        super(null, "", identifier);
-        myText = identifier.stringValue();
+        super(message);
+        myText = name;
     }
 
-    @Override
-    String getBaseMessage()
+
+    static UnboundIdentifierException makeUnboundError(SyntaxSymbol identifier)
     {
-        return "unbound identifier. The symbol " + IonTextUtils.printQuotedSymbol(myText) +
-                   " has no binding where it's used, so check for correct spelling and imports.";
+        String name = identifier.stringValue();
+        String details =
+            "unbound identifier. The symbol " + printQuotedSymbol(name) +
+            " has no binding where it's used, so check for correct spelling and imports.";
+        String message = composeMessage(details);
+
+        UnboundIdentifierException e = new UnboundIdentifierException(message, name);
+        e.addContext(identifier.getLocation());
+        return e;
     }
 
     /**

--- a/runtime/src/main/java/dev/ionfusion/fusion/WrongSyntaxProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/WrongSyntaxProc.java
@@ -4,6 +4,7 @@
 package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionIo.safeDisplayManyToString;
+import static dev.ionfusion.fusion.SyntaxException.makeSyntaxError;
 
 /**
  * Fusion procedure to raise a syntax error.
@@ -21,6 +22,6 @@ final class WrongSyntaxProc
         String name = null; // TODO infer name
         String message = safeDisplayManyToString(eval, args, 1);
 
-        throw new SyntaxException(name, message, stx);
+        throw makeSyntaxError(eval, name, message, stx);
     }
 }


### PR DESCRIPTION
Covers `SyntaxException`, `AmbiguousBindingFailure`, and `UnboundIdentifierException`.

## Description

This one is a bit more complicated since these classes are coupled in how they compose messages.  Sorry, I couldn't figure out how to tease out smaller PRs without a lot of work.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
