### PR TITLE
Print a link to the fcov report after a build.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/Cover.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/Cover.java
@@ -5,6 +5,7 @@ package dev.ionfusion.fusion.cli;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.nio.file.Path;
 
 /**
  *
@@ -77,10 +78,10 @@ class Cover
         {
             CoverageReportWriter renderer = new CoverageReportWriter(myDataDir);
 
-            renderer.renderFullReport(myReportDir);
+            Path index = renderer.renderFullReport(myReportDir);
 
             out.print("Wrote Fusion coverage report to ");
-            out.println(myReportDir.getPath());
+            out.println(index.toUri());
 
             return 0;
         }

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/CoverageReportWriter.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/CoverageReportWriter.java
@@ -667,10 +667,10 @@ public final class CoverageReportWriter
     }
 
 
-    private void renderIndex(File outputDir)
+    private void renderIndex(Path indexFile)
         throws IOException
     {
-        try (StreamWriter out = new StreamWriter(outputDir, "index.html"))
+        try (StreamWriter out = new StreamWriter(indexFile))
         {
             HtmlWriter indexHtml = new HtmlWriter(out);
             indexHtml.renderHeadWithInlineCss("Fusion Code Coverage", CSS);
@@ -699,7 +699,10 @@ public final class CoverageReportWriter
     }
 
 
-    public void renderFullReport(File outputDir)
+    /**
+     * @return the path of the index file.
+     */
+    public Path renderFullReport(File outputDir)
         throws FusionException, IOException
     {
         analyze();
@@ -707,6 +710,9 @@ public final class CoverageReportWriter
         prepareRelativeNames();
 
         renderSourceFiles(outputDir);
-        renderIndex(outputDir);
+
+        Path indexFile = outputDir.toPath().resolve("index.html");
+        renderIndex(indexFile);
+        return indexFile;
     }
 }

--- a/runtime/src/test/java/dev/ionfusion/fusion/cli/CoverTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/cli/CoverTest.java
@@ -4,10 +4,13 @@
 package dev.ionfusion.fusion.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
@@ -98,8 +101,9 @@ public class CoverTest
         // I'm surprised this works without any coverage data!
         run(0, "report_coverage", dataDir, reportDir);
         assertThat(stdoutText,
-                   containsString("Wrote Fusion coverage report to " + reportDir));
-        assertThat(stderrText, isEmptyString());
+                   allOf(containsString("Wrote Fusion coverage report to "),
+                         containsString(reportDir)));
+        assertThat(stderrText, is(emptyString()));
 
         assertTrue(new File(reportDir, "index.html").isFile());
     }


### PR DESCRIPTION
This makes it clickable from the shell.

Example:
```
> Task :runtime:fcovTestReport
Wrote Fusion coverage report to file:///Users/todd/src/fusion-java/runtime/build/reports/fcov/index.html
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
