### PR TITLE
Get rid of `SourceName.getFile()` and `getUrl()`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/ModuleLocation.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ModuleLocation.java
@@ -157,7 +157,7 @@ abstract class ModuleLocation
         InputStream openStream()
             throws IOException
         {
-            return sourceName().getUrl().openStream();
+            return sourceName().getUri().toURL().openStream();
         }
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -99,7 +100,7 @@ public class CoverageDatabase
     {
         // We can record a location with either a file or a URL.
         SourceName name = loc.getSourceName();
-        return name != null && (name.getFile() != null || name.getUrl() != null);
+        return name != null && (name.getPath() != null || name.getUri() != null);
     }
 
 
@@ -188,17 +189,17 @@ public class CoverageDatabase
     {
         iw.stepIn(STRUCT);
         {
-            File file = name.getFile();
+            Path file = name.getPath();
             if (file != null)
             {
                 iw.setFieldName("file");
-                iw.writeString(file.getPath());
+                iw.writeString(file.toString());
             }
             else
             {
-                URL url = name.getUrl();
+                URI url = name.getUri();
                 iw.setFieldName("url");
-                iw.writeString(url.toExternalForm());
+                iw.writeString(url.toString());
             }
 
             ModuleIdentity id = name.getModuleIdentity();

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceName.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceName.java
@@ -51,33 +51,18 @@ public class SourceName
      *
      * @return null if this source is not an actual file.
      */
-    public File getFile()
-    {
-        return null;
-    }
-
-    /**
-     * Returns the absolute path of the source file if one is known.
-     *
-     * @return null if this source is not an actual file.
-     */
     public Path getPath()
     {
         return null;
     }
 
     /**
-     * Returns a URL for the source. The protocol can vary; at least {@code file}
-     * and {@code jar} are possible. In general, {@link URL#openStream()} is
+     * Returns a URI for the source. The protocol can vary; at least {@code file}
+     * and {@code jar} are possible. In general, {@code toUrl().openStream()} is
      * expected to work.
      *
-     * @return null if this source cannot be identified as a URL.
+     * @return null if this source cannot be identified as a URI.
      */
-    public URL getUrl()
-    {
-        return null;
-    }
-
     public URI getUri()
     {
         return null;
@@ -161,9 +146,6 @@ public class SourceName
         }
 
         @Override
-        public File getFile() { return myFile; }
-
-        @Override
         public Path getPath() { return myFile.toPath(); }
 
         @Override
@@ -187,9 +169,6 @@ public class SourceName
             myId   = id;
             myFile = file;
         }
-
-        @Override
-        public File getFile() { return myFile; }
 
         @Override
         public Path getPath() { return myFile.toPath(); }
@@ -221,9 +200,6 @@ public class SourceName
             myId  = id;
             myUrl = url;
         }
-
-        @Override
-        public URL getUrl() { return myUrl; }
 
         @Override
         public URI getUri()
@@ -295,6 +271,11 @@ public class SourceName
     }
 
 
+    /**
+     * @param id must not be null.
+     * @param sourceFile must not be null.
+     * @return a new {@link SourceName}.
+     */
     public static SourceName forModule(ModuleIdentity id, File sourceFile)
     {
         requireNonNull(id, "id must not be null");
@@ -302,6 +283,11 @@ public class SourceName
     }
 
 
+    /**
+     * @param id must not be null.
+     * @param url must not be null.
+     * @return a new {@link SourceName}.
+     */
     public static SourceName forUrl(ModuleIdentity id, URL url)
     {
         requireNonNull(id, "id must not be null");


### PR DESCRIPTION
Use `getPath()` and `getUri()` instead, since we are trying to converge on those forms everywhere.

There's currently some asymmetry with URL/URI but that'll be cleaned up incrementally.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
