### PR TITLE
Centralize FusionInterrupt handling in embedding layer

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/StandardRuntime.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/StandardRuntime.java
@@ -37,8 +37,8 @@ final class StandardRuntime
     {
         IonSystem ionSystem =
             IonSystemBuilder.standard()
-                .withCatalog(builder.getDefaultIonCatalog())
-                .build();
+                            .withCatalog(builder.getDefaultIonCatalog())
+                            .build();
         myRegistry = new ModuleRegistry();
 
         myDefaultLanguage = builder.getDefaultLanguage();
@@ -196,14 +196,15 @@ final class StandardRuntime
     }
 
 
-    //========================================================================
+
 
 
     @Override
     public IonValue ionize(Object fusionValue, ValueFactory factory)
         throws FusionException
     {
-        return FusionValue.copyToIonValue(myTopLevel.getEvaluator(), fusionValue, factory);
+        return myTopLevel.withEvaluator(() ->
+                                            FusionValue.copyToIonValue(myTopLevel.getEvaluator(), fusionValue, factory));
     }
 
 
@@ -211,11 +212,12 @@ final class StandardRuntime
     public IonValue ionizeMaybe(Object fusionValue, ValueFactory factory)
         throws FusionException
     {
-        return FusionValue.copyToIonValueMaybe(myTopLevel.getEvaluator(), fusionValue, factory);
+        return myTopLevel.withEvaluator(() ->
+                                            FusionValue.copyToIonValueMaybe(myTopLevel.getEvaluator(), fusionValue, factory));
     }
 
 
-    //========================================================================
+
 
 
     private class SandboxBuilderImpl

--- a/runtime/src/main/java/dev/ionfusion/fusion/StandardRuntime.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/StandardRuntime.java
@@ -203,8 +203,8 @@ final class StandardRuntime
     public IonValue ionize(Object fusionValue, ValueFactory factory)
         throws FusionException
     {
-        return myTopLevel.withEvaluator(() ->
-                                            FusionValue.copyToIonValue(myTopLevel.getEvaluator(), fusionValue, factory));
+        return myTopLevel.withEvaluator(eval ->
+                                            FusionValue.copyToIonValue(eval, fusionValue, factory));
     }
 
 
@@ -212,12 +212,9 @@ final class StandardRuntime
     public IonValue ionizeMaybe(Object fusionValue, ValueFactory factory)
         throws FusionException
     {
-        return myTopLevel.withEvaluator(() ->
-                                            FusionValue.copyToIonValueMaybe(myTopLevel.getEvaluator(), fusionValue, factory));
+        return myTopLevel.withEvaluator(eval ->
+                                            FusionValue.copyToIonValueMaybe(eval, fusionValue, factory));
     }
-
-
-
 
 
     private class SandboxBuilderImpl

--- a/runtime/src/main/java/dev/ionfusion/fusion/StandardTopLevel.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/StandardTopLevel.java
@@ -35,8 +35,8 @@ final class StandardTopLevel
     {
         CoverageCollector collector = globalState.myCoverageCollector;
         Evaluator eval = (collector == null
-                            ? new Evaluator(globalState)
-                            : new CoverageEvaluator(globalState, collector));
+                          ? new Evaluator(globalState)
+                          : new CoverageEvaluator(globalState, collector));
 
         if (continuationMarks.length != 0)
         {
@@ -77,6 +77,28 @@ final class StandardTopLevel
         return myNamespace.getRegistry();
     }
 
+    @FunctionalInterface
+    interface EvalTask<T>
+    {
+        T run() throws FusionException;
+    }
+
+    <T> T withEvaluator(EvalTask<T> task)
+        throws FusionException
+    {
+        try
+        {
+            return task.run();
+        }
+        catch (FusionInterrupt e)
+        {
+            throw new FusionInterruptedException(e);
+        }
+    }
+
+
+    //========================================================================
+
     @Override
     public Object eval(String source, SourceName name)
         throws FusionInterruptedException, FusionException
@@ -106,8 +128,7 @@ final class StandardTopLevel
     public Object eval(IonReader source, SourceName name)
         throws FusionInterruptedException, FusionException
     {
-        try
-        {
+        return withEvaluator(() -> {
             Object result = voidValue(myEvaluator);
 
             if (source.getType() == null) source.next();
@@ -121,11 +142,7 @@ final class StandardTopLevel
             }
 
             return result;
-        }
-        catch (FusionInterrupt e)
-        {
-            throw new FusionInterruptedException(e);
-        }
+        });
     }
 
 
@@ -141,19 +158,12 @@ final class StandardTopLevel
     public Object load(File source)
         throws FusionInterruptedException, FusionException
     {
-        try
-        {
+        return withEvaluator(() -> {
             LoadHandler load = myEvaluator.getGlobalState().myLoadHandler;
 
             // This method parameterizes current_namespace for us:
-            return load.loadTopLevel(myEvaluator,
-                                     myNamespace,
-                                     source.toString());
-        }
-        catch (FusionInterrupt e)
-        {
-            throw new FusionInterruptedException(e);
-        }
+            return load.loadTopLevel(myEvaluator, myNamespace, source.toString());
+        });
     }
 
 
@@ -170,8 +180,7 @@ final class StandardTopLevel
             throw new IllegalArgumentException(message);
         }
 
-        try
-        {
+        withEvaluator(() -> {
             // Make sure we use the registry on our namespace.
             Evaluator eval =
                 myEvaluator.parameterizeCurrentNamespace(myNamespace);
@@ -184,24 +193,15 @@ final class StandardTopLevel
                 ModuleLocation.forIonReader(source, name);
 
             resolver.loadModule(eval, id, loc, true /* reload it */);
-        }
-        catch (FusionInterrupt e)
-        {
-            throw new FusionInterruptedException(e);
-        }
+            return null;
+        });
     }
 
     ModuleIdentity loadModule(String modulePath)
         throws FusionInterruptedException, FusionException
     {
-        try
-        {
-            return myNamespace.resolveAndLoadModule(myEvaluator, modulePath);
-        }
-        catch (FusionInterrupt e)
-        {
-            throw new FusionInterruptedException(e);
-        }
+        return withEvaluator(() ->
+                                 myNamespace.resolveAndLoadModule(myEvaluator, modulePath));
     }
 
     /**
@@ -210,42 +210,28 @@ final class StandardTopLevel
     ModuleInstance instantiateLoadedModule(ModuleIdentity id)
         throws FusionInterruptedException, FusionException
     {
-        try
-        {
-            return getRegistry().instantiate(myEvaluator, id);
-        }
-        catch (FusionInterrupt e)
-        {
-            throw new FusionInterruptedException(e);
-        }
+        return withEvaluator(() ->
+                                 getRegistry().instantiate(myEvaluator, id));
     }
 
 
     void attachModule(StandardTopLevel src, String modulePath)
         throws FusionInterruptedException, FusionException
     {
-        try
-        {
+        withEvaluator(() -> {
             myNamespace.attachModule(myEvaluator, src.myNamespace, modulePath);
-        }
-        catch (FusionInterrupt e)
-        {
-            throw new FusionInterruptedException(e);
-        }
+            return null;
+        });
     }
 
     @Override
     public void requireModule(String modulePath)
         throws FusionInterruptedException, FusionException
     {
-        try
-        {
+        withEvaluator(() -> {
             myNamespace.require(myEvaluator, modulePath);
-        }
-        catch (FusionInterrupt e)
-        {
-            throw new FusionInterruptedException(e);
-        }
+            return null;
+        });
     }
 
 
@@ -262,14 +248,10 @@ final class StandardTopLevel
             throw new IllegalArgumentException(msg);
         }
 
-        try
-        {
+        withEvaluator(() -> {
             myNamespace.bind(name, fv);
-        }
-        catch (FusionInterrupt e)
-        {
-            throw new FusionInterruptedException(e);
-        }
+            return null;
+        });
     }
 
 
@@ -277,24 +259,17 @@ final class StandardTopLevel
     public Object lookup(String name)
         throws FusionInterruptedException, FusionException
     {
-        try
-        {
-            return myNamespace.lookup(name);
-        }
-        catch (FusionInterrupt e)
-        {
-            // I don't think this can happen, but I prefer to be consistent
-            // throughout this class to be more resilient to changes.
-            throw new FusionInterruptedException(e);
-        }
+        return withEvaluator(() ->
+                                 // I don't think this can happen, but I prefer to be consistent
+                                 // throughout this class to be more resilient to changes.
+                                 myNamespace.lookup(name));
     }
 
 
     private Procedure lookupProcedure(String procedureName)
         throws FusionInterruptedException, FusionException
     {
-        try
-        {
+        return withEvaluator(() -> {
             Object proc = lookup(procedureName);
             if (proc instanceof Procedure)
             {
@@ -310,11 +285,7 @@ final class StandardTopLevel
             throw new FusionException(printQuotedSymbol(procedureName) +
                                       " is not a procedure: " +
                                       safeWriteToString(myEvaluator, proc));
-        }
-        catch (FusionInterrupt e)
-        {
-            throw new FusionInterruptedException(e);
-        }
+        });
     }
 
 
@@ -336,15 +307,9 @@ final class StandardTopLevel
             arguments[i] = fv;
         }
 
-        try
-        {
-            // TODO Should this set current_namespace?
-            return myEvaluator.callNonTail(proc, arguments);
-        }
-        catch (FusionInterrupt e)
-        {
-            throw new FusionInterruptedException(e);
-        }
+        return withEvaluator(() ->
+                                 // TODO Should this set current_namespace?
+                                 myEvaluator.callNonTail(proc, arguments));
     }
 
 
@@ -375,13 +340,9 @@ final class StandardTopLevel
     public void ionize(Object value, IonWriter out)
         throws FusionException
     {
-        try
-        {
+        withEvaluator(() -> {
             FusionIo.ionize(myEvaluator, out, value);
-        }
-        catch (FusionInterrupt e)
-        {
-            throw new FusionInterruptedException(e);
-        }
+            return null;
+        });
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/StandardTopLevel.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/StandardTopLevel.java
@@ -80,7 +80,7 @@ final class StandardTopLevel
     @FunctionalInterface
     interface EvalTask<T>
     {
-        T run() throws FusionException;
+        T run(Evaluator eval) throws FusionException;
     }
 
     <T> T withEvaluator(EvalTask<T> task)
@@ -88,7 +88,7 @@ final class StandardTopLevel
     {
         try
         {
-            return task.run();
+            return task.run(myEvaluator);
         }
         catch (FusionInterrupt e)
         {
@@ -128,16 +128,16 @@ final class StandardTopLevel
     public Object eval(IonReader source, SourceName name)
         throws FusionInterruptedException, FusionException
     {
-        return withEvaluator(() -> {
-            Object result = voidValue(myEvaluator);
+        return withEvaluator(eval -> {
+            Object result = voidValue(eval);
 
             if (source.getType() == null) source.next();
             while (source.getType() != null)
             {
-                SyntaxValue sourceExpr = readSyntax(myEvaluator, source, name);
+                SyntaxValue sourceExpr = readSyntax(eval, source, name);
 
                 // This method parameterizes current_namespace for us:
-                result = FusionEval.eval(myEvaluator, sourceExpr, myNamespace);
+                result = FusionEval.eval(eval, sourceExpr, myNamespace);
                 source.next();
             }
 
@@ -158,11 +158,11 @@ final class StandardTopLevel
     public Object load(File source)
         throws FusionInterruptedException, FusionException
     {
-        return withEvaluator(() -> {
-            LoadHandler load = myEvaluator.getGlobalState().myLoadHandler;
+        return withEvaluator(eval -> {
+            LoadHandler load = eval.getGlobalState().myLoadHandler;
 
             // This method parameterizes current_namespace for us:
-            return load.loadTopLevel(myEvaluator, myNamespace, source.toString());
+            return load.loadTopLevel(eval, myNamespace, source.toString());
         });
     }
 
@@ -180,19 +180,19 @@ final class StandardTopLevel
             throw new IllegalArgumentException(message);
         }
 
-        withEvaluator(() -> {
+        withEvaluator(eval -> {
             // Make sure we use the registry on our namespace.
-            Evaluator eval =
-                myEvaluator.parameterizeCurrentNamespace(myNamespace);
+            Evaluator parameterized =
+                eval.parameterizeCurrentNamespace(myNamespace);
 
             ModuleNameResolver resolver =
-                myEvaluator.getGlobalState().myModuleNameResolver;
+                eval.getGlobalState().myModuleNameResolver;
             ModuleIdentity id =
                 ModuleIdentity.forAbsolutePath(absoluteModulePath);
             ModuleLocation loc =
                 ModuleLocation.forIonReader(source, name);
 
-            resolver.loadModule(eval, id, loc, true /* reload it */);
+            resolver.loadModule(parameterized, id, loc, true /* reload it */);
             return null;
         });
     }
@@ -200,8 +200,8 @@ final class StandardTopLevel
     ModuleIdentity loadModule(String modulePath)
         throws FusionInterruptedException, FusionException
     {
-        return withEvaluator(() ->
-                                 myNamespace.resolveAndLoadModule(myEvaluator, modulePath));
+        return withEvaluator(eval ->
+                                 myNamespace.resolveAndLoadModule(eval, modulePath));
     }
 
     /**
@@ -210,16 +210,16 @@ final class StandardTopLevel
     ModuleInstance instantiateLoadedModule(ModuleIdentity id)
         throws FusionInterruptedException, FusionException
     {
-        return withEvaluator(() ->
-                                 getRegistry().instantiate(myEvaluator, id));
+        return withEvaluator(eval ->
+                                 getRegistry().instantiate(eval, id));
     }
 
 
     void attachModule(StandardTopLevel src, String modulePath)
         throws FusionInterruptedException, FusionException
     {
-        withEvaluator(() -> {
-            myNamespace.attachModule(myEvaluator, src.myNamespace, modulePath);
+        withEvaluator(eval -> {
+            myNamespace.attachModule(eval, src.myNamespace, modulePath);
             return null;
         });
     }
@@ -228,8 +228,8 @@ final class StandardTopLevel
     public void requireModule(String modulePath)
         throws FusionInterruptedException, FusionException
     {
-        withEvaluator(() -> {
-            myNamespace.require(myEvaluator, modulePath);
+        withEvaluator(eval -> {
+            myNamespace.require(eval, modulePath);
             return null;
         });
     }
@@ -248,7 +248,7 @@ final class StandardTopLevel
             throw new IllegalArgumentException(msg);
         }
 
-        withEvaluator(() -> {
+        withEvaluator(eval -> {
             myNamespace.bind(name, fv);
             return null;
         });
@@ -259,7 +259,7 @@ final class StandardTopLevel
     public Object lookup(String name)
         throws FusionInterruptedException, FusionException
     {
-        return withEvaluator(() ->
+        return withEvaluator(eval ->
                                  // I don't think this can happen, but I prefer to be consistent
                                  // throughout this class to be more resilient to changes.
                                  myNamespace.lookup(name));
@@ -269,7 +269,7 @@ final class StandardTopLevel
     private Procedure lookupProcedure(String procedureName)
         throws FusionInterruptedException, FusionException
     {
-        return withEvaluator(() -> {
+        return withEvaluator(eval -> {
             Object proc = lookup(procedureName);
             if (proc instanceof Procedure)
             {
@@ -284,7 +284,7 @@ final class StandardTopLevel
 
             throw new FusionException(printQuotedSymbol(procedureName) +
                                       " is not a procedure: " +
-                                      safeWriteToString(myEvaluator, proc));
+                                      safeWriteToString(eval, proc));
         });
     }
 
@@ -307,9 +307,9 @@ final class StandardTopLevel
             arguments[i] = fv;
         }
 
-        return withEvaluator(() ->
+        return withEvaluator(eval ->
                                  // TODO Should this set current_namespace?
-                                 myEvaluator.callNonTail(proc, arguments));
+                                 eval.callNonTail(proc, arguments));
     }
 
 
@@ -340,8 +340,8 @@ final class StandardTopLevel
     public void ionize(Object value, IonWriter out)
         throws FusionException
     {
-        withEvaluator(() -> {
-            FusionIo.ionize(myEvaluator, out, value);
+        withEvaluator(eval -> {
+            FusionIo.ionize(eval, out, value);
             return null;
         });
     }

--- a/runtime/src/main/java/dev/ionfusion/fusion/StandardTopLevel.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/StandardTopLevel.java
@@ -35,8 +35,8 @@ final class StandardTopLevel
     {
         CoverageCollector collector = globalState.myCoverageCollector;
         Evaluator eval = (collector == null
-                          ? new Evaluator(globalState)
-                          : new CoverageEvaluator(globalState, collector));
+                            ? new Evaluator(globalState)
+                            : new CoverageEvaluator(globalState, collector));
 
         if (continuationMarks.length != 0)
         {
@@ -259,10 +259,7 @@ final class StandardTopLevel
     public Object lookup(String name)
         throws FusionInterruptedException, FusionException
     {
-        return withEvaluator(eval ->
-                                 // I don't think this can happen, but I prefer to be consistent
-                                 // throughout this class to be more resilient to changes.
-                                 myNamespace.lookup(name));
+        return withEvaluator(eval -> myNamespace.lookup(name));
     }
 
 
@@ -307,9 +304,8 @@ final class StandardTopLevel
             arguments[i] = fv;
         }
 
-        return withEvaluator(eval ->
-                                 // TODO Should this set current_namespace?
-                                 eval.callNonTail(proc, arguments));
+        // TODO Should this set current_namespace?
+        return withEvaluator(eval -> eval.callNonTail(proc, arguments));
     }
 
 


### PR DESCRIPTION
Closes #517

Introduces `EvalTask<T>` functional interface and `withEvaluator()` helper
on `StandardTopLevel` to centralize `FusionInterrupt → FusionInterruptedException`
translation in one place.

All call sites in `StandardTopLevel` and `StandardRuntime` now use
`withEvaluator()`, including the previously missing `ionize` and
`ionizeMaybe` methods in `StandardRuntime`.