### PR TITLE
Coverage API uses an atomic counter

### DIFF
--- a/fusioncli/src/main/java/dev/ionfusion/fusioncli/cover/CoverageReport.java
+++ b/fusioncli/src/main/java/dev/ionfusion/fusioncli/cover/CoverageReport.java
@@ -221,10 +221,12 @@ public class CoverageReport
 
     /**
      * Can be called multiple times for the same (effective) location; if any
-     * invocation passes true, then the location is considered covered.
+     * invocation passes nonzero, then the location is considered covered.
      */
-    private void noteLocationCoverage(SourceLocation loc, Boolean covered)
+    private void noteLocationCoverage(SourceLocation loc, Number count)
     {
+        boolean covered = count.longValue() > 0;
+
         ModuleIdentity id = loc.getModuleIdentity();
         if (id != null)
         {

--- a/runtime/src/main/java/dev/ionfusion/fusion/CoverageEvaluator.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/CoverageEvaluator.java
@@ -6,6 +6,7 @@ package dev.ionfusion.fusion;
 import dev.ionfusion.runtime._private.cover.CoverageCollector;
 import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.SourceLocation;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  *
@@ -65,9 +66,8 @@ final class CoverageEvaluator
             {
                 if (myCollector.locationIsRecordable(loc))
                 {
-                    form = new CoverageCompiledForm(loc, form);
-
-                    myCollector.locationInstrumented(loc);
+                    AtomicInteger counter = myCollector.locationInstrumented(loc);
+                    form = new CoverageCompiledForm(counter, form);
                 }
             }
 
@@ -83,22 +83,20 @@ final class CoverageEvaluator
     private static final class CoverageCompiledForm
         implements CompiledForm
     {
-        private final SourceLocation myLocation;
-        private final CompiledForm   myForm;
+        private final AtomicInteger myCounter;
+        private final CompiledForm  myForm;
 
-        CoverageCompiledForm(SourceLocation location,
-                             CompiledForm   decorated)
+        CoverageCompiledForm(AtomicInteger counter, CompiledForm decorated)
         {
-            myLocation  = location;
-            myForm      = decorated;
+            myCounter = counter;
+            myForm    = decorated;
         }
 
         @Override
         public Object doEval(Evaluator eval, Store store)
             throws FusionException
         {
-            CoverageCollector collector = ((CoverageEvaluator) eval).myCollector;
-            collector.locationEvaluated(myLocation);
+            myCounter.getAndIncrement();
 
             // TODO Eliminate tail-call?
             return myForm.doEval(eval, store);

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollector.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollector.java
@@ -4,6 +4,7 @@
 package dev.ionfusion.runtime._private.cover;
 
 import dev.ionfusion.runtime.base.SourceLocation;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * EXPERIMENTAL extension point for collecting code-coverage statistics.
@@ -13,10 +14,8 @@ import dev.ionfusion.runtime.base.SourceLocation;
  * may constrain the extent of coverage metrics by filtering based on location:
  * a {@code false} result indicates that the code point should not be
  * instrumented.  If the code is instrumented, it must be recorded with
- * {@link #locationInstrumented}.
- * <p>
- * At run time, {@link #locationEvaluated(SourceLocation)} is called each time a
- * coverable code point is (about to be) evaluated.
+ * {@link #locationInstrumented}. The resulting counter should be incremented each time
+ * the instrumented location is (about to be) evaluated.
  */
 public interface CoverageCollector
 {
@@ -25,28 +24,20 @@ public interface CoverageCollector
      * A true result is not an obligation to instrument the code.
      *
      * @return whether the compiler should record coverage for the location.
-     * If false, then {@link #locationInstrumented} and {@link #locationEvaluated}
-     * must not be called with an equivalent location.
+     * If false, then {@link #locationInstrumented} must not be called with an
+     * equivalent location.
      */
     boolean locationIsRecordable(SourceLocation loc);
 
     /**
      * Records that the code at some location has been instrumented.
      * <p>
-     * This method is called during compilation, so the code point hasn't been
-     * evaluated yet (and may never be evaluated).
-     * Implementations must be idempotent.
+     * This method is called during compilation, so the code point hasn't been evaluated
+     * yet (and may never be evaluated). Implementations must be idempotent.
      *
      * @param loc must be {@linkplain #locationIsRecordable recordable}.
-     */
-    void locationInstrumented(SourceLocation loc);
-
-    /**
-     * Records that the code at some location is about to be evaluated.
-     * This method will be called once for each evaluation associated with the
-     * location.
      *
-     * @param loc must have been {@linkplain #locationInstrumented instrumented}.
+     * @return the counter for the location, to be incremented for each evaluation.
      */
-    void locationEvaluated(SourceLocation loc);
+    AtomicInteger locationInstrumented(SourceLocation loc);
 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollectorImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageCollectorImpl.java
@@ -6,6 +6,7 @@ package dev.ionfusion.runtime._private.cover;
 import dev.ionfusion.runtime.base.SourceLocation;
 import dev.ionfusion.runtime.embed.FusionRuntime;
 import java.io.File;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Implements code-coverage metrics collection.
@@ -59,15 +60,8 @@ public final class CoverageCollectorImpl
 
 
     @Override
-    public void locationInstrumented(SourceLocation loc)
+    public AtomicInteger locationInstrumented(SourceLocation loc)
     {
-        mySession.locationInstrumented(loc);
-    }
-
-
-    @Override
-    public void locationEvaluated(SourceLocation loc)
-    {
-        mySession.locationEvaluated(loc);
+        return mySession.locationInstrumented(loc);
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
 
@@ -39,10 +40,11 @@ import java.util.function.BiConsumer;
  * Collects, reads, and writes coverage instrumentation data.
  */
 public class CoverageDatabase
+    implements CoverageCollector
 {
     private final Set<File> myRepositories = ConcurrentHashMap.newKeySet();
 
-    private final Map<SourceLocation,Boolean> myLocations = new ConcurrentHashMap<>();
+    private final Map<SourceLocation, AtomicInteger> myLocations = new ConcurrentHashMap<>();
 
 
     public CoverageDatabase()
@@ -96,7 +98,8 @@ public class CoverageDatabase
     /**
      * Indicates whether this database can record the given location.
      */
-    boolean locationIsRecordable(SourceLocation loc)
+    @Override
+    public boolean locationIsRecordable(SourceLocation loc)
     {
         // We can record a location with either a file or a URL.
         SourceName name = loc.getSourceName();
@@ -109,27 +112,18 @@ public class CoverageDatabase
      *
      * @param loc must be {@linkplain #locationIsRecordable recordable}.
      */
-    void locationInstrumented(SourceLocation loc)
+    @Override
+    public AtomicInteger locationInstrumented(SourceLocation loc)
     {
-        myLocations.computeIfAbsent(loc, l -> Boolean.FALSE);
-    }
-
-
-    /**
-     * Records that the code at some location is about to be evaluated.
-     *
-     * @param loc must have been {@linkplain #locationInstrumented instrumented}.
-     */
-    void locationEvaluated(SourceLocation loc)
-    {
-        myLocations.put(loc, Boolean.TRUE);
+        return myLocations.computeIfAbsent(loc, l -> new AtomicInteger());
     }
 
 
     /** Has a location been covered? */
     public boolean locationCovered(SourceLocation loc)
     {
-        return myLocations.getOrDefault(loc, false);
+        AtomicInteger covered = myLocations.get(loc);
+        return (covered != null && covered.get() > 0);
     }
 
 
@@ -149,7 +143,7 @@ public class CoverageDatabase
     }
 
 
-    public void forEachLocationCoverage(BiConsumer<SourceLocation, Boolean> visitor)
+    public void forEachLocationCoverage(BiConsumer<SourceLocation, AtomicInteger> visitor)
     {
         myLocations.forEach(visitor);
     }
@@ -416,14 +410,13 @@ public class CoverageDatabase
                 }
             }
 
-            SourceLocation loc =
-                SourceLocation.forLineColumn(line, column, name);
-            assert loc != null;
+            SourceLocation loc = SourceLocation.forLineColumn(line, column, name);
 
-            locationInstrumented(loc);
+            // Record the location even if it isn't covered
+            AtomicInteger counter = locationInstrumented(loc);
             if (covered)
             {
-                locationEvaluated(loc);
+                counter.getAndIncrement();
             }
         }
         in.stepOut();

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageSession.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageSession.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 /**
@@ -83,15 +84,9 @@ public class CoverageSession
     }
 
     @Override
-    public void locationInstrumented(SourceLocation loc)
+    public AtomicInteger locationInstrumented(SourceLocation loc)
     {
-        myDatabase.locationInstrumented(loc);
-    }
-
-    @Override
-    public void locationEvaluated(SourceLocation loc)
-    {
-        myDatabase.locationEvaluated(loc);
+        return myDatabase.locationInstrumented(loc);
     }
 
     @Override

--- a/runtime/src/test/java/dev/ionfusion/fusion/CoverageTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/CoverageTest.java
@@ -3,7 +3,8 @@
 
 package dev.ionfusion.fusion;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import dev.ionfusion.runtime._private.cover.CoverageCollector;
@@ -11,8 +12,9 @@ import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.SourceLocation;
 import dev.ionfusion.runtime.base.SourceName;
 import dev.ionfusion.runtime.embed.TopLevel;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -26,35 +28,21 @@ public class CoverageTest
     {
         boolean instrumentOnlyLineOne = false;
 
-        final Set<SourceLocation> instrumented = new HashSet<>();
-        final Set<SourceLocation> evaluated    = new HashSet<>();
+        final Map<SourceLocation, AtomicInteger> instrumented = new HashMap<>();
 
         @Override
         public boolean locationIsRecordable(SourceLocation loc)
         {
-            return (instrumentOnlyLineOne ? loc.getLine() == 1 : true);
+            return (!instrumentOnlyLineOne || loc.getLine() == 1);
         }
 
         @Override
-        public void locationInstrumented(SourceLocation loc)
+        public AtomicInteger locationInstrumented(SourceLocation loc)
         {
             // For simplicity, we'll ignore the offset.
             SourceLocation loc2 =
-                SourceLocation.forLineColumn(loc.getLine(),
-                                             loc.getColumn(),
-                                             loc.getSourceName());
-            instrumented.add(loc2);
-        }
-
-        @Override
-        public void locationEvaluated(SourceLocation loc)
-        {
-            // For simplicity, we'll ignore the offset.
-            SourceLocation loc2 =
-                SourceLocation.forLineColumn(loc.getLine(),
-                                             loc.getColumn(),
-                                             loc.getSourceName());
-            evaluated.add(loc2);
+                SourceLocation.forLineColumn(loc.getLine(), loc.getColumn(), loc.getSourceName());
+            return instrumented.computeIfAbsent(loc2,l ->new AtomicInteger());
         }
     }
 
@@ -69,8 +57,7 @@ public class CoverageTest
     private void checkCovered(SourceName name, long line, long column)
     {
         SourceLocation loc = SourceLocation.forLineColumn(line, column, name);
-        assertTrue(collector.instrumented.contains(loc));
-        assertTrue(collector.evaluated.contains(loc));
+        assertTrue(collector.instrumented.get(loc).get() > 0);
     }
 
 
@@ -91,8 +78,7 @@ public class CoverageTest
     private void checkNotCovered(SourceName name, long line, long column)
     {
         SourceLocation loc = SourceLocation.forLineColumn(line, column, name);
-        assertTrue(collector.instrumented.contains(loc));
-        assertFalse(collector.evaluated.contains(loc));
+        assertEquals(0, collector.instrumented.get(loc).get());
     }
 
 
@@ -112,8 +98,7 @@ public class CoverageTest
     private void checkNotInstrumented(SourceName name, long line, long column)
     {
         SourceLocation loc = SourceLocation.forLineColumn(line, column, name);
-        assertFalse(collector.instrumented.contains(loc));
-        assertFalse(collector.evaluated.contains(loc));
+        assertNull(collector.instrumented.get(loc));
     }
 
 


### PR DESCRIPTION
This avoids map lookups and method calls during execution.

## Description

Combined with the previous change, this noticeably improves build times (25-38s vs 40-50).


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
