### PR TITLE
Remove unused `CoverageCollector.flushMetrics()`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollector.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollector.java
@@ -4,7 +4,6 @@
 package dev.ionfusion.runtime._private.cover;
 
 import dev.ionfusion.runtime.base.SourceLocation;
-import java.io.IOException;
 
 /**
  * EXPERIMENTAL extension point for collecting code-coverage statistics.
@@ -50,11 +49,4 @@ public interface CoverageCollector
      * @param loc must have been {@linkplain #locationInstrumented instrumented}.
      */
     void locationEvaluated(SourceLocation loc);
-
-
-    // TODO Think this through. I'm not really convinced this is correct.
-    //      Perhaps close() would be better?  save()?
-    // This appears to be unused.
-    void flushMetrics()
-        throws IOException;
 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollectorImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollectorImpl.java
@@ -6,7 +6,6 @@ package dev.ionfusion.runtime._private.cover;
 import dev.ionfusion.runtime.base.SourceLocation;
 import dev.ionfusion.runtime.embed.FusionRuntime;
 import java.io.File;
-import java.io.IOException;
 
 /**
  * Implements code-coverage metrics collection.
@@ -70,13 +69,5 @@ public final class CoverageCollectorImpl
     public void locationEvaluated(SourceLocation loc)
     {
         mySession.locationEvaluated(loc);
-    }
-
-
-    @Override
-    public void flushMetrics()
-        throws IOException
-    {
-        mySession.flushMetrics();
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageSession.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageSession.java
@@ -95,12 +95,6 @@ public class CoverageSession
     }
 
     @Override
-    public void flushMetrics()
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public boolean equals(Object o)
     {
         if (o == null || getClass() != o.getClass()) { return false; }

--- a/runtime/src/test/java/dev/ionfusion/fusion/CoverageTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/CoverageTest.java
@@ -56,11 +56,6 @@ public class CoverageTest
                                              loc.getSourceName());
             evaluated.add(loc2);
         }
-
-        @Override
-        public void flushMetrics()
-        {
-        }
     }
 
 


### PR DESCRIPTION

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
