### PR TITLE
Move general test cases into the `runtime` package.

### DIFF
--- a/runtime/src/test/java/dev/ionfusion/runtime/AssertionsEnabledTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/AssertionsEnabledTest.java
@@ -1,10 +1,11 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion.util;
+package dev.ionfusion.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+
 import org.junit.jupiter.api.Test;
 
 

--- a/runtime/src/test/java/dev/ionfusion/runtime/ScriptedTests.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/ScriptedTests.java
@@ -1,6 +1,8 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+package dev.ionfusion.runtime;
+
 import static dev.ionfusion.fusion.TestSetup.makeRuntimeBuilder;
 import static dev.ionfusion.testing.ProjectLayout.testRepositoryDirectory;
 import static dev.ionfusion.testing.ProjectLayout.testScriptDirectory;


### PR DESCRIPTION
## Description

This gets the last class out of `dev.ionfusion.fusion.util`.

And it was kinda weird to have one test outside of any package.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
