### PR TITLE
Share coverage sessions, not collectors.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollectorImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollectorImpl.java
@@ -4,13 +4,10 @@
 package dev.ionfusion.runtime._private.cover;
 
 import dev.ionfusion.fusion._Private_CoverageCollector;
-import dev.ionfusion.fusion._private.InternMap;
 import dev.ionfusion.runtime.base.SourceLocation;
 import dev.ionfusion.runtime.embed.FusionRuntime;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Objects;
 
 /**
  * Implements code-coverage metrics collection.
@@ -29,43 +26,36 @@ import java.util.Objects;
 public final class CoverageCollectorImpl
     implements _Private_CoverageCollector
 {
-    /**
-     * TODO remove when {@link InternMap} supports direct key comparison.
-     * @see CoverageCollectorFactory#createSession(Path)
-     */
-    private final Path                  myDataDir;
     private final CoverageConfiguration myConfig;
 
     /** Where we store our metrics. */
-    private final CoverageDatabase myDatabase;
+    private final CoverageSession mySession;
 
 
-    CoverageCollectorImpl(Path                  dataDir,
-                          CoverageConfiguration config,
-                          CoverageDatabase      database)
+    CoverageCollectorImpl(CoverageConfiguration config,
+                          CoverageSession       session)
     {
-        myDataDir  = dataDir;
         myConfig   = config;
-        myDatabase = database;
+        mySession  = session;
     }
 
 
-    CoverageDatabase getDatabase()
+    public CoverageSession getSession()
     {
-        return myDatabase;
+        return mySession;
     }
 
 
     public void noteRepository(File repoDir)
     {
-        myDatabase.noteRepository(repoDir);
+        mySession.noteRepository(repoDir);
     }
 
 
     @Override
     public boolean locationIsRecordable(SourceLocation loc)
     {
-       return (myDatabase.locationIsRecordable(loc) &&
+       return (mySession.locationIsRecordable(loc) &&
                myConfig.locationIsSelected(loc));
     }
 
@@ -73,14 +63,14 @@ public final class CoverageCollectorImpl
     @Override
     public void locationInstrumented(SourceLocation loc)
     {
-        myDatabase.locationInstrumented(loc);
+        mySession.locationInstrumented(loc);
     }
 
 
     @Override
     public void locationEvaluated(SourceLocation loc)
     {
-        myDatabase.locationEvaluated(loc);
+        mySession.locationEvaluated(loc);
     }
 
 
@@ -88,27 +78,6 @@ public final class CoverageCollectorImpl
     public void flushMetrics()
         throws IOException
     {
-        try
-        {
-            myDatabase.write();
-        }
-        catch (IOException e)
-        {
-            throw new IOException("Error writing Fusion coverage data", e);
-        }
-    }
-
-    @Override
-    public boolean equals(Object o)
-    {
-        if (o == null || getClass() != o.getClass()) { return false; }
-        CoverageCollectorImpl that = (CoverageCollectorImpl) o;
-        return Objects.equals(this.myDataDir, that.myDataDir);
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hashCode(myDataDir);
+        mySession.flushMetrics();
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
@@ -6,8 +6,6 @@ package dev.ionfusion.runtime._private.cover;
 import static com.amazon.ion.IonType.LIST;
 import static com.amazon.ion.IonType.STRING;
 import static com.amazon.ion.IonType.STRUCT;
-import static java.nio.file.Files.createDirectories;
-import static java.nio.file.Files.createTempFile;
 import static java.nio.file.Files.isRegularFile;
 import static java.nio.file.Files.newDirectoryStream;
 
@@ -81,35 +79,20 @@ public class CoverageDatabase
 
     //=========================================================================
 
-
-    private final Path myStorageFile;
-
     private final Set<File> myRepositories = new HashSet<>();
 
     private final Map<SourceLocation,Boolean> myLocations = new HashMap<>();
 
 
-    private CoverageDatabase(Path session)
+    CoverageDatabase()
     {
-        myStorageFile = session;
-    }
-
-
-    public static CoverageDatabase openSession(Path dataDir)
-        throws IOException
-    {
-        Path sessionsDir = dataDir.resolve("sessions");
-        createDirectories(sessionsDir);
-
-        Path session = createTempFile(sessionsDir, "", ".ion");
-        return new CoverageDatabase(session);
     }
 
 
     public static CoverageDatabase loadSessions(Path dataDir)
         throws IOException
     {
-        CoverageDatabase db = new CoverageDatabase(null);
+        CoverageDatabase db = new CoverageDatabase();
 
         Path sessionsDir = dataDir.resolve("sessions");
         if (Files.exists(sessionsDir))
@@ -363,7 +346,7 @@ public class CoverageDatabase
     }
 
 
-    synchronized void write()
+    synchronized void write(Path myStorageFile)
         throws IOException
     {
         try (OutputStream out = Files.newOutputStream(myStorageFile))
@@ -383,12 +366,12 @@ public class CoverageDatabase
         }
     }
 
-    void uncheckedWrite()
+    void uncheckedWrite(Path storageFile)
         throws UncheckedIOException
     {
         try
         {
-            write();
+            write(storageFile);
         }
         catch (IOException e)
         {

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageSession.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageSession.java
@@ -1,0 +1,117 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime._private.cover;
+
+import static java.nio.file.Files.createDirectories;
+import static java.nio.file.Files.createTempFile;
+
+import dev.ionfusion.fusion._Private_CoverageCollector;
+import dev.ionfusion.fusion._private.InternMap;
+import dev.ionfusion.runtime._private.util.Flusher;
+import dev.ionfusion.runtime.base.SourceLocation;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Objects;
+
+
+/**
+ * Associates a {@link CoverageDatabase} with a storage file. Instances automatically
+ * flush their database to disk when they are garbage-collected or when the JVM exits.
+ */
+public class CoverageSession
+    implements _Private_CoverageCollector
+{
+    private static final Flusher ourFlusher = new Flusher("Fusion coverage session flusher");
+
+
+    /**
+     * TODO remove when {@link InternMap} supports direct key comparison.
+     *
+     * @see CoverageCollectorFactory#createSession(Path)
+     */
+    private final Path             mySessionsDir;
+    private final Path             myStorageFile;
+    private final CoverageDatabase myDatabase;
+
+
+    private CoverageSession(Path sessions, Path storage, CoverageDatabase database)
+    {
+        mySessionsDir = sessions;
+        myStorageFile = storage;
+        myDatabase = database;
+    }
+
+
+    public static CoverageSession createSession(Path sessionsDir)
+        throws IOException
+    {
+        createDirectories(sessionsDir);
+
+        Path sessionFile = createTempFile(sessionsDir, "", ".ion");
+
+        CoverageDatabase db      = new CoverageDatabase();
+        CoverageSession  session = new CoverageSession(sessionsDir, sessionFile, db);
+
+        // WARNING: The flush action must not retain a reference to the session!
+        ourFlusher.register(session, () -> db.uncheckedWrite(sessionFile));
+
+        return session;
+    }
+
+
+    public Path getStorageFile()
+    {
+        return myStorageFile;
+    }
+
+    public CoverageDatabase getDatabase()
+    {
+        return myDatabase;
+    }
+
+
+    void noteRepository(File repoDir)
+    {
+        myDatabase.noteRepository(repoDir);
+    }
+
+    @Override
+    public boolean locationIsRecordable(SourceLocation loc)
+    {
+        return myDatabase.locationIsRecordable(loc);
+    }
+
+    @Override
+    public void locationInstrumented(SourceLocation loc)
+    {
+        myDatabase.locationInstrumented(loc);
+    }
+
+    @Override
+    public void locationEvaluated(SourceLocation loc)
+    {
+        myDatabase.locationEvaluated(loc);
+    }
+
+    @Override
+    public void flushMetrics()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == null || getClass() != o.getClass()) { return false; }
+        CoverageSession that = (CoverageSession) o;
+        return Objects.equals(this.mySessionsDir, that.mySessionsDir);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(mySessionsDir);
+    }
+}

--- a/runtime/src/test/java/dev/ionfusion/runtime/_private/cover/CoverageCollectorTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/_private/cover/CoverageCollectorTest.java
@@ -21,13 +21,16 @@ public class CoverageCollectorTest
     public Path tmpDir;
 
 
+    /**
+     * Coverage collectors are unique, even when sharing the same directory.
+     */
     @Test
-    public void testRepeatInstantiation()
+    public void testUniqueInstances()
         throws Exception
     {
         CoverageCollectorImpl c1 = fromDirectory(tmpDir);
         CoverageCollectorImpl c2 = fromDirectory(tmpDir);
-        assertSame(c1, c2);
+        assertNotSame(c1, c2);
     }
 
 
@@ -50,7 +53,8 @@ public class CoverageCollectorTest
         CoverageCollectorImpl c2 = fromDirectory(dir2);
         CoverageCollectorImpl c3 = fromDirectory(linkToDir1);
 
-        assertNotSame(c1, c2, "different dirs");
-        assertSame(c1, c3, "canonicalized symlink");
+
+        assertNotSame(c1.getSession(), c2.getSession(), "different dirs");
+        assertSame(c1.getSession(), c3.getSession(), "canonicalized symlink");
     }
 }


### PR DESCRIPTION
The model is now:
  * `CoverageCollectorImpl` has a `CoverageSession` and configuration.
  * `CoverageSession` has a `CoverageDatabase` and a file to save it in.
  * `CoverageDatabase` is just the data, but it can read/write to given files. This better handles the case when the data has been loaded from multiple sessions.

We now intern/share _sessions_, not the collector. This unblocks having different config per collector, which unblocks having config outside the data dir.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
