### PR TITLE
Avoid `SourceLocation` in coverage reporting

### DIFF
--- a/fusioncli/src/main/java/dev/ionfusion/fusioncli/cover/CoverageReport.java
+++ b/fusioncli/src/main/java/dev/ionfusion/fusioncli/cover/CoverageReport.java
@@ -12,7 +12,6 @@ import dev.ionfusion.runtime._private.cover.CoverageConfiguration;
 import dev.ionfusion.runtime._private.cover.CoverageDatabase;
 import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ModuleIdentity;
-import dev.ionfusion.runtime.base.SourceLocation;
 import dev.ionfusion.runtime.base.SourceName;
 import java.io.File;
 import java.io.IOException;
@@ -69,8 +68,8 @@ public class CoverageReport
         // With all module sources collected, we can note a single one for each module.
         myCoveredModules.values().forEach(this::notePreferredSourceOfModule);
 
-        // With all source files identified, we can collect location metrics.
-        db.forEachLocationCoverage(this::noteLocationCoverage);
+        // With all source files identified, we can collect coverage metrics.
+        db.forEachCoverageEntry(this::noteCoverageEntry);
     }
 
 
@@ -223,29 +222,24 @@ public class CoverageReport
      * Can be called multiple times for the same (effective) location; if any
      * invocation passes nonzero, then the location is considered covered.
      */
-    private void noteLocationCoverage(SourceLocation loc, Number count)
+    private void noteCoverageEntry(URI uri, long offset, ModuleIdentity id,
+                                   Number count)
     {
         boolean covered = count.longValue() > 0;
 
-        ModuleIdentity id = loc.getModuleIdentity();
         if (id != null)
         {
             CoveredModule module = myCoveredModules.get(id);
+            module.noteOffsetCoverage(offset, covered);
 
-            // Use a SourceLocation with the module's preferred SourceName.
-            loc = module.normalizeLocation(loc);
-
-            module.noteLocationCoverage(loc, covered);
+            // Record stats using the module's preferred resource.
+            uri = module.getUri();
         }
 
-        // WARNING: `loc` may have been normalized above, in which case this uses the
-        // preferred SourceName.
-        SourceName name = loc.getSourceName();
-        URI uri = name.getUri();
         CoveredFile file = myCoveredFiles.get(uri);
-        assert file != null : "No CoveredFile for " + name;
+        assert file != null : "No CoveredFile for module " + id + " at " + uri;
 
-        file.noteLocationCoverage(loc, covered);
+        file.noteOffsetCoverage(offset, covered);
     }
 
 

--- a/fusioncli/src/main/java/dev/ionfusion/fusioncli/cover/CoveredEntity.java
+++ b/fusioncli/src/main/java/dev/ionfusion/fusioncli/cover/CoveredEntity.java
@@ -3,7 +3,6 @@
 
 package dev.ionfusion.fusioncli.cover;
 
-import dev.ionfusion.runtime.base.SourceLocation;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -43,11 +42,10 @@ abstract class CoveredEntity
     abstract Path getPath();
 
 
-    void noteLocationCoverage(SourceLocation loc, Boolean covered)
+    void noteOffsetCoverage(long offset, Boolean covered)
     {
-        assert loc.getStartOffset() >= 0;
-        assert loc.getSourceName().getUri().equals(getUri());
-        myCoverage.merge(loc.getStartOffset(), covered, (a, b) -> a || b);
+        assert offset >= 0;
+        myCoverage.merge(offset, covered, (a, b) -> a || b);
     }
 
 

--- a/fusioncli/src/main/java/dev/ionfusion/fusioncli/cover/CoveredModule.java
+++ b/fusioncli/src/main/java/dev/ionfusion/fusioncli/cover/CoveredModule.java
@@ -5,7 +5,6 @@ package dev.ionfusion.fusioncli.cover;
 
 import dev.ionfusion.runtime._private.cover.CoverageDatabase;
 import dev.ionfusion.runtime.base.ModuleIdentity;
-import dev.ionfusion.runtime.base.SourceLocation;
 import dev.ionfusion.runtime.base.SourceName;
 import java.net.URI;
 import java.nio.file.Path;
@@ -102,33 +101,5 @@ public class CoveredModule
                 }
             }
         }
-    }
-
-
-    /**
-     * Returns an equivalent location using our preferred source name.
-     */
-    public SourceLocation normalizeLocation(SourceLocation loc)
-    {
-        assert myPreferredSource != null;
-        if (loc.getSourceName().equals(myPreferredSource))
-        {
-            return loc;
-        }
-
-        return SourceLocation.forOffset(loc.getStartOffset(), myPreferredSource);
-    }
-
-
-    /**
-     * @param loc must have been {@link #normalizeLocation normalized}.
-     */
-    public void noteLocationCoverage(SourceLocation loc, Boolean covered)
-    {
-        assert myId == loc.getModuleIdentity();
-
-        // Assume the caller has normalized the location, otherwise we'll have
-        // two different keys for the same effective location.
-        super.noteLocationCoverage(loc, covered);
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
 
 
 /**
@@ -143,9 +142,19 @@ public class CoverageDatabase
     }
 
 
-    public void forEachLocationCoverage(BiConsumer<SourceLocation, AtomicInteger> visitor)
+    public interface CoverageEntryVisitor
     {
-        myLocations.forEach(visitor);
+        void visit(URI uri, long offset, ModuleIdentity module, AtomicInteger count);
+    }
+
+    public void forEachCoverageEntry(CoverageEntryVisitor visitor)
+    {
+        myLocations.forEach((loc, count) -> {
+            visitor.visit(loc.getSourceName().getUri(),
+                          loc.getStartOffset(),
+                          loc.getModuleIdentity(),
+                          count);
+        });
     }
 
 


### PR DESCRIPTION
## Context for recent changes

In the current stream of changes I'm reducing exposure to `SourceName` and `SourceLocation`.

`SourceName` containing a `ModuleIdentity` is problematic since a source file will be able to contain multiple modules.  That relationship is more appropriate in `SourceLocation`, but the latter class only has access to the module via the former.

Removing that has the deepest impact on (a) the coverage collecting and reporting, and (b) stack traces.  The coverage tooling really shouldn't need any of that, and this is another step in cleaning it up.

I've work-in-progress on a better model for identifying resources and their metadata, which should appear after some more preparatory cleanup.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
