### PR TITLE
Cleanup Gradle scripts.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,15 +18,18 @@ dependencies {
 
     testReportAggregation(project(":sdk"))
     testReportAggregation(project(":testing"))
+
+    fcovReportData(project(":runtime", "fcovData"))
+    fcovReportData(project(":fusioncli", "fcovData"))
 }
 
 tasks.check {
-    dependsOn(tasks.named<JacocoReport>("testCodeCoverageReport"))
-    dependsOn(tasks.named<TestReport>("testAggregateTestReport"))
+    dependsOn(tasks.testCodeCoverageReport)
+    dependsOn(tasks.testAggregateTestReport)
     dependsOn(fcovAggregateReport)
 }
 
-tasks.named<JacocoReport>("testCodeCoverageReport") {
+tasks.testCodeCoverageReport {
     reports {
         // Simplify the output
         html.outputLocation = reporting.baseDirectory.dir("jacoco")
@@ -34,7 +37,7 @@ tasks.named<JacocoReport>("testCodeCoverageReport") {
     }
 }
 
-tasks.named<TestReport>("testAggregateTestReport") {
+tasks.testAggregateTestReport {
     destinationDirectory = reporting.baseDirectory.dir("tests")
 }
 
@@ -45,20 +48,13 @@ tasks.named<TestReport>("testAggregateTestReport") {
 //======================================================================================
 // Fusion coverage aggregate report
 
-// Declare the dataDirs for aggregate reporting.
-dependencies {
-    "fcovReportData"(project(path = ":runtime", configuration = "fcovData"))
-    "fcovReportData"(project(path = ":fusioncli", configuration = "fcovData"))
-}
-
-
 // The task is here instead of the conventions file because it is tied to the CLI's
 // classpath, which can't be used from every subproject (notably `runtime`).
 
 val fcovReportData by configurations.getting
 val fcovReportDir = reporting.baseDirectory.dir("fcov")
 
-val fcovAggregateReport = tasks.register<JavaExec>("fcovAggregateReport") {
+val fcovAggregateReport by tasks.registering(JavaExec::class) {
     group = "verification"
     description = "Generates Fusion code coverage report"
 

--- a/buildSrc/src/main/kotlin/buildlogic.fusion-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.fusion-common-conventions.gradle.kts
@@ -18,7 +18,7 @@ val fcovReportDir = reporting.baseDirectory.dir("fcov")
 //=============================================================================
 // Code Coverage Data Collection
 
-tasks.named<Test>("test") {
+tasks.test {
     // Rerun tests if the coverage config changes; we might record different things.
     inputs.file(fcovConfig)
     outputs.dir(fcovDataDir)
@@ -41,8 +41,8 @@ private fun instrumentationArguments(): List<String> {
 
 
 // Signal the test task to collect Fusion coverage data.
-val fcovTestCollect = tasks.register("fcovTestCollect") {
-    dependsOn(tasks.named<Test>("test"))
+val fcovTestCollect by tasks.registering {
+    dependsOn(tasks.test)
     outputs.dir(fcovDataDir)
     doLast {
         logger.lifecycle("Collected Fusion coverage data into ${fcovDataDir.get().asFile.path}")

--- a/buildSrc/src/main/kotlin/buildlogic.java-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.java-common-conventions.gradle.kts
@@ -3,7 +3,7 @@
 
 // Conventions for Java libraries and applications.
 
-version = project.properties.get("projectVersion")!!
+version = project.properties["projectVersion"]!!
 
 plugins {
     java
@@ -35,19 +35,19 @@ java {
 }
 
 // Enable some linting.  TODO Work toward -Xlint:all
-tasks.withType<JavaCompile>() {
+tasks.withType<JavaCompile> {
     options.compilerArgumentProviders.add {
         listOf("-Xlint:serial")
     }
 }
 
-tasks.named<Test>("test") {
+tasks.test {
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()
 }
 
 // Temporary alias until we migrate tooling
 // TODO https://github.com/ion-fusion/fusion-java/issues/429
-tasks.register("release") {
+val release by tasks.registering {
     dependsOn(tasks.build)  // build depends on assemble & check
 }

--- a/fusioncli/build.gradle.kts
+++ b/fusioncli/build.gradle.kts
@@ -32,7 +32,7 @@ tasks.jacocoTestCoverageVerification {
 //=============================================================================
 // Application
 
-// It took a loooong time to figure out how to access APP_HOME.
+// It took a long time to figure out how to access APP_HOME.
 // https://discuss.gradle.org/t/42870/4
 // https://stackoverflow.com/questions/22153041?rq=3
 // It's still not entirely working: `gradle run` doesn't see the replaced script.
@@ -46,6 +46,6 @@ tasks.startScripts {
 application {
     applicationName = "fusion"
     mainClass.set("dev.ionfusion.fusioncli.Cli")
-    // This is unused today, but is likely to be useful and it was hard to do.
+    // This is unused today, but is likely to be useful, and it was hard to do.
     applicationDefaultJvmArgs = listOf("-Ddev.ionfusion.fusion.Home={{APP_HOME}}/fusion")
 }

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -52,7 +52,7 @@ tasks.test {
     inputs.dir(testFusionRepo)
 }
 
-val ftstRepo = tasks.register<Jar>("ftstRepo") {
+val ftstRepo by tasks.registering(Jar::class) {
     destinationDirectory = base.libsDirectory
     archiveFileName = "ftst-repo.jar"
 
@@ -100,7 +100,3 @@ tasks.javadoc {
         noTimestamp(true)
     }
 }
-
-
-//=============================================================================
-// Distribution

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -19,10 +19,6 @@ dependencies {
 }
 
 
-// Locate the repository from which we'll generate Fusion docs.
-// TODO Define appropriate consumable and resolvable configurations for Fusion repos.
-val mainFusionRepo = layout.projectDirectory.dir("../runtime/src/main/fusion")
-
 // This subproject currently doesn't have any Java code
 tasks.jar {
     enabled = false
@@ -46,15 +42,24 @@ tasks.test {
 //=============================================================================
 // Documentation
 
-val fusiondoc = tasks.register<JavaExec>("fusiondoc") {
+val fusiondoc by tasks.registering(JavaExec::class) {
     group = "Documentation"
     description = "Generates Fusion language and library documentation."
 
-    val fusiondocDir = java.docsDir.dir("fusiondoc")
+    // Locate the repository from which we'll generate Fusion docs.
+    // TODO Define consumable and resolvable configurations for Fusion repos.
+    val runtimeRepo = project(":runtime").file("src/main/fusion")
+    inputs.dir(runtimeRepo)
 
     var docSrcDir   = layout.projectDirectory.dir("src/doc")
+    inputs.dir(docSrcDir)
+
     var articlesDir = docSrcDir.dir("articles")
     var assetsDir   = docSrcDir.dir("assets")
+
+    val outputDir = java.docsDir.dir("fusiondoc")
+    outputs.dir(outputDir)
+
 
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = java.toolchain.languageVersion
@@ -63,19 +68,12 @@ val fusiondoc = tasks.register<JavaExec>("fusiondoc") {
     classpath = project(":fusioncli").sourceSets["main"].runtimeClasspath
     mainClass = "dev.ionfusion.fusioncli.Cli"
     args = listOf("document",
-                  "--modules",  mainFusionRepo.toString(),
+                  "--modules",  runtimeRepo.toString(),
                   "--articles", articlesDir.toString(),
                   "--assets",   assetsDir.toString(),
-                  fusiondocDir.get().asFile.path)
+                  outputDir.get().asFile.path)
 
     enableAssertions = true
-
-    // Docgen has Java code! Not sure if this is the best solution...
-    dependsOn(tasks.compileJava)
-
-    inputs.dir(mainFusionRepo)
-    inputs.dir(docSrcDir)
-    outputs.dir(fusiondocDir)
 }
 
 
@@ -89,10 +87,8 @@ distributions {
         distributionBaseName = "ion-fusion-sdk"
 
         contents {
-            val javadoc = project(":runtime").tasks.javadoc
-
             into("bin") {
-                from(project(":fusioncli").tasks.named("startScripts"))
+                from(project(":fusioncli").tasks.startScripts)
             }
 
             // TODO JavaDocs should be beside, not inside, the Fusion docs.
@@ -101,7 +97,7 @@ distributions {
                 from(fusiondoc)
             }
             into("docs/javadoc") {
-                from(javadoc)
+                from(project(":runtime").tasks.javadoc)
             }
 
             from(rootDir.resolve("LICENSE"))


### PR DESCRIPTION
Use Kotlin idioms to avoid repeating symbolic names as strings.

## Description

Apparently the only way to learn the crisp way is by first copying examples that do things in the roundabout way.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
