### PR TITLE
Enforce that CompiledForm.doEval doesn't return null.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/CompiledForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/CompiledForm.java
@@ -18,6 +18,8 @@ interface CompiledForm
      * Evaluates a compiled form using the given dynamic context.
      * <p>
      * <em>Do not call this directly! Go through the evaluator.</em>
+     *
+     * @return not null.
      */
     Object doEval(Evaluator eval, Store store)
         throws FusionException;

--- a/runtime/src/main/java/dev/ionfusion/fusion/Evaluator.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Evaluator.java
@@ -505,12 +505,15 @@ class Evaluator
                         throw e;
                     }
 
+                    if (result == null)
+                    {
+                        return voidValue(this);
+                    }
+
                     continue checkingResult;
                 }
-                if (result == null)
-                {
-                    result = voidValue(this);
-                }
+
+                assert result != null;
                 return result;
             }
         }
@@ -566,6 +569,7 @@ class Evaluator
                     throw new FusionInterrupt();
                 }
 
+                // Closures bounce their body form to eliminate a stack frame:
                 if (result instanceof TailForm)
                 {
                     TailForm tail = (TailForm) result;
@@ -654,6 +658,8 @@ class Evaluator
      * Wraps an expression for evaluation in tail-position. MUST not be called from a
      * procedure. The result MUST be immediately returned to this evaluator, it's not a
      * normal value!
+     *
+     * @return not null
      */
     Object bounceTailForm(Store store, CompiledForm form)
     {


### PR DESCRIPTION
This removes an unnecessary branch from the interpreter's inner loop. 

I did a manual verification of all 40(!) implementations, and all are currently non-null per contract.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
