### PR TITLE
[editorconfig] Lower max line length from 100 to 88.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = true
-max_line_length = 100
+max_line_length = 88
 tab_width = 4
 trim_trailing_whitespace = true
 ij_continuation_indent_size = 8
@@ -12,7 +12,7 @@ ij_formatter_off_tag = @formatter:off
 ij_formatter_on_tag = @formatter:on
 ij_formatter_tags_enabled = true
 ij_smart_tabs = false
-ij_visual_guides = 79,100
+ij_visual_guides = 88
 ij_wrap_on_typing = false
 
 [*.css]
@@ -35,7 +35,7 @@ ij_css_use_double_quotes = true
 ij_css_value_alignment = do_not_align
 
 [*.java]
-max_line_length = 100
+max_line_length = 88
 ij_continuation_indent_size = 4
 ij_java_align_consecutive_assignments = false
 ij_java_align_consecutive_variable_declarations = true
@@ -411,9 +411,9 @@ ij_html_space_inside_empty_tag = false
 ij_html_text_wrap = normal
 
 [{*.markdown,*.md}]
-max_line_length = 100
+max_line_length = 88
 ij_continuation_indent_size = 4
-ij_visual_guides = 100
+ij_visual_guides = 88
 ij_wrap_on_typing = true
 ij_markdown_force_one_space_after_blockquote_symbol = true
 ij_markdown_force_one_space_after_header_symbol = true


### PR DESCRIPTION
Try as I might, I can't use 100 CPL comfortably.  In particular, it's too wide for side-by-side diffs in a reasonable viewport, and even on my widescreen display I need a huge window to get more than two files aside each other.

https://blog.glyph.im/2025/08/the-best-line-length.html

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
