### PR TITLE
Extract `CoverageReport` from `CoverageReportWriter`.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/Cover.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/Cover.java
@@ -8,6 +8,7 @@ import static java.nio.file.Files.isDirectory;
 import static java.nio.file.Files.isReadable;
 import static java.nio.file.Files.isRegularFile;
 
+import dev.ionfusion.fusion.cli.cover.CoverageReport;
 import dev.ionfusion.fusion.cli.cover.CoverageReportWriter;
 import dev.ionfusion.runtime._private.cover.CoverageConfiguration;
 import dev.ionfusion.runtime._private.cover.CoverageDatabase;
@@ -149,7 +150,9 @@ class Cover
                 database.loadSessions(dataDir);
             }
 
-            CoverageReportWriter renderer = new CoverageReportWriter(config, database);
+            CoverageReport report = new CoverageReport(config, database);
+
+            CoverageReportWriter renderer = new CoverageReportWriter(report);
 
             Path index = renderer.renderFullReport(myReportDir);
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/cover/CoverageReport.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/cover/CoverageReport.java
@@ -1,0 +1,268 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion.cli.cover;
+
+import static dev.ionfusion.fusion._Private_Trampoline.discoverModulesInRepository;
+import static dev.ionfusion.runtime.base.SourceName.FUSION_SOURCE_EXTENSION;
+import static java.nio.file.Files.walkFileTree;
+import static java.util.stream.Collectors.toList;
+
+import dev.ionfusion.runtime._private.cover.CoverageConfiguration;
+import dev.ionfusion.runtime._private.cover.CoverageDatabase;
+import dev.ionfusion.runtime.base.FusionException;
+import dev.ionfusion.runtime.base.ModuleIdentity;
+import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.SourceName;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class CoverageReport
+{
+    private final CoverageConfiguration myConfig;
+
+    private final Map<URI, CoveredFile>              myCoveredFiles;
+    private final Map<ModuleIdentity, CoveredModule> myCoveredModules;
+    private final CoverageInfoPair                   myGlobalSummary;
+
+    public CoverageReport(CoverageConfiguration config, CoverageDatabase db)
+        throws FusionException, IOException
+    {
+        myConfig = config;
+        myCoveredFiles = new HashMap<>();
+        myCoveredModules = new HashMap<>();
+        myGlobalSummary = new CoverageInfoPair();
+
+        // WARNING: We currently can't do this more than once per report.  Doing so may
+        // change preferred module sources, at the very least.
+        loadDatabase(db);
+
+        // Compute each entity's summary, as well as the global summary.
+        summarize();
+    }
+
+
+    private void loadDatabase(CoverageDatabase db)
+        throws FusionException, IOException
+    {
+        // Identify all the modules in recorded repositories.
+        noteModulesInRepositories(db.getRepositories());
+
+        // Identify all the scripts in the configured directories.
+        // TODO Database should record covered dirs, like it does for modules.
+        noteScripts(myConfig.getIncludedSourceDirs());
+
+        // Traverse the database's instrumented sources, noting source files and
+        // determining the preferred source of each module.
+        db.sourceNames().forEach(this::noteSourceName);
+
+        // With all module sources collected, we can note a single one for each module.
+        myCoveredModules.values().forEach(this::notePreferredSourceOfModule);
+
+        // With all source files identified, we can collect location metrics.
+        db.forEachLocationCoverage(this::noteLocationCoverage);
+    }
+
+
+    public Collection<CoveredFile> sourceFiles()
+    {
+        return myCoveredFiles.values();
+    }
+
+    /**
+     * Gets the source files that are not defining modules in repositories.
+     */
+    public Collection<CoveredFile> scripts()
+    {
+        return myCoveredFiles.values()
+                             .stream()
+                             .filter(CoveredFile::isScript)
+                             .collect(toList());
+    }
+
+    public Collection<CoveredModule> modules()
+    {
+        return myCoveredModules.values();
+    }
+
+
+    //==================================================================================
+    // Initial source discovery
+
+    /**
+     * Collect all the modules the repositories can discover, so we can find modules
+     * that are not used and don't appear in the database.
+     */
+    private void noteModulesInRepositories(Set<File> repos)
+        throws FusionException
+    {
+        for (File f : repos)
+        {
+            discoverModulesInRepository(f.toPath(),
+                                        myConfig::moduleIsSelected,
+                                        this::noteModule);
+        }
+    }
+
+
+    /**
+     * Ensures that we have a {@link CoveredModule} for the module.
+     */
+    private CoveredModule noteModule(ModuleIdentity id)
+    {
+        return myCoveredModules.computeIfAbsent(id, CoveredModule::new);
+    }
+
+
+    /**
+     * Notes the file if it's selected by our configuration.
+     */
+    private void noteScript(Path file)
+    {
+        file = file.normalize();
+        if (myConfig.fileIsSelected(file))
+        {
+            noteFile(file);
+        }
+    }
+
+    /**
+     * Ensures that we have a {@link CoveredFile} for the file.
+     */
+    private CoveredFile noteFile(Path file)
+    {
+        // TODO canonicalize?
+        URI uri = file.toUri();
+        return noteFile(uri);
+    }
+
+    /**
+     * Ensures that we have a {@link CoveredFile} for the source.
+     */
+    private CoveredFile noteFile(URI uri)
+    {
+        assert uri != null;
+        return myCoveredFiles.computeIfAbsent(uri, CoveredFile::forUri);
+    }
+
+
+    /**
+     * Notes (via {@link #noteScript(Path)} all the {@code .fusion} files
+     * within the configured script directories.
+     */
+    private void noteScripts(Set<Path> scriptDirs)
+        throws IOException
+    {
+        FileVisitor<Path> visitor = new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path entry, BasicFileAttributes attrs)
+            {
+                if (entry.getFileName().toString().endsWith(FUSION_SOURCE_EXTENSION))
+                {
+                    noteScript(entry);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        };
+
+        for (Path dir : scriptDirs)
+        {
+            walkFileTree(dir, visitor);
+        }
+    }
+
+
+    private void noteSourceName(SourceName name)
+    {
+        ModuleIdentity id = name.getModuleIdentity();
+        if (myConfig.moduleIsSelected(id))
+        {
+            // A module can occur in different sessions with different locations,
+            // one with a file Path and the other with a jar URI.  Here we look for
+            // such duplicates and normalize to the file Path.
+
+            noteModule(id).noteSourceName(name);
+            // We'll come back later to note the preferred source file.
+        }
+        else
+        {
+            // TODO Warn about instrumented scripts that are not selected by our config?
+            Path path = name.getPath();
+            if (path != null)
+            {
+                noteScript(path);
+            }
+            // Assuming that Jar-packed scripts are not a thing.
+        }
+    }
+
+
+    private void notePreferredSourceOfModule(CoveredModule module)
+    {
+        // Some modules are "directories" with no source file.
+        URI uri = module.getUri();
+        if (uri != null)
+        {
+            // Not filtered by configuration
+            noteFile(uri).containsModule(module);
+        }
+    }
+
+
+    /**
+     * Can be called multiple times for the same (effective) location; if any
+     * invocation passes true, then the location is considered covered.
+     */
+    private void noteLocationCoverage(SourceLocation loc, Boolean covered)
+    {
+        SourceName name = loc.getSourceName();
+        ModuleIdentity id = name.getModuleIdentity();
+        if (id != null)
+        {
+            CoveredModule module = myCoveredModules.get(id);
+
+            // Use a SourceLocation with the module's preferred SourceName.
+            loc = module.normalizeLocation(loc);
+
+            module.noteLocationCoverage(loc, covered);
+        }
+
+        // WARNING: `loc` may have been normalized above.
+        URI uri = loc.getSourceName().getUri();
+        CoveredFile file = myCoveredFiles.get(uri);
+        assert file != null : "No CoveredFile for " + loc.getSourceName();
+
+        file.noteLocationCoverage(loc, covered);
+    }
+
+
+    private void summarize()
+    {
+        myCoveredModules.values().forEach(CoveredModule::summarize);
+        myCoveredFiles.values().forEach(CoveredFile::summarize);
+
+        // The modules are a subset of the files; don't apply them twice to the globals.
+        myCoveredFiles.values().forEach(f -> f.summarizeInto(myGlobalSummary));
+    }
+
+
+    /**
+     * Aggregated coverage metrics for the entire report.
+     *
+     * @return not null.
+     */
+    CoverageInfoPair globalSummary()
+    {
+        return myGlobalSummary;
+    }
+}

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/cover/CoverageReportWriter.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/cover/CoverageReportWriter.java
@@ -3,10 +3,9 @@
 
 package dev.ionfusion.fusion.cli.cover;
 
-import static dev.ionfusion.fusion._Private_Trampoline.discoverModulesInRepository;
 import static dev.ionfusion.runtime.base.SourceLocation.compareByLineColumn;
-import static dev.ionfusion.runtime.base.SourceName.FUSION_SOURCE_EXTENSION;
-import static java.nio.file.Files.walkFileTree;
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.toList;
 
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonType;
@@ -17,27 +16,16 @@ import com.amazon.ion.Timestamp;
 import com.amazon.ion.system.IonReaderBuilder;
 import dev.ionfusion.fusion._private.HtmlWriter;
 import dev.ionfusion.fusion._private.StreamWriter;
-import dev.ionfusion.runtime._private.cover.CoverageConfiguration;
-import dev.ionfusion.runtime._private.cover.CoverageDatabase;
-import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ModuleIdentity;
 import dev.ionfusion.runtime.base.SourceLocation;
-import dev.ionfusion.runtime.base.SourceName;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
-import java.nio.file.FileVisitResult;
-import java.nio.file.FileVisitor;
-import java.nio.file.Files;
+import java.net.URI;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  *
@@ -65,17 +53,18 @@ public final class CoverageReportWriter
         "div.separator {height: 10px;}";
 
 
-    private final CoverageDatabase                  myDatabase;
-    private final CoverageConfiguration             myConfig;
-    private final Set<ModuleIdentity>               myModules;
-    private final Set<Path>                         mySourceFiles;
-    private final Map<ModuleIdentity, SourceName>   myNamesForModules;
-    private final Map<Path, SourceName>             myNamesForFiles;
-    private final Map<SourceName, CoverageInfoPair> myFileCoverages;
-    private final Map<SourceName, String>           myRelativeNamesForSources;
+    private final CoverageReport myReport;
 
-    private final CoverageInfoPair myGlobalCoverage = new CoverageInfoPair();
-    private       long             myUnloadedEntries;
+    /**
+     * Maps each reported source file to its HTML file in the generated site.
+     */
+    private final Map<Path, String> myRelativeNamesForSources;
+
+    /**
+     * Counts the number of modules and/or scripts that have no coverage data.
+     * Used to estimate coverage stats for them.
+     */
+    private long myUnloadedEntries;
 
     // For rendering highlighted source files
     private static final int BUFFER_SIZE = 2048;
@@ -84,52 +73,15 @@ public final class CoverageReportWriter
     private boolean coverageState;
 
 
-    public CoverageReportWriter(CoverageConfiguration config,
-                                CoverageDatabase      database)
+    public CoverageReportWriter(CoverageReport report)
     {
-        myConfig   = config;
-        myDatabase = database;
-
-        myModules                 = new HashSet<>();
-        mySourceFiles             = new HashSet<>();
-        myNamesForModules         = new HashMap<>();
-        myNamesForFiles           = new HashMap<>();
-        myFileCoverages           = new HashMap<>();
+        myReport = report;
         myRelativeNamesForSources = new HashMap<>();
     }
 
 
     //=========================================================================
     // Metrics Analysis
-
-    /**
-     * Populate {@link #mySourceFiles} set with all the {@code .fusion} files
-     * within the configured source directories.
-     */
-    private void collectSourceFiles()
-        throws IOException
-    {
-        FileVisitor<Path> visitor = new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult visitFile(Path entry, BasicFileAttributes attrs)
-            {
-                if (entry.getFileName().toString().endsWith(FUSION_SOURCE_EXTENSION))
-                {
-                    if (myConfig.fileIsSelected(entry))
-                    {
-                        mySourceFiles.add(entry);
-                    }
-                }
-                return FileVisitResult.CONTINUE;
-            }
-        };
-
-        for (Path dir : myConfig.getIncludedSourceDirs())
-        {
-            walkFileTree(dir, visitor);
-        }
-    }
-
 
     private Path commonPrefix(Path a, Path b)
     {
@@ -150,20 +102,18 @@ public final class CoverageReportWriter
 
     /**
      * Determine the number of leading {@link Path} name elements common to all
-     * files of the given {@link SourceName}s.  We omit this prefix from the
+     * files in our {@link CoverageReport}.  We omit this prefix from the
      * directory tree of generated HTML files.
      * <p>
      * TODO It would be better to use paths relative to repository roots, to
      *   avoid exposing details of the build-time environment.  This suggests
      *   that {@code SourceName} should track the repository holding the source.
-     *
-     * @param sourceNames must not be null.
      */
-    private int commonPrefixLen(Set<SourceName> sourceNames)
+    private int commonPrefixLen()
         throws IOException
     {
         Path prefix = null;
-        for (SourceName sourceName : sourceNames)
+        for (CoveredFile sourceName : myReport.sourceFiles())
         {
             // Skip URL-based sources.
             Path file = sourceName.getPath();
@@ -186,10 +136,9 @@ public final class CoverageReportWriter
     private void prepareRelativeNames()
         throws IOException
     {
-        Set<SourceName> sourceNames = myDatabase.sourceNames();
-        int prefixLen = commonPrefixLen(sourceNames);
+        int prefixLen = commonPrefixLen();
 
-        for (SourceName sourceName : sourceNames)
+        for (CoveredFile sourceName : myReport.sourceFiles())
         {
             // TODO Determine this on demand, it's only needed twice per source.
             //      so this code is more complicated than its worth.
@@ -198,86 +147,35 @@ public final class CoverageReportWriter
             {
                 Path path        = file.toRealPath();
                 Path shorterPath = path.subpath(prefixLen, path.getNameCount());
-                myRelativeNamesForSources.put(sourceName, shorterPath.toString());
+                myRelativeNamesForSources.put(path, shorterPath.toString());
             }
         }
     }
 
 
-    /**
-     * Collects relevant modules into {@link #myModules}, source files
-     * into {@link #mySourceFiles}, and map covered modules and files to
-     * {@link SourceName}s via {@link #myNamesForModules} and
-     * {@link #myNamesForFiles}.
-     * <p>
-     * TODO Rename to be more informative; maybe collectModulesAndSources()?
-     *
-     * @throws FusionException if an error occurs.
-     */
-    private void analyze()
-        throws FusionException, IOException
+    private List<CoveredModule> sortedModules()
     {
-        // Collect all the modules the repositories can discover, so we can find
-        // modules that are not used and don't appear in the database.
-        for (File f : myDatabase.getRepositories())
-        {
-            discoverModulesInRepository(f.toPath(),
-                                        myConfig::moduleIsSelected,
-                                        myModules::add);
-        }
-
-        // Now do the same thing for non-repository source trees.
-        // TODO Why aren't these dirs recorded in the database like modules?
-        collectSourceFiles();
-
-        for (SourceLocation loc : myDatabase.locations())
-        {
-            // TODO Assert that a name exists. There's no use in persisting
-            //      nameless locations that we can't report.
-            SourceName sourceName = loc.getSourceName();
-            if (sourceName != null)
-            {
-                ModuleIdentity id = sourceName.getModuleIdentity();
-                // TODO Why would this selector differ from the collection-time?
-                if (myConfig.moduleIsSelected(id))
-                {
-                    myModules.add(id);
-
-                    SourceName prior = myNamesForModules.put(id, sourceName);
-                    assert prior == null || prior.equals(sourceName) :
-                        "SourceName has changed for module " + id;
-                }
-                else
-                {
-                    Path f = sourceName.getPath();
-                    if (f != null)
-                    {
-                        mySourceFiles.add(f);
-
-                        SourceName prior = myNamesForFiles.put(f, sourceName);
-                        assert prior == null || prior.equals(sourceName) :
-                            "SourceName has changed for file " + f +
-                                "\nThis can happen if you `load` a module's file " +
-                                "within a registered repository.";
-                    }
-                }
-            }
-        }
+        return myReport.modules()
+                       .stream()
+                       .sorted(comparing(CoveredModule::getId))
+                       .collect(toList());
     }
 
-
-    private ModuleIdentity[] sortedModules()
+    private List<CoveredFile> sortedScripts()
     {
-        ModuleIdentity[] modules = myModules.toArray(new ModuleIdentity[0]);
-        Arrays.sort(modules);
-        return modules;
+        return myReport.scripts()
+                       .stream()
+                       .sorted(comparing(CoveredFile::getPath))
+                       .collect(toList());
     }
 
-    private Path[] sortedFiles()
+    private SourceLocation[] sortedLocations(CoveredFile name)
     {
-        Path[] result = mySourceFiles.toArray(new Path[0]);
-        Arrays.sort(result);
-        return result;
+        SourceLocation[] locations = name.locations().toArray(new SourceLocation[0]);
+        assert locations.length == name.getSummary().total()
+            : "Number of locations doesn't match coverage summary";
+        Arrays.sort(locations, SourceLocation::compareByLineColumn);
+        return locations;
     }
 
 
@@ -341,17 +239,9 @@ public final class CoverageReportWriter
         coverageState = covered;
     }
 
-    private InputStream readSource(SourceName source)
-        throws IOException
-    {
-        URL url = source.getUrl();
-        if (url != null) return url.openStream();
-
-        return Files.newInputStream(source.getFile().toPath());
-    }
 
     private void renderSource(HtmlWriter sourceHtml,
-                              SourceName name)
+                              CoveredFile name)
         throws IOException
     {
         sourceHtml.renderHeadWithInlineCss("Fusion Code Coverage", CSS);
@@ -375,34 +265,34 @@ public final class CoverageReportWriter
                 else
                 {
                     // TODO improve this rendering
-                    path = name.getUrl().toExternalForm();
+                    path = name.getUri().toString();
                 }
                 sourceHtml.append(sourceHtml.escapeString(path));
             }
             else
             {
                 sourceHtml.append("File ");
-                sourceHtml.append(name.display());
+                sourceHtml.append(name.getPath().toString());
                 sourceHtml.append("</h1>\n");
             }
         }
 
-        SourceLocation[] locations = myDatabase.sortedLocations(name);
+        SourceLocation[] locations = sortedLocations(name);
         assert locations.length != 0;
 
         int locationIndex = 0;
-        final CoverageInfoPair coverageInfoPair = new CoverageInfoPair();
 
         sourceHtml.append("\n<hr/>\n");
         sourceHtml.append("<pre>");
 
         // Copy the document in chunks separated by coverage state changes.
         // At each change, we insert appropriate HTML <span> markup.
-        try (InputStream ionBytes = readSource(name))
+        try (InputStream ionBytes = name.readSource())
         {
             myIonBytesRead = 0;
 
-            try (IonReader ionReader = IonReaderBuilder.standard().build(readSource(name)))
+            try (IonReader ionReader =
+                     IonReaderBuilder.standard().build(name.readSource()))
             {
                 SpanProvider spanProvider =
                     ionReader.asFacet(SpanProvider.class);
@@ -425,15 +315,10 @@ public final class CoverageReportWriter
 
                     if (compareByLineColumn(currentLoc, coverageLoc) == 0)
                     {
-                        boolean covered =
-                            myDatabase.locationCovered(coverageLoc);
+                        boolean covered = name.isLocationCovered(coverageLoc);
                         setCoverageState(sourceHtml, ionBytes, spanProvider,
                                          covered);
                         locationIndex++;
-
-                        coverageInfoPair.foundExpression(covered);
-                        myGlobalCoverage.foundExpression(covered);
-
                         if (locationIndex == locations.length) break;
                     }
 
@@ -451,8 +336,6 @@ public final class CoverageReportWriter
 
                 assert locationIndex == locations.length
                     : "Not all locations were found in the source";
-                assert locationIndex == coverageInfoPair.total()
-                    : "Not all locations were counted";
 
                 // Copy the rest of the Ion source.
                 copySourceThroughOffset(sourceHtml, ionBytes, Long.MAX_VALUE);
@@ -463,24 +346,24 @@ public final class CoverageReportWriter
 
         sourceHtml.append("</pre>\n");
         sourceHtml.append("<hr/>");
-        coverageInfoPair.renderCoveragePercentage(sourceHtml);
-
-        myFileCoverages.put(name, coverageInfoPair);
+        name.getSummary().renderCoveragePercentage(sourceHtml);
     }
 
 
-    private String relativeName(SourceName name)
+    private String relativeName(CoveredEntity name)
     {
         String resource;
-        if (name.getFile() != null)
+        Path file = name.getPath();
+        if (file != null)
         {
-            resource = myRelativeNamesForSources.get(name);
+            resource = myRelativeNamesForSources.get(file);
         }
         else
         {
-            URL url = name.getUrl();
-            assert (url.getProtocol().equalsIgnoreCase("jar"));
-            String path = url.getPath();
+            URI uri = name.getUri();
+            assert (uri.getScheme().equalsIgnoreCase("jar"));
+            String path = uri.getSchemeSpecificPart();
+            assert path != null : "null path in " + uri;
             int    bang = path.indexOf("!/");
             assert bang > 1;
             resource = path.substring(bang + 2);
@@ -494,7 +377,7 @@ public final class CoverageReportWriter
     private void renderSourceFiles(Path outputDir)
         throws IOException
     {
-        for (SourceName name : myDatabase.sourceNames())
+        for (CoveredFile name : myReport.sourceFiles())
         {
             Path outFile = outputDir.resolve(relativeName(name));
             try (StreamWriter sourceHtml = new StreamWriter(outFile))
@@ -505,17 +388,16 @@ public final class CoverageReportWriter
     }
 
 
-    private <T> void renderRows(HtmlWriter         indexHtml,
-                                String             category,
-                                T[]                keys,
-                                Map<T, SourceName> keyToNames)
+    private <T extends CoveredEntity> void renderRows(HtmlWriter indexHtml,
+                                                      String     category,
+                                                      List<T>    rows)
         throws IOException
     {
         long totalExpressions = 0;
         long unloadedCount = 0;
 
         boolean first = true;
-        for (T key : keys)
+        for (CoveredEntity row : rows)
         {
             if (first)
             {
@@ -528,15 +410,12 @@ public final class CoverageReportWriter
                 first = false;
             }
 
-            CoverageInfoPair pair;
-            SourceName name = keyToNames.get(key);
-            if (name != null)
+            CoverageInfoPair pair = row.getSummary();
+            if (pair.total() != 0)
             {
-                pair = myFileCoverages.get(name);
-
                 totalExpressions += pair.total();
             }
-            else // The module was never loaded!
+            else // The source was never loaded
             {
                 pair = new EstimatedCoverageInfoPair();
 
@@ -547,16 +426,18 @@ public final class CoverageReportWriter
             pair.renderPercentageGraph(indexHtml);
             indexHtml.append("</td><td>");
 
-            if (name != null)
+            String descr = row.describe();
+            URI    uri   = row.getUri();
+            if (uri != null)
             {
                 // TODO Exclude the common prefix when key is a script File.
-                indexHtml.append("<a href=\"" + relativeName(name) + "\">");
-                indexHtml.append(key.toString());
+                indexHtml.append("<a href=\"" + relativeName(row) + "\">");
+                indexHtml.append(descr);
                 indexHtml.append("</a>");
             }
             else
             {
-                indexHtml.append(key.toString());
+                indexHtml.append(descr);
             }
 
             indexHtml.append("</td></tr>\n");
@@ -564,12 +445,12 @@ public final class CoverageReportWriter
 
         if (unloadedCount != 0)
         {
-            long loadedCount = keys.length - unloadedCount;
+            long loadedCount = rows.size() - unloadedCount;
             long average = (loadedCount == 0
                                ? 500                        // TODO Totally made up
                                : totalExpressions / loadedCount);
 
-            myGlobalCoverage.uncoveredExpressions += (unloadedCount * average);
+            myReport.globalSummary().uncoveredExpressions += (unloadedCount * average);
 
             myUnloadedEntries += unloadedCount;
         }
@@ -590,14 +471,14 @@ public final class CoverageReportWriter
 
             indexHtml.append("<table class='report'>\n");
 
-            renderRows(indexHtml, "Module", sortedModules(), myNamesForModules);
-            renderRows(indexHtml, "File",   sortedFiles(),   myNamesForFiles);
+            renderRows(indexHtml, "Module", sortedModules());
+            renderRows(indexHtml, "File",   sortedScripts());
 
             indexHtml.append("</table>\n<br/>\n");
 
             // We can't render this earlier since the result is affected by
             // unloaded rows.
-            myGlobalCoverage.renderCoveragePercentage(indexHtml);
+            myReport.globalSummary().renderCoveragePercentage(indexHtml);
             if (myUnloadedEntries != 0)
             {
                 indexHtml.append(" (estimate since ");
@@ -612,10 +493,8 @@ public final class CoverageReportWriter
      * @return the path of the index file.
      */
     public Path renderFullReport(Path outputDir)
-        throws FusionException, IOException
+        throws IOException
     {
-        analyze();
-
         prepareRelativeNames();
 
         renderSourceFiles(outputDir);

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/cover/CoveredEntity.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/cover/CoveredEntity.java
@@ -1,0 +1,88 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion.cli.cover;
+
+import dev.ionfusion.runtime.base.SourceLocation;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Collects location coverage data for some module or file.
+ */
+abstract class CoveredEntity
+{
+    private final Map<SourceLocation, Boolean> myCoverage;
+    private final CoverageInfoPair             mySummary;
+
+    CoveredEntity()
+    {
+        myCoverage = new HashMap<>();
+        mySummary = new CoverageInfoPair();
+    }
+
+
+    /**
+     * Describes this entity for use by the index page.
+     */
+    abstract String describe();
+
+    /**
+     * Our source URI.
+     *
+     * @return an absolute URI with either "file" or "jar" scheme; not null.
+     */
+    abstract URI getUri();
+
+    /**
+     * Our concrete source file, if any.
+     */
+    abstract Path getPath();
+
+
+    void noteLocationCoverage(SourceLocation loc, Boolean covered)
+    {
+        assert loc.getSourceName().getUri().equals(getUri());
+        myCoverage.merge(loc, covered, (a, b) -> a || b);
+    }
+
+
+    Set<SourceLocation> locations()
+    {
+        return myCoverage.keySet();
+    }
+
+    boolean isLocationCovered(SourceLocation loc)
+    {
+        return myCoverage.get(loc);
+    }
+
+
+    void summarizeInto(CoverageInfoPair summary)
+    {
+        myCoverage.values().forEach(summary::foundExpression);
+    }
+
+    /**
+     * Computes summary metrics from the noted locations.
+     */
+    void summarize()
+    {
+        summarizeInto(mySummary);
+    }
+
+
+    /**
+     * Aggregated coverage metrics for this entity.
+     * The result is only valid after {@link #summarize()} has been called.
+     *
+     * @return not null.
+     */
+    CoverageInfoPair getSummary()
+    {
+        return mySummary;
+    }
+}

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/cover/CoveredFile.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/cover/CoveredFile.java
@@ -1,0 +1,100 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion.cli.cover;
+
+import static java.nio.file.Files.newInputStream;
+
+import dev.ionfusion.runtime.base.ModuleIdentity;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Represents a source file (either physical or embedded in a Jar) and associated
+ * coverage metrics.
+ * <p>
+ * Assumes at most one module per file.
+ */
+public class CoveredFile
+    extends CoveredEntity
+{
+    private final URI  myUri;
+    private final Path myPath;
+
+    /**
+     * Tracks the module defined in this file.
+     */
+    private ModuleIdentity myModuleId;
+
+
+    private CoveredFile(URI uri, Path path)
+    {
+        assert uri != null;
+        myUri = uri;
+        myPath = path;
+    }
+
+
+    static CoveredFile forUri(URI uri)
+    {
+        String scheme = uri.getScheme();
+        if ("file".equalsIgnoreCase(scheme))
+        {
+            return new CoveredFile(uri, Paths.get(uri));
+        }
+        if ("jar".equalsIgnoreCase(scheme))
+        {
+            return new CoveredFile(uri, null);
+        }
+
+        throw new IllegalArgumentException("URI must have file or jar scheme: " + uri);
+    }
+
+
+    @Override
+    public String describe()
+    {
+        return myPath.toString();
+    }
+
+    public URI getUri()
+    {
+        return myUri;
+    }
+
+    public Path getPath()
+    {
+        return myPath;
+    }
+
+
+    public InputStream readSource()
+        throws IOException
+    {
+        return myPath != null ? newInputStream(myPath) : myUri.toURL().openStream();
+    }
+
+
+    public void containsModule(CoveredModule module)
+    {
+        assert myModuleId == null;
+        myModuleId = module.getId();
+    }
+
+
+    /**
+     * A file is a script if it's not associated with a module.
+     */
+    public boolean isScript()
+    {
+        return myModuleId == null;
+    }
+
+    public ModuleIdentity getModuleIdentity()
+    {
+        return myModuleId;
+    }
+}

--- a/runtime/src/main/java/dev/ionfusion/fusion/cli/cover/CoveredModule.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/cli/cover/CoveredModule.java
@@ -1,0 +1,135 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion.cli.cover;
+
+import dev.ionfusion.runtime._private.cover.CoverageDatabase;
+import dev.ionfusion.runtime.base.ModuleIdentity;
+import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.SourceName;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Represents a module and associated coverage metrics.
+ * <p>
+ * One subtle challenge is that a module may have coverage data using two different
+ * source names: one test session might load the module via a concrete path, while
+ * another might load it from a jar.  This class normalizes such duplicates to a
+ * preferred form, which is the first concrete path encountered, else the first jar.
+ * <p>
+ * This normalization should really be happening in the {@link CoverageDatabase}.
+ */
+public class CoveredModule
+    extends CoveredEntity
+{
+    private final ModuleIdentity myId;
+
+    /**
+     * Tracks the source code we want to present for this module.
+     * We prefer a file-based source if one exists.
+     */
+    private SourceName myPreferredSource;
+
+    /**
+     * Remembers that we've processed a particular source to avoid the clunky
+     * normalization for every location.
+     */
+    private final Set<SourceName> myNames;
+
+
+    CoveredModule(ModuleIdentity id)
+    {
+        myId = id;
+        myNames = new HashSet<>();
+    }
+
+
+    public ModuleIdentity getId()
+    {
+        return myId;
+    }
+
+    @Override
+    public String describe()
+    {
+        return myId.absolutePath();
+    }
+
+    /**
+     * @return the URI of the preferred source.
+     */
+    @Override
+    public URI getUri()
+    {
+        return (myPreferredSource == null ? null : myPreferredSource.getUri());
+    }
+
+    /**
+     * @return the path of the preferred source.
+     */
+    @Override
+    public Path getPath()
+    {
+        return (myPreferredSource == null ? null : myPreferredSource.getPath());
+    }
+
+
+    void noteSourceName(SourceName sourceName)
+    {
+        if (myNames.add(sourceName))
+        {
+            if (myPreferredSource == null)
+            {
+                myPreferredSource = sourceName;
+            }
+            else
+            {
+                Path preferredPath = myPreferredSource.getPath();
+                Path givenPath = sourceName.getPath();
+                if (preferredPath == null)
+                {
+                    // Prefer a Path-based source over a URL-based one.
+                    if (givenPath != null) myPreferredSource = sourceName;
+                }
+                else
+                {
+                    // We don't expect the same module to come from two different
+                    // concrete files.
+                    assert givenPath == null || preferredPath.equals(givenPath);
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Returns an equivalent location using our preferred source name.
+     */
+    public SourceLocation normalizeLocation(SourceLocation loc)
+    {
+        assert myPreferredSource != null;
+        if (loc.getSourceName().equals(myPreferredSource))
+        {
+            return loc;
+        }
+
+        return SourceLocation.forLineColumn(loc.getLine(),
+                                            loc.getColumn(), myPreferredSource);
+    }
+
+
+    /**
+     * @param loc must have been {@link #normalizeLocation normalized}.
+     */
+    public void noteLocationCoverage(SourceLocation loc, Boolean covered)
+    {
+        assert myId == loc.getSourceName().getModuleIdentity();
+
+        // Assume the caller has normalized the location, otherwise we'll have
+        // two different keys for the same effective location.
+        super.noteLocationCoverage(loc, covered);
+    }
+}

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
@@ -27,12 +27,11 @@ import java.net.URL;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 
 /**
@@ -150,54 +149,18 @@ public class CoverageDatabase
         for (SourceLocation loc : myLocations.keySet())
         {
             SourceName name = loc.getSourceName();
-            if (name != null)
-            {
-                names.add(name);
-            }
+            assert name != null;  // per locationIsRecordable()
+            names.add(name);
         }
 
         return names;
     }
 
 
-    SourceName[] sortedNames()
+    public synchronized
+    void forEachLocationCoverage(BiConsumer<SourceLocation, Boolean> visitor)
     {
-        Set<SourceName> sourceSet = sourceNames();
-
-        SourceName[] sourceArray = sourceSet.toArray(new SourceName[0]);
-
-        Arrays.sort(sourceArray, SourceName::compareByDisplay);
-
-        return sourceArray;
-    }
-
-
-    /**
-     * @return not null.
-     */
-    public synchronized Set<SourceLocation> locations()
-    {
-        return myLocations.keySet();
-    }
-
-
-    public synchronized SourceLocation[] sortedLocations(SourceName name)
-    {
-        ArrayList<SourceLocation> locsList = new ArrayList<>();
-
-        for (SourceLocation loc : myLocations.keySet())
-        {
-            if (name.equals(loc.getSourceName()))
-            {
-                locsList.add(loc);
-            }
-        }
-
-        SourceLocation[] locsArray = locsList.toArray(new SourceLocation[0]);
-
-        Arrays.sort(locsArray, SourceLocation::compareByLineColumn);
-
-        return locsArray;
+        myLocations.forEach(visitor);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceName.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceName.java
@@ -6,6 +6,8 @@ package dev.ionfusion.runtime.base;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 
@@ -75,6 +77,12 @@ public class SourceName
     {
         return null;
     }
+
+    public URI getUri()
+    {
+        return null;
+    }
+
 
     /**
      * It is not guaranteed that the module declaration is the only content of
@@ -157,6 +165,9 @@ public class SourceName
 
         @Override
         public Path getPath() { return myFile.toPath(); }
+
+        @Override
+        public URI getUri() { return myFile.toURI(); }
     }
 
 
@@ -183,6 +194,7 @@ public class SourceName
         @Override
         public Path getPath() { return myFile.toPath(); }
 
+        public URI getUri() { return myFile.toURI(); }
 
         @Override
         public ModuleIdentity getModuleIdentity() { return myId; }
@@ -212,6 +224,19 @@ public class SourceName
 
         @Override
         public URL getUrl() { return myUrl; }
+
+        @Override
+        public URI getUri()
+        {
+            try
+            {
+                return myUrl.toURI();
+            }
+            catch (URISyntaxException e)
+            {
+                throw new AssertionError(e); // should not happen
+            }
+        }
 
         @Override
         public ModuleIdentity getModuleIdentity() { return myId; }


### PR DESCRIPTION
This is better separation of concerns, the latter was too complex.

Since the data analysis was interwoven with the page generation, a simple copy-paste was not possible. So I took the opportunity to re-think and rebuild all of the analysis from the ground up.

## Notes

This one is a bit chonky, but the new data model and processing should be pretty clear, and I commented judiciously (as much for future-me as for you!) 

I recommend reviewing the classes in this order:

  * `Cover` -- the CLI command and entry point
  * `CoveredEntity` -- base class of the data model of things that have coverage metrics
  * `CoveredFile` -- model of source files, independent of content
  * `CoveredModule` -- model of modules loaded from repositories.
  * `CoverageReport` -- discovers all of the above, then computes metrics summaries for each.
  * `CoverageReportWriter` -- existing class now is purely HTML composition
  * `CoverageDatabase` and `SourceName` -- removed dead code; added minor capabilities.

## Why?

In order to move code out of the `runtime` subproject, the code-coverage infrastructure needs to support loading data sessions from multiple subproject.  That immediately leads to a problem in that coverage sessions can refer to the same module via multiple paths. Specifically, `runtime` tests use a file-based repository (prior to packing modules into the jar), while tests downstream in `sdk` (for instance) access those same modules from the runtime jar.  The coverage database serializes these different, the former as simple paths and the latter as a URLs like `jar:file:///...../foo.jar!path/to/module.fusion`

So ultimately the problem of needing to detect and dedupe those paths, and a ton of experimentation on design, led me to the much-improved, more flexible modeling here.


## Testing

This generates exactly the same HTML report as previously.  It also does so _after_ all the CLI code and tests moves into the `sdk` subproject (to come later).

## Learnings

You might note the new use of `URI` here, where `SourceName` has used `URL`.  After lots of thrashing about, and digging deep into the docs and code for both to understand the tradeoffs, I believe that `URI` is the way to go.  In fact, I can imagine getting rid of `SourceName` entirely in exchange for bespoke URI schemes.  This aligns well, since `SourceName` is really a source _identifier_, not all of which can be _located_.  But that's just rough ideas at this point.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.