### PR TITLE
Move HAMT into the newer `runtime/_private` package.

### DIFF
--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -81,9 +81,7 @@ tasks.jacocoTestCoverageVerification {
 // Documentation
 
 tasks.javadoc {
-    exclude("**/_Private_*",
-            "**/_private/**",
-            "dev/ionfusion/fusion/util/hamt/**")
+    exclude("**/_Private_*", "**/_private/**")
 
     title = "FusionJava API Reference"
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionStruct.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionStruct.java
@@ -33,7 +33,7 @@ import dev.ionfusion.fusion.FusionCollection.BaseCollection;
 import dev.ionfusion.fusion.FusionCompare.EqualityTier;
 import dev.ionfusion.fusion.FusionIterator.AbstractIterator;
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
-import dev.ionfusion.fusion.util.hamt.MultiHashTrie;
+import dev.ionfusion.runtime._private.util.hamt.MultiHashTrie;
 import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.SourceLocation;
 import java.io.IOException;

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/util/hamt/EmptyHashTrie.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/util/hamt/EmptyHashTrie.java
@@ -1,7 +1,7 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
 import java.util.Collections;
 import java.util.Set;

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/util/hamt/FunctionalHashTrie.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/util/hamt/FunctionalHashTrie.java
@@ -1,9 +1,9 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.TrieNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.TrieNode;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/util/hamt/HashArrayMappedTrie.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/util/hamt/HashArrayMappedTrie.java
@@ -1,7 +1,7 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/util/hamt/KvArrayIterator.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/util/hamt/KvArrayIterator.java
@@ -1,11 +1,11 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.CollisionNode;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.HashArrayMappedNode;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.TrieNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.CollisionNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.HashArrayMappedNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.TrieNode;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Iterator;
 import java.util.Map.Entry;

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/util/hamt/MultiHashTrie.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/util/hamt/MultiHashTrie.java
@@ -1,11 +1,11 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
-import static dev.ionfusion.fusion.util.hamt.EmptyHashTrie.EMPTY;
+import static dev.ionfusion.runtime._private.util.hamt.EmptyHashTrie.EMPTY;
 
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.TrieNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.TrieNode;
 import java.util.AbstractSet;
 import java.util.Collection;
 import java.util.Iterator;

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/util/hamt/MultiHashTrieImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/util/hamt/MultiHashTrieImpl.java
@@ -1,11 +1,11 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
-import static dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.NOTHING;
+import static dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.NOTHING;
 
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.TrieNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.TrieNode;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.Collection;

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/util/hamt/NodeArrayIterator.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/util/hamt/NodeArrayIterator.java
@@ -1,10 +1,10 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.HashArrayMappedNode;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.TrieNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.HashArrayMappedNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.TrieNode;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;

--- a/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/BitMappedNodeTransformTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/BitMappedNodeTransformTest.java
@@ -1,13 +1,13 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
 import static dev.ionfusion.testing.Permute.generateSubsetPermutations;
 import static java.util.Collections.unmodifiableList;
 
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.BitMappedNode;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.Changes;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.BitMappedNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.Changes;
 import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;

--- a/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/CustomKey.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/CustomKey.java
@@ -1,7 +1,7 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
 /**
  * This class allows us to easily form hash collisions for different keys.

--- a/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/EmptyHashTrieTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/EmptyHashTrieTest.java
@@ -1,14 +1,15 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
-import static dev.ionfusion.fusion.util.hamt.MultiHashTrie.empty;
+import static dev.ionfusion.runtime._private.util.hamt.MultiHashTrie.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import dev.ionfusion.fusion.util.hamt.TransformTestCase.IncrementXform;
+
+import dev.ionfusion.runtime._private.util.hamt.TransformTestCase.IncrementXform;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +59,7 @@ public class EmptyHashTrieTest
     @Test
     public void merge1GivenSingleValuesReturnsIt()
     {
-        FunctionalHashTrie h = hash1(10,1, 11,1, 12,1);
+        FunctionalHashTrie h = hash1(10, 1, 11, 1, 12, 1);
         assertThat(empty().merge1(h), sameInstance(h));
     }
 

--- a/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/FlatNodeTransformTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/FlatNodeTransformTest.java
@@ -1,13 +1,13 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
 import static dev.ionfusion.testing.Permute.generateSubsetPermutations;
 import static java.util.Collections.unmodifiableList;
 
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.CollisionNode;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.FlatNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.CollisionNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.FlatNode;
 import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;

--- a/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/FunctionalHashTrieTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/FunctionalHashTrieTest.java
@@ -1,13 +1,13 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
-import static dev.ionfusion.fusion.util.hamt.FunctionalHashTrie.empty;
-import static dev.ionfusion.fusion.util.hamt.FunctionalHashTrie.fromArrays;
-import static dev.ionfusion.fusion.util.hamt.FunctionalHashTrie.fromEntries;
-import static dev.ionfusion.fusion.util.hamt.FunctionalHashTrie.fromMap;
-import static dev.ionfusion.fusion.util.hamt.FunctionalHashTrie.fromSelectedKeys;
+import static dev.ionfusion.runtime._private.util.hamt.FunctionalHashTrie.empty;
+import static dev.ionfusion.runtime._private.util.hamt.FunctionalHashTrie.fromArrays;
+import static dev.ionfusion.runtime._private.util.hamt.FunctionalHashTrie.fromEntries;
+import static dev.ionfusion.runtime._private.util.hamt.FunctionalHashTrie.fromMap;
+import static dev.ionfusion.runtime._private.util.hamt.FunctionalHashTrie.fromSelectedKeys;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;

--- a/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/HamNodeTransformTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/HamNodeTransformTest.java
@@ -1,7 +1,7 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
 import static dev.ionfusion.testing.Permute.generateSubsets;
 import static java.util.Collections.unmodifiableList;
@@ -10,10 +10,10 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.BitMappedNode;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.Changes;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.HashArrayMappedNode;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.TrieNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.BitMappedNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.Changes;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.HashArrayMappedNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.TrieNode;
 import java.util.List;
 import java.util.function.BiFunction;
 import org.junit.jupiter.api.AfterAll;

--- a/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/HashArrayMappedTrieTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/HashArrayMappedTrieTest.java
@@ -1,12 +1,12 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
-import static dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.empty;
-import static dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.fromArrays;
-import static dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.fromSelectedKeys;
-import static dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.hashCodeFor;
+import static dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.empty;
+import static dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.fromArrays;
+import static dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.fromSelectedKeys;
+import static dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.hashCodeFor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -16,12 +16,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.BitMappedNode;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.Changes;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.CollisionNode;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.FlatNode;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.HashArrayMappedNode;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.TrieNode;
+
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.BitMappedNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.Changes;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.CollisionNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.FlatNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.HashArrayMappedNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.TrieNode;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/MultiHashTrieImplTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/MultiHashTrieImplTest.java
@@ -1,18 +1,19 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
-import static dev.ionfusion.fusion.util.hamt.MultiHashTrie.empty;
-import static dev.ionfusion.fusion.util.hamt.MultiHashTrie.fromArrays;
-import static dev.ionfusion.fusion.util.hamt.MultiHashTrie.fromEntries;
-import static dev.ionfusion.fusion.util.hamt.MultiHashTrie.fromSelectedKeys;
+import static dev.ionfusion.runtime._private.util.hamt.MultiHashTrie.empty;
+import static dev.ionfusion.runtime._private.util.hamt.MultiHashTrie.fromArrays;
+import static dev.ionfusion.runtime._private.util.hamt.MultiHashTrie.fromEntries;
+import static dev.ionfusion.runtime._private.util.hamt.MultiHashTrie.fromSelectedKeys;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import dev.ionfusion.fusion.util.hamt.TransformTestCase.Remove3sIncrement2sXform;
+
+import dev.ionfusion.runtime._private.util.hamt.TransformTestCase.Remove3sIncrement2sXform;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;

--- a/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/MultiHashTrieTestCase.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/MultiHashTrieTestCase.java
@@ -1,10 +1,10 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
-import static dev.ionfusion.fusion.util.hamt.FunctionalHashTrie.fromEntries;
-import static dev.ionfusion.fusion.util.hamt.MultiHashTrie.empty;
+import static dev.ionfusion.runtime._private.util.hamt.FunctionalHashTrie.fromEntries;
+import static dev.ionfusion.runtime._private.util.hamt.MultiHashTrie.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/RandomTrieTransformTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/RandomTrieTransformTest.java
@@ -1,10 +1,10 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.Changes;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.TrieNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.Changes;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.TrieNode;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;

--- a/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/TransformTestCase.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/_private/util/hamt/TransformTestCase.java
@@ -1,10 +1,10 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util.hamt;
+package dev.ionfusion.runtime._private.util.hamt;
 
-import static dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.NOTHING;
-import static dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.empty;
+import static dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.NOTHING;
+import static dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -14,8 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.Changes;
-import dev.ionfusion.fusion.util.hamt.HashArrayMappedTrie.TrieNode;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.Changes;
+import dev.ionfusion.runtime._private.util.hamt.HashArrayMappedTrie.TrieNode;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;


### PR DESCRIPTION

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
