### PR TITLE
Simplify and strengthen namespace-level storage.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/Binding.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Binding.java
@@ -74,7 +74,7 @@ abstract class Binding
 
     /**
      * Gets the original binding to which this binding refers.
-     * Returns itself, if and only if this binding is original.
+     * Returns itself if and only if this binding is original.
      *
      * @return not null.
      */

--- a/runtime/src/main/java/dev/ionfusion/fusion/Namespace.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Namespace.java
@@ -284,8 +284,12 @@ abstract class Namespace
 
     private final SyntaxWraps          myWraps;
     private final BoundIdMap<NsBinding> myBindings = new BoundIdMap<>();
-    private       int                   myDefinitionCount;
-    private final ArrayList<Object>    myValues   = new ArrayList<>();
+
+    /**
+     * Storage for the values of namespace-level definitions.
+     */
+    private final ArrayList<Object> myDefinedValues = new ArrayList<>();
+
     private ArrayList<BindingDoc> myBindingDocs;
 
 
@@ -369,7 +373,10 @@ abstract class Namespace
      */
     final int definitionCount()
     {
-        return myDefinitionCount;
+        synchronized (myDefinedValues)
+        {
+            return myDefinedValues.size();
+        }
     }
 
     /**
@@ -516,8 +523,15 @@ abstract class Namespace
         }
         if (newDefinition == null)
         {
-            newDefinition = newDefinedBinding(identifier, myDefinitionCount);
-            myDefinitionCount++;
+            // Allocate a new address for this definition.
+            int address;
+            synchronized (myDefinedValues)
+            {
+                address = myDefinedValues.size();
+                myDefinedValues.add(null);
+            }
+
+            newDefinition = newDefinedBinding(identifier, address);
         }
 
         installBinding(identifier, newDefinition);
@@ -548,7 +562,7 @@ abstract class Namespace
         }
         else // We need to grow the list. Annoying lack of API to do this.
         {
-            list.ensureCapacity(myDefinitionCount);        // Grow all at once
+            list.ensureCapacity(definitionCount());        // Grow all at once
             for (int i = size; i < address; i++)
             {
                 list.add(null);
@@ -567,7 +581,10 @@ abstract class Namespace
     @Override
     public final void set(int address, Object value)
     {
-        set(myValues, address, value);
+        synchronized (myDefinedValues)
+        {
+            myDefinedValues.set(address, value);
+        }
     }
 
 
@@ -811,9 +828,13 @@ abstract class Namespace
         if (binding.isOwnedBy(this))
         {
             int address = binding.myAddress;
-            if (address < myValues.size())         // for prepare-time lookup
+
+            synchronized (myDefinedValues)
             {
-                return myValues.get(address);
+                if (address < myDefinedValues.size())         // for prepare-time lookup
+                {
+                    return myDefinedValues.get(address);
+                }
             }
         }
         return null;
@@ -855,7 +876,10 @@ abstract class Namespace
     @Override
     public final Object lookup(int address)
     {
-        return myValues.get(address);
+        synchronized (myDefinedValues)
+        {
+            return myDefinedValues.get(address);
+        }
     }
 
     @Override
@@ -867,7 +891,10 @@ abstract class Namespace
 
     final Object[] extractValues()
     {
-        return myValues.toArray();
+        synchronized (myDefinedValues)
+        {
+            return myDefinedValues.toArray();
+        }
     }
 
 


### PR DESCRIPTION
This does two things:
  * Stop pointless lazy allocation that left dangerous edge cases while adding work to every mutation of a namespace variable.
  * Synchronizes all access to the store, so behavior under contention is better behaved.  At the very least, we won't corrupt this data structure.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
