### PR TITLE
Revamp coverage collector interning and flushing.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionRuntimeBuilder.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionRuntimeBuilder.java
@@ -929,7 +929,7 @@ public class FusionRuntimeBuilder
             if (b.myCoverageDataDirectory != null)
             {
                 CoverageCollectorImpl c =
-                    fromDirectory(b.myCoverageDataDirectory);
+                    fromDirectory(b.myCoverageDataDirectory.toPath());
 
                 // Register the active repositories with the collector.
                 // These are persisted in the coverage session, so the reporter

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollectorImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollectorImpl.java
@@ -4,10 +4,13 @@
 package dev.ionfusion.runtime._private.cover;
 
 import dev.ionfusion.fusion._Private_CoverageCollector;
+import dev.ionfusion.fusion._private.InternMap;
 import dev.ionfusion.runtime.base.SourceLocation;
 import dev.ionfusion.runtime.embed.FusionRuntime;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Objects;
 
 /**
  * Implements code-coverage metrics collection.
@@ -26,15 +29,22 @@ import java.io.IOException;
 public final class CoverageCollectorImpl
     implements _Private_CoverageCollector
 {
+    /**
+     * TODO remove when {@link InternMap} supports direct key comparison.
+     * @see CoverageCollectorFactory#createSession(Path)
+     */
+    private final Path                  myDataDir;
     private final CoverageConfiguration myConfig;
 
     /** Where we store our metrics. */
     private final CoverageDatabase myDatabase;
 
 
-    CoverageCollectorImpl(CoverageConfiguration config,
+    CoverageCollectorImpl(Path                  dataDir,
+                          CoverageConfiguration config,
                           CoverageDatabase      database)
     {
+        myDataDir  = dataDir;
         myConfig   = config;
         myDatabase = database;
     }
@@ -86,5 +96,19 @@ public final class CoverageCollectorImpl
         {
             throw new IOException("Error writing Fusion coverage data", e);
         }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == null || getClass() != o.getClass()) { return false; }
+        CoverageCollectorImpl that = (CoverageCollectorImpl) o;
+        return Objects.equals(this.myDataDir, that.myDataDir);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(myDataDir);
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -37,17 +38,7 @@ import java.util.Set;
 
 
 /**
- * Records and persists coverage instrumentation data.
- * <p>
- * Instances are tied to a specific filesystem directory, and assumes full
- * control of its content.  In particular, no other process, and no other
- * {@code CoverageDatabase} instance, should access the directory until the
- * database is flushed via {@link #write()}.  This implies that instances need
- * to be interned or otherwise deduplicated, based on their physical directory.
- * At present, {@link CoverageCollectorImpl} implements these constraints.
- * <p>
- * TODO: The flushing protocol would be more obvious if this class implemented
- *       {@link java.io.Closeable}.
+ * Collects, reads, and writes coverage instrumentation data.
  */
 public class CoverageDatabase
 {
@@ -389,6 +380,19 @@ public class CoverageDatabase
                     writeSource(iw, name);
                 }
             }
+        }
+    }
+
+    void uncheckedWrite()
+        throws UncheckedIOException
+    {
+        try
+        {
+            write();
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/util/Flusher.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/util/Flusher.java
@@ -1,0 +1,177 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime._private.util;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Ensures that cleanup actions happen when an object is GCd or when the JVM shuts down.
+ * <p>
+ * Basically a simiplified version of the Java 11 {@code java.lang.ref.Cleaner}, with
+ * the addition of a shutdown hook for stronger cleanup guarantees.
+ */
+public final class Flusher
+{
+    /**
+     * Refs that still need to be flushed. To ensure the flush action is invoked only
+     * once, a ref must only be flushed immediately after removal from this queue!
+     */
+    private final ConcurrentLinkedQueue<FlushableRef> myUnflushedRefs =
+        new ConcurrentLinkedQueue<>();
+
+    private final Thread myShutdownHook;
+
+    private boolean myRegistrationOpen = true;
+
+    /**
+     * Refs that have become unreachable via GC. Polled by {@link #flushUnreachables()}.
+     */
+    private final ReferenceQueue<Object> myUnreachableRefs = new ReferenceQueue<>();
+
+
+    public Flusher(String nameOfThread)
+    {
+        Thread ourFlusherThread = new Thread(this::flushUnreachables, nameOfThread);
+        ourFlusherThread.setDaemon(true);
+        ourFlusherThread.start();
+        // The thread will stop itself when all refs are flushed.
+
+        myShutdownHook = new Thread(this::shutdown);
+        Runtime.getRuntime().addShutdownHook(myShutdownHook);
+        // Deregistered by flushUnreachables() if we are stopped.
+    }
+
+
+    /**
+     * Register an action to run when the object becomes phantom reachable.
+     *
+     * @param obj the object to monitor.
+     * @param action must not retain a reference to {@code toClean}!
+     */
+    public synchronized void register(Object obj, Runnable action)
+    {
+        if (myRegistrationOpen)
+        {
+            myUnflushedRefs.add(new FlushableRef(obj, action));
+        }
+        else
+        {
+            throw new IllegalStateException("Flusher is closed to registration.");
+        }
+    }
+
+
+    /**
+     * Disable all further registrations. Cleanup threads will keep running until all
+     * actions have been completed.
+     */
+    public synchronized void stop()
+    {
+        myRegistrationOpen = false;
+    }
+
+    public synchronized boolean stillRunning()
+    {
+        return myRegistrationOpen || !myUnflushedRefs.isEmpty();
+    }
+
+
+
+    private final class FlushableRef
+        extends PhantomReference<Object>
+    {
+        private final Runnable myAction;
+
+        private FlushableRef(Object obj, Runnable action)
+        {
+            super(obj, myUnreachableRefs);
+            myAction = action;
+        }
+
+        /**
+         * Deregisters the ref and runs the action.
+         */
+        private void flush()
+        {
+            if (myUnflushedRefs.remove(this))
+            {
+                myAction.run();
+            }
+        }
+    }
+
+
+    /**
+     * {@link Runnable} for the main flushing thread. Polls {@link #myUnreachableRefs}
+     * to flush items that have been garbage collected.
+     */
+    private void flushUnreachables()
+    {
+        while (stillRunning())
+        {
+            try
+            {
+                FlushableRef ref = (FlushableRef) myUnreachableRefs.remove(60 * 1000);
+                ref.flush();
+            }
+            catch (InterruptedException e)
+            {
+                // Thread is interrupted by stop() below.
+                break;
+            }
+            catch (Throwable e)
+            {
+                // Ignore and keep polling.
+            }
+        }
+
+        // All registered objects have been flushed, so we can remove the shutdown hook.
+        try
+        {
+            Runtime.getRuntime().removeShutdownHook(myShutdownHook);
+        }
+        catch (Throwable e)
+        {
+            // We don't care, just exit the thread.
+        }
+    }
+
+
+    /**
+     * JVM shutdown hook to ensure everything gets flushed.
+     * <p>
+     * Per {@link Runtime#addShutdownHook}, "daemon threads will continue to
+     * run during the shutdown sequence, as will non-daemon threads if shutdown
+     * was initiated by invoking the exit method."
+     * <p>
+     * This means that {@link #flushUnreachables()} may be simultaneously flushing
+     * entries.
+     */
+    private void shutdown()
+    {
+        // Ensure that no more objects are registered.
+        stop();
+
+        while (!myUnflushedRefs.isEmpty())
+        {
+            // DO NOT remove the ref from the set!
+            // That will prevent the action from firing.
+            FlushableRef ref = myUnflushedRefs.peek();
+            if (ref != null)
+            {
+                ref.clear();
+                try
+                {
+                    ref.flush(); // Removes itself from the queue
+                }
+                catch (Throwable e)
+                {
+                    // Ignore and keep polling.
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Here we separate the two concerns, making each one easier to handle:

* Use `InternMap` instead of rolling our own.
* Use a new `Flusher` for the auto-flushing.

The latter is a simplified version of Java 11 `Cleaner`, with the addition of shutdown handling.  The new implementation is much more straightforward than its predecessor, and hopefully easier to understand.

## Notes

* Please review `Flusher` carefully.  This logic is way better now, and it should be comprehensible.  I've commented judiciously but don't hesitate to ask questions.
* Probably easier to just read the streamlined `CoverageCollectorFactory` directly, the diff is useless and the new file is quite short now that all the nasty is removed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
