### PR TITLE
Add `SourceLocation.getModuleIdentity()`.

### DIFF
--- a/fusioncli/src/main/java/dev/ionfusion/fusioncli/cover/CoverageReport.java
+++ b/fusioncli/src/main/java/dev/ionfusion/fusioncli/cover/CoverageReport.java
@@ -225,8 +225,7 @@ public class CoverageReport
      */
     private void noteLocationCoverage(SourceLocation loc, Boolean covered)
     {
-        SourceName name = loc.getSourceName();
-        ModuleIdentity id = name.getModuleIdentity();
+        ModuleIdentity id = loc.getModuleIdentity();
         if (id != null)
         {
             CoveredModule module = myCoveredModules.get(id);
@@ -237,10 +236,12 @@ public class CoverageReport
             module.noteLocationCoverage(loc, covered);
         }
 
-        // WARNING: `loc` may have been normalized above.
-        URI uri = loc.getSourceName().getUri();
+        // WARNING: `loc` may have been normalized above, in which case this uses the
+        // preferred SourceName.
+        SourceName name = loc.getSourceName();
+        URI uri = name.getUri();
         CoveredFile file = myCoveredFiles.get(uri);
-        assert file != null : "No CoveredFile for " + loc.getSourceName();
+        assert file != null : "No CoveredFile for " + name;
 
         file.noteLocationCoverage(loc, covered);
     }

--- a/fusioncli/src/main/java/dev/ionfusion/fusioncli/cover/CoveredModule.java
+++ b/fusioncli/src/main/java/dev/ionfusion/fusioncli/cover/CoveredModule.java
@@ -126,7 +126,7 @@ public class CoveredModule
      */
     public void noteLocationCoverage(SourceLocation loc, Boolean covered)
     {
-        assert myId == loc.getSourceName().getModuleIdentity();
+        assert myId == loc.getModuleIdentity();
 
         // Assume the caller has normalized the location, otherwise we'll have
         // two different keys for the same effective location.

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageConfiguration.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageConfiguration.java
@@ -227,13 +227,14 @@ public final class CoverageConfiguration
      */
     boolean locationIsSelected(SourceLocation loc)
     {
+        ModuleIdentity id = loc.getModuleIdentity();
+        if (moduleIsSelected(id)) return true;
+
         SourceName name = loc.getSourceName();
         if (name == null) return false;
 
-        ModuleIdentity id   = name.getModuleIdentity();
-        Path           file = name.getPath();
-
-        return (moduleIsSelected(id) || fileIsSelected(file));
+        Path file = name.getPath();
+        return fileIsSelected(file);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceLocation.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceLocation.java
@@ -80,6 +80,12 @@ public class SourceLocation
     }
 
 
+    public ModuleIdentity getModuleIdentity()
+    {
+        return (myName == null) ? null : myName.getModuleIdentity();
+    }
+
+
     //==================================================================================
     // Concrete implementations
 


### PR DESCRIPTION
This is a step toward removing `ModuleIdentity` from `SourceName`. Eventually, a source file may contain multiple modules, and a module could have data from multiple files.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
