### PR TITLE
Configure Gradle `build` task to work like `release`.

### DIFF
--- a/buildSrc/src/main/kotlin/buildlogic.java-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.java-common-conventions.gradle.kts
@@ -41,3 +41,9 @@ tasks.named<Test>("test") {
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()
 }
+
+// Temporary alias until we migrate tooling
+// TODO https://github.com/ion-fusion/fusion-java/issues/429
+tasks.register("release") {
+    dependsOn(tasks.build)  // build depends on assemble & check
+}

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -160,7 +160,7 @@ val fcovTestReport = tasks.register<JavaExec>("fcovTestReport") {
 }
 
 
-// Signal to test task to collect coverage data.
+// Signal the test task to collect Fusion coverage data.
 var fcovRunning = false
 gradle.taskGraph.whenReady {
     fcovRunning = hasTask(fcovTestReport.get())
@@ -195,10 +195,7 @@ tasks.javadoc {
 //=============================================================================
 // Distribution
 
-// Gradle doesn't seem to have an equivalent "do everything" task.
-tasks.register("release") {
-    group = "Build"
-    description = "Build all artifacts and reports"
-
-    dependsOn(tasks.build, tasks.jacocoTestReport, fcovTestReport)
+tasks.build {
+    // To speed up the dev workflow, only enable FCOV when doing a full build.
+    dependsOn(tasks.jacocoTestReport, fcovTestReport)
 }

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -120,15 +120,3 @@ distributions {
         }
     }
 }
-
-
-//=============================================================================
-// Distribution
-
-// Gradle doesn't seem to have an equivalent "do everything" task.
-tasks.register("release") {
-    group = "Build"
-    description = "Build all artifacts and reports"
-
-    dependsOn(tasks.assemble, tasks.check)
-}


### PR DESCRIPTION
Fixes #430

## Description

Per the linked issue, I'd like to get rid of the legacy `release` task.  This enables migration of other components before we do so.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
