### PR TITLE
Update CI and docs to use Gradle `build` target.

### DIFF
--- a/.github/workflows/pr-build-dependency-graph.yml
+++ b/.github/workflows/pr-build-dependency-graph.yml
@@ -41,7 +41,7 @@ jobs:
       uses: gradle/actions/setup-gradle@v4
 
     - name: Build with Gradle Wrapper
-      run: ./gradlew release
+      run: ./gradlew build
 
   generate-dependency-graph:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-gradle-ci.yml
+++ b/.github/workflows/push-gradle-ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     # Run build
     - name: Build with Gradle Wrapper
-      run: ./gradlew release
+      run: ./gradlew build
 
     # Upload an artifact release for later jobs to consume
     - name: Upload distribution

--- a/sdk/src/doc/articles/howto_build.md
+++ b/sdk/src/doc/articles/howto_build.md
@@ -14,19 +14,19 @@ Building from source should be straightforward:
 
     git clone https://github.com/ion-fusion/fusion-java.git
     cd fusion-java
-    ./gradlew release
+    ./gradlew build
 
-After a successful release build, you'll have a basic SDK under `build/install/fusion`. The notable
-artifacts within that directory are:
+After a successful build, you'll have a basic SDK under `sdk/build/install/ion-fusion-sdk`.
+The notable artifacts within that directory are:
 
 * `bin/fusion` is the `fusion` CLI
-* `docs/fusiondoc/fusion.html` is the documentation for the Ion Fusion language
+* `docs/fusion.html` is the documentation for the Ion Fusion language
 * `docs/javadoc/index.html` is the documentation embedding Ion Fusion in your Java application
 * `lib` holds the jars needed for embedding
 
 To experiment with the CLI, add the `bin` to your path:
 
-    PATH=$PATH:$PWD/build/install/fusion/bin
+    PATH=$PATH:$PWD/sdk/build/install/ion-fusion-sdk/bin
     fusion help
 
 That should give you an overview of the CLI's subcommands.


### PR DESCRIPTION
Fix the build docs to reflect the new project layout.

Fixes #431

## Description

I've poked at our other repositories and don't think anything else invokes Gradle.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
