### PR TITLE
Add `fusion report_coverage --configFile` option.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/Command.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/Command.java
@@ -362,6 +362,18 @@ abstract class Command
     }
 
 
+    /**
+     * Prepare a command executor based on the global options, any local options,
+     * and the remaining command-line arguments.
+     * <p>
+     * This implementation ignores the {@code options} and inkoves
+     * {@link #makeExecutor(GlobalOptions, String[])}.
+     *
+     * @return null if the arguments are inappropriate or insufficient.
+     *
+     * @throws UsageException if there are command-line errors preventing the
+     * command from being used.
+     */
     Executor makeExecutor(GlobalOptions globals,
                           Object        options,
                           String[]      arguments)

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/CoverageReportWriter.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/CoverageReportWriter.java
@@ -175,11 +175,11 @@ public final class CoverageReportWriter
     private boolean coverageState;
 
 
-    public CoverageReportWriter(Path dataDir)
-        throws FusionException, IOException
+    public CoverageReportWriter(CoverageConfiguration config,
+                                CoverageDatabase      database)
     {
-        myDatabase = new CoverageDatabase(dataDir);
-        myConfig   = CoverageConfiguration.forDataDir(dataDir);
+        myConfig   = config;
+        myDatabase = database;
 
         myModules                 = new HashSet<>();
         mySourceFiles             = new HashSet<>();


### PR DESCRIPTION
This allows the coverage report to be configured via a version-controlled file, shared across projects, etc. It should also let the report use different filtering than during collection runs.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
