### PR TITLE
Make top-level forward references more robust.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/TopLevelNamespace.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/TopLevelNamespace.java
@@ -374,20 +374,24 @@ final class TopLevelNamespace
     /**
      * A reference to a top-level variable in the lexically-enclosing
      * namespace, when the binding isn't known at compile-time.
-     * In other words, a forward reference.
-     * <p>
-     * The first time the variable is dereferenced, we have to resolve the
-     * binding. We cache the resulting address so we only have to perform the
-     * expensive work once.
-     * <p>
-     * This uses a rare safe instance of the double-checked locking idiom:
-     * http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html
+     * In other words, a forward reference, or perhaps an erroneous unbound variable.
      */
     static final class CompiledFreeVariableReference
         implements CompiledForm
     {
-        private SyntaxSymbol myId;
+        /**
+         * The address of this variable in its namespace store.
+         * Since the variable was free at compile-time, we have to determine it lazily.
+         * As an invariant, this field is non-negative IFF the binding has been
+         * initialized with a value.
+         */
         private volatile int myAddress = -1;
+
+        /**
+         * The identifier used by this variable reference, to be resolved lazily.
+         * We clear it out when the fast path is enabled.
+         */
+        private volatile SyntaxSymbol myId;
 
         CompiledFreeVariableReference(SyntaxSymbol id)
         {
@@ -400,37 +404,53 @@ final class TopLevelNamespace
         {
             Namespace ns = (Namespace) store.namespace();
 
+            // Minimize reads from a volatile member.
+            // TBH I'm not sure if this has any meaningful effect.
             int address = myAddress;
-            if (address < 0)
+            if (address >= 0)
             {
-                synchronized (this)
-                {
-                    if (myAddress < 0)
-                    {
-                        NsDefinedBinding binding = ns.resolveDefinition(myId);
-                        if (binding == null)
-                        {
-                            throw makeUnboundError(myId);
-                        }
-
-                        myAddress = binding.myAddress;
-                        myId = null;
-                    }
-                }
-
-                address = myAddress;
+                // Fast path: the binding is defined and initialized.
+                return ns.lookup(address);
             }
 
-            // There's a potential failure here: the binding may have had an
-            // address assigned, but not yet a value. That could happen when
-            // another thread is in the midst of defining the binding.
-            // In such a scenario, the `result` may be null or even corrupt
-            // (if we happen to read from the store while it's being updated).
-            // However, that scenario is an *application* thread-safety
-            // violation since Fusion doesn't promise that concurrent
-            // mutation of a top-level namespace is thread-safe.
+            // Slow path: the identifier is not known to be defined and initialized.
+            // Use of double-checked locking idiom is safe b/c `myAddress` is volatile.
+            // http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html
+            synchronized (this)
+            {
+                address = myAddress;
+                if (address >= 0)    // double-check!
+                {
+                    // Another thread won the race through this slow path, so go fast.
+                    return ns.lookup(address);
+                }
 
-            return ns.lookup(address);
+                NsDefinedBinding binding = ns.resolveDefinition(myId);
+                if (binding != null)
+                {
+                    address = binding.myAddress;
+
+                    // Address allocation and slot initialization are not atomic!
+                    // The slot may still be empty.
+                    Object val = ns.lookup(address);
+                    if (val != null)
+                    {
+                        // Initialization is complete, so switch to the fast path.
+                        myAddress = address;
+
+                        // An identifier can carry lots of metadata. Let the GC take it.
+                        myId = null;
+
+                        return val;
+                    }
+
+                    // The slot is allocated but not yet initialized. From this thread's
+                    // perspective, the variable is effectively unbound.
+                }
+            }
+
+            throw makeUnboundError(myId);
+            // We will return to the slow path next time around.
         }
     }
 }

--- a/runtime/src/test/java/dev/ionfusion/fusion/BreakpointProc.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/BreakpointProc.java
@@ -1,0 +1,62 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.fusion;
+
+import static dev.ionfusion.fusion.FusionVoid.voidValue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * A very simple, single-use Fusion breakpoint.
+ */
+class BreakpointProc
+    extends Procedure0
+{
+    /**
+     * Latch that drops to zero when this breakpoint is hit.
+     */
+    final CountDownLatch myPauseLatch = new CountDownLatch(1);
+
+    /**
+     * Latch that drops to zero when this breakpoint should resume.
+     */
+    final CountDownLatch myResumeLatch = new CountDownLatch(1);
+
+
+    /**
+     * Wait for the Fusion breakpoint to be hit, pausing that thread.
+     */
+    void await()
+        throws InterruptedException
+    {
+        myPauseLatch.await();
+    }
+
+    /**
+     * Signal the Fusion thread to continue.
+     */
+    void resume()
+    {
+        assertTrue(myResumeLatch.getCount() > 0, "Breakpoint not hit");
+        myResumeLatch.countDown();
+    }
+
+
+    @Override
+    Object doApply(Evaluator eval)
+    {
+        try
+        {
+            myPauseLatch.countDown();     // Signal that we're paused.
+            myResumeLatch.await();        // Wait for the resume signal.
+        }
+        catch (InterruptedException e)
+        {
+            throw new FusionInterrupt();
+        }
+
+        return voidValue(eval);
+    }
+}

--- a/runtime/src/test/java/dev/ionfusion/fusion/CoreTestCase.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/CoreTestCase.java
@@ -509,10 +509,17 @@ public class CoreTestCase
     }
 
 
-    void expectUnboundIdentifierExn(String expr)
+    UnboundIdentifierException expectUnboundIdentifierExn(String expr)
         throws Exception
     {
-        assertEvalThrows(UnboundIdentifierException.class, expr);
+        return assertEvalThrows(UnboundIdentifierException.class, expr);
+    }
+
+    void expectUnboundIdentifierExn(String expr, String varName)
+        throws Exception
+    {
+        UnboundIdentifierException e = expectUnboundIdentifierExn(expr);
+        assertEquals(varName, e.getIdentifierString(), "implicated variable name");
     }
 
 

--- a/runtime/src/test/java/dev/ionfusion/fusion/TopLevelTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/TopLevelTest.java
@@ -6,7 +6,11 @@ package dev.ionfusion.fusion;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.embed.TopLevel;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -56,5 +60,74 @@ public class TopLevelTest
         Object plus = top.lookup("+");
         assertTrue(FusionProcedure.isProcedure(top, plus));
         checkLong(3, top.call(plus, 1, 2));
+    }
+
+
+    /**
+     * Tests behavior of top-level forward references evaluated simultaneously to the
+     * corresponding definition.
+     */
+    @Test
+    public void testRacingFreeVariableReference()
+        throws Exception
+    {
+        TopLevel top = topLevel();
+
+        BreakpointProc defnBreak = new BreakpointProc();
+        top.define("defn_break", defnBreak);
+
+        BreakpointProc initBreak = new BreakpointProc();
+        top.define("init_break", initBreak);
+
+        // Run a script in a worker thread. We'll use the above latches to step
+        // it through the various stages of initialization.
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try
+        {
+            Future<Object> worker = executor.submit(() -> {
+                try
+                {
+                    String src = "(begin                      \n" +
+                                 "  (define (getter) delayed) \n" + // forward reference
+                                 "  (defn_break)              \n" +
+                                 "  (define delayed           \n" +
+                                 "    (begin                  \n" +
+                                 "      (init_break)          \n" +
+                                 "      '''initialized'''))   \n" +
+                                 "  '''defined''')";
+                    return top.eval(src);
+                }
+                catch (FusionException e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            // Wait for the worker to define the forward-referencing getter proc.
+            defnBreak.await();
+            expectUnboundIdentifierExn("(getter)", "delayed");
+
+            // Let the worker start evaluating the definition.
+            defnBreak.resume();
+            initBreak.await();
+
+            // The worker is evaluating the definition but has not initialized the
+            // new slot.
+            expectUnboundIdentifierExn("(getter)", "delayed");
+
+            // Let the worker complete the delayed initialization.
+            initBreak.resume();
+
+            // Wait for the worker to complete.
+            Object workerResult = worker.get();  // Throws exn if the thread threw one.
+            checkString("defined", workerResult);
+
+            Object getterResult = eval("(getter)");
+            checkString("initialized", getterResult);
+        }
+        finally
+        {
+            executor.shutdownNow();
+        }
     }
 }


### PR DESCRIPTION
In conjunction with recent locking of storage in `Namespace`, this addresses a race condition to ensure the result is always valid.

The code is heavily rearranged and more thoroughly explained.

The new test case is less useful than it appears: the non-atomicity of `define` is deeper in the implementation than we can meaningfully test.  I had written most of this before I realized that, but the breakpoint approach seems worth keeping, so here it is.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
