### PR TITLE
Revamp module loader to avoid `ModuleLocation`.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/Evaluator.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Evaluator.java
@@ -129,6 +129,13 @@ class Evaluator
     //========================================================================
 
 
+    interface Thunk<R>
+    {
+        R eval(Evaluator eval)
+            throws FusionException;
+    }
+
+
     /**
      * Injects an Ion DOM into the equivalent Fusion runtime objects.
      * It is an error for modifications to be made to the argument instance

--- a/runtime/src/main/java/dev/ionfusion/fusion/LoadHandler.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/LoadHandler.java
@@ -11,6 +11,7 @@ import static dev.ionfusion.fusion.SyntaxException.makeSyntaxError;
 
 import com.amazon.ion.IonException;
 import com.amazon.ion.IonReader;
+import dev.ionfusion.fusion.Evaluator.Thunk;
 import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ModuleIdentity;
 import dev.ionfusion.runtime.base.SourceLocation;
@@ -21,7 +22,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 
 /**
- * Parallel to Racket's load handler.
+ * Parallel to Racket's default load handler, usually {@code (current-load)}.
  */
 final class LoadHandler
 {
@@ -141,25 +142,23 @@ final class LoadHandler
     }
 
 
+    /**
+     * @param name may be null
+     */
     private SyntaxSexp readModuleDeclaration(Evaluator eval,
-                                             ModuleIdentity id,
-                                             ModuleLocation loc)
+                                             Thunk<IonReader> readerMaker,
+                                             SourceName name,
+                                             ModuleIdentity id)
         throws FusionException
     {
-        SourceName sourceName = loc.sourceName();
-        try
+        try (IonReader reader = readerMaker.eval(eval))
         {
-            try (IonReader reader = loc.read(eval))
-            {
-                return readModuleDeclaration(eval, id, sourceName, reader);
-            }
+            return readModuleDeclaration(eval, id, name, reader);
         }
         catch (IOException | IonException e)
         {
-            String where =
-                (sourceName == null ? id.toString() : sourceName.display());
-            String message =
-                "Error loading " + where + ": " + e.getMessage();
+            String where = (name == null ? id.toString() : name.display());
+            String message = "Error loading " + where + ": " + e.getMessage();
             throw new FusionException(message, e);
         }
     }
@@ -186,6 +185,7 @@ final class LoadHandler
     /**
      * Reads module source and declares it in the current namespace's registry.
      * The module is not instantiated.
+     * Its identity is determined by the current-module-declare-name parameter.
      */
     private void evalModuleDeclaration(Evaluator eval,
                                        SourceName sourceName,
@@ -219,24 +219,30 @@ final class LoadHandler
 
 
     /**
-     * Reads module source and declares it in the current namespace's registry.
-     * The module is not instantiated.
+     * Reads module source and declares it in the current namespace's registry. The
+     * module is not instantiated.
+     *
+     * @param name may be null.
      */
-    void loadModule(Evaluator eval, ModuleIdentity id, ModuleLocation loc)
+    void loadModule(Evaluator eval,
+                    Thunk<IonReader> reader,
+                    SourceName name,
+                    ModuleIdentity id)
         throws FusionException
     {
-        SyntaxSexp moduleDeclaration = readModuleDeclaration(eval, id, loc);
+        SyntaxSexp decl = readModuleDeclaration(eval, reader, name, id);
 
         try
         {
-            evalModuleDeclaration(eval, loc.sourceName(), moduleDeclaration);
+            evalModuleDeclaration(eval, name, decl);
         }
         catch (AssertionError e)
         {
             // Attempt to make debugging easier.
             // TODO Similarly wrap other unchecked exceptions?
             // TODO this doesn't need to be rewrapped by each module
-            throw new AssertionError("Assertion failure in " + loc + ": ", e);
+            String where = (name == null ? id.toString() : name.display());
+            throw new AssertionError("Assertion failure loading " + where + ": ", e);
         }
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/ModuleLocation.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ModuleLocation.java
@@ -3,7 +3,9 @@
 
 package dev.ionfusion.fusion;
 
+import com.amazon.ion.IonException;
 import com.amazon.ion.IonReader;
+import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ModuleIdentity;
 import dev.ionfusion.runtime.base.SourceName;
 import java.io.File;
@@ -20,8 +22,7 @@ import java.nio.file.Files;
  * encapsulating the physical location of the module code.  They are consumed by
  * the {@link LoadHandler}, when loading the module.
  * <p>
- * "ModuleResource" might be a better name, or perhaps "ModuleCodeProvider"
- * since they can only be consumed once (see {@link #read}).
+ * "ModuleResource" might be a better name, or perhaps "ModuleCodeProvider".
  * <p>
  * TODO: {@link SourceName} should track the repository holding the module.
  *    This would enable better messaging, cover Jar-based resources nicely, and
@@ -53,6 +54,22 @@ abstract class ModuleLocation
     abstract IonReader read(Evaluator eval)
         throws IOException;
 
+    IonReader openReader(Evaluator eval)
+        throws FusionException
+    {
+        try
+        {
+            return this.read(eval);
+        }
+        catch (IOException | IonException e)
+        {
+            String where = myName.getModuleIdentity().toString();
+            String message =
+                "Error loading " + where + ": " + e.getMessage();
+            throw new FusionException(message, e);
+        }
+    }
+
 
     @Override
     public String toString()
@@ -61,17 +78,22 @@ abstract class ModuleLocation
         return (name == null ? super.toString() : name.toString());
     }
 
-    static ModuleLocation forIonReader(IonReader source, SourceName name)
-    {
-        return new IonReaderModuleLocation(source, name);
-    }
 
+    /**
+     * @param id must not be null.
+     * @param sourceFile must not be null.
+     * @return a new {@link ModuleLocation}.
+     */
     static ModuleLocation forFile(ModuleIdentity id, File sourceFile)
     {
         return new FileModuleLocation(id, sourceFile);
     }
 
-
+    /**
+     * @param id must not be null.
+     * @param url must not be null.
+     * @return a new {@link ModuleLocation}.
+     */
     static ModuleLocation forUrl(ModuleIdentity id, URL url)
     {
         // TODO We may want to handle jar: URLs specially, so we can distinguish
@@ -92,25 +114,6 @@ abstract class ModuleLocation
         catch (URISyntaxException e)
         {
             throw new RuntimeException("Malformed `file:` URL", e);
-        }
-    }
-
-
-    private static final class IonReaderModuleLocation
-        extends ModuleLocation
-    {
-        private final IonReader  mySource;
-
-        IonReaderModuleLocation(IonReader source, SourceName name)
-        {
-            super(name);
-            mySource = source;
-        }
-
-        @Override
-        IonReader read(Evaluator eval)
-        {
-            return mySource;
         }
     }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/ModuleNameResolver.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ModuleNameResolver.java
@@ -13,8 +13,11 @@ import static dev.ionfusion.fusion.SyntaxException.makeSyntaxError;
 import static dev.ionfusion.runtime.base.ModuleIdentity.isValidAbsoluteModulePath;
 import static dev.ionfusion.runtime.base.ModuleIdentity.isValidModulePath;
 
+import com.amazon.ion.IonReader;
+import dev.ionfusion.fusion.Evaluator.Thunk;
 import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ModuleIdentity;
+import dev.ionfusion.runtime.base.SourceName;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -99,7 +102,7 @@ final class ModuleNameResolver
     /**
      * Check whether we know that a module has been declared in a registry.
      */
-    boolean isDeclared(ModuleRegistry registry, ModuleIdentity id)
+    private boolean isDeclared(ModuleRegistry registry, ModuleIdentity id)
     {
         synchronized (myRegistryCache)
         {
@@ -190,10 +193,11 @@ final class ModuleNameResolver
 
         if (isDeclared(reg, id)) return id;
 
+        // Ensure that the requested module exists in one of our repositories.
         ModuleLocation loc = locate(eval, id, stxForErrors);
         if (loc != null)
         {
-            if (load) loadModule(eval, id, loc, false /* don't reload */);
+            if (load) loadModule(eval, loc::openReader, loc.sourceName(), id, false /* don't reload */);
             return id;
         }
 
@@ -253,23 +257,25 @@ final class ModuleNameResolver
 
 
     /**
-     * Loads a module from a known location into the current namespace's
-     * registry. The module is not instantiated.
+     * Loads a module from a known location into the current namespace's registry. The
+     * module is not instantiated.
      * <p>
-     * This method is awkwardly placed in this class, and might make more sense
-     * in {@link LoadHandler}.  However, Racket gives this component the task
-     * of parameterizing current_module_declare_name and performing cycle
-     * detection, and I'm loath to change that without good cause.
+     * This method is awkwardly placed in this class, and might make more sense in
+     * {@link LoadHandler}.  However, Racket gives this component the task of
+     * parameterizing current_module_declare_name and performing cycle detection, and
+     * I'm loath to change that without good cause.
      * <p>
-     * Also, its unclear how all of this will play out for enclosed submodules
-     * like {@code (module Parent ... (module Child ...))}.
+     * Also, its unclear how all of this will play out for enclosed submodules like
+     * {@code (module Parent ... (module Child ...))}.
      *
-     * @param reload indicates whether the module should be reloaded if it's
-     * already in the registry.
+     * @param name may be null.
+     * @param reload indicates whether the module should be reloaded if it's already in
+     * the registry.
      */
     void loadModule(Evaluator      eval,
+                    Thunk<IonReader> reader,
+                    SourceName name,
                     ModuleIdentity id,
-                    ModuleLocation loc,
                     boolean reload)
         throws FusionException
     {
@@ -288,7 +294,7 @@ final class ModuleNameResolver
                     eval.markedContinuation(new Object[]{ myCurrentModuleDeclareName,
                                                           MODULE_LOADING_MARK },
                                             new Object[]{ id, id });
-                myLoadHandler.loadModule(loadEval, id, loc);
+                myLoadHandler.loadModule(loadEval, reader, name, id);
                 // Evaluation of 'module' declares it, but doesn't instantiate.
                 // It also calls-back to registerDeclaredModule().
             }

--- a/runtime/src/main/java/dev/ionfusion/fusion/StandardTopLevel.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/StandardTopLevel.java
@@ -189,10 +189,8 @@ final class StandardTopLevel
                 eval.getGlobalState().myModuleNameResolver;
             ModuleIdentity id =
                 ModuleIdentity.forAbsolutePath(absoluteModulePath);
-            ModuleLocation loc =
-                ModuleLocation.forIonReader(source, name);
 
-            resolver.loadModule(parameterized, id, loc, true /* reload it */);
+            resolver.loadModule(parameterized, (e) -> source, name, id, true /* reload it */);
             return null;
         });
     }


### PR DESCRIPTION
This class has too much responsibility, notably the (generally one-shot) `IonReader` access.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
