### PR TITLE
Use a unique file per code coverage session.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionRuntimeBuilder.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionRuntimeBuilder.java
@@ -932,8 +932,8 @@ public class FusionRuntimeBuilder
                     fromDirectory(b.myCoverageDataDirectory);
 
                 // Register the active repositories with the collector.
-                // These are persisted in the coverage.ion file, so we can later
-                // scan them and identify files that haven't been covered.
+                // These are persisted in the coverage session, so the reporter
+                // can scan them and identify files that haven't been covered.
                 if (b.getBootstrapRepository() != null)
                 {
                     c.noteRepository(b.getBootstrapRepository());

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/Cover.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/Cover.java
@@ -120,7 +120,7 @@ class Cover
                 config = CoverageConfiguration.forDataDir(myDataDir);
             }
 
-            CoverageDatabase database = new CoverageDatabase(myDataDir);
+            CoverageDatabase database = CoverageDatabase.loadSessions(myDataDir);
 
             CoverageReportWriter renderer = new CoverageReportWriter(config, database);
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/CoverageReportWriter.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/CoverageReportWriter.java
@@ -335,8 +335,8 @@ public final class CoverageReportWriter
                     myModules.add(id);
 
                     SourceName prior = myNamesForModules.put(id, sourceName);
-                    assert prior == null || prior == sourceName :
-                        "SourceName instance has changed for module " + id;
+                    assert prior == null || prior.equals(sourceName) :
+                        "SourceName has changed for module " + id;
                 }
                 else
                 {
@@ -346,8 +346,8 @@ public final class CoverageReportWriter
                         mySourceFiles.add(f);
 
                         SourceName prior = myNamesForFiles.put(f, sourceName);
-                        assert prior == null || prior == sourceName :
-                            "SourceName instance has changed for file " + f +
+                        assert prior == null || prior.equals(sourceName) :
+                            "SourceName has changed for file " + f +
                                 "\nThis can happen if you `load` a module's file " +
                                 "within a registered repository.";
                     }

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollectorImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollectorImpl.java
@@ -336,8 +336,7 @@ public final class CoverageCollectorImpl
 
         CoverageConfiguration config =
             CoverageConfiguration.forDataDir(dataDir.toPath());
-        CoverageDatabase database =
-            new CoverageDatabase(dataDir.toPath());
+        CoverageDatabase database = CoverageDatabase.openSession(dataDir.toPath());
 
         collector = new CoverageCollectorImpl(config, database);
 


### PR DESCRIPTION
  * Move collected coverage data into `fcov/sessions/`.
  * Add factories for creating new sessions versus loading existing ones.
  * The report writer loads all of them by fixing a too-strict assert.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
