### PR TITLE
Update to Structural (Gradle plugin) 1.1.6

### DIFF
--- a/runtime/.structural-baseline.xml
+++ b/runtime/.structural-baseline.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <StructuralBaseline>
   <CurrentIssues>
-    <ID>ForbiddenImport$FusionJarInfo$6$dev.ionfusion.runtime.base$dev.ionfusion.fusion</ID>
-    <ID>ForbiddenImport$FusionRuntimeBuilder$8$dev.ionfusion.runtime.embed$dev.ionfusion.fusion</ID>
-    <ID>ForbiddenImport$TopLevel$7$dev.ionfusion.runtime.embed$dev.ionfusion.fusion</ID>
+    <ID>ForbiddenImport$FusionJarInfo$dev.ionfusion.runtime.base$dev.ionfusion.fusion._Private_Trampoline</ID>
+    <ID>ForbiddenImport$FusionRuntimeBuilder$dev.ionfusion.runtime.embed$dev.ionfusion.fusion._Private_Trampoline</ID>
+    <ID>ForbiddenImport$TopLevel$dev.ionfusion.runtime.embed$dev.ionfusion.fusion.FusionInterruptedException</ID>
   </CurrentIssues>
 </StructuralBaseline>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
     plugins {
         // Enforce our desired inter-package dependency structure.
         // https://github.com/adrianczuczka/structural
-        id("com.adrianczuczka.structural") version "1.1.5"
+        id("com.adrianczuczka.structural") version "1.1.6"
     }
 }
 


### PR DESCRIPTION
This uses a more robust schema for the baseline file, so it won't trigger violations for irrelevant changes.

See https://github.com/adrianczuczka/structural/issues/6

## Description

This solves the problem @DimitriosDalaklidhs encountered during #518 ([here](https://github.com/ion-fusion/fusion-java/pull/518#issuecomment-4230137008))

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
