### PR TITLE
Don't sort locations when writing `CoverageDatabase`.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
@@ -343,14 +343,14 @@ public class CoverageDatabase
     private void writeLocations(IonWriter iw, SourceName name)
         throws IOException
     {
-        SourceLocation[] locations = sortedLocations(name);
-        assert locations.length != 0;
-
         iw.stepIn(LIST);
         {
-            for (SourceLocation loc : locations)
+            for (SourceLocation loc : myLocations.keySet())
             {
-                writeLocation(iw, loc);
+                if (name.equals(loc.getSourceName()))
+                {
+                    writeLocation(iw, loc);
+                }
             }
         }
         iw.stepOut();


### PR DESCRIPTION
It's not necessary and wastes resources.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
