### PR TITLE
Add utility class `ResourceIdentifier`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceIdentifier.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceIdentifier.java
@@ -1,0 +1,236 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Identifies a persistent, external resource, such as a file or a JAR entry.
+ * <p>
+ * On the whole, this offers a Fusion-oriented alternative to {@link URI}.
+ */
+public abstract class ResourceIdentifier
+{
+    /**
+     * Prevent instantiation from other places.
+     */
+    private ResourceIdentifier() {}
+
+
+    /**
+     * Returns a URI for the resource. The protocol can vary; at least {@code file} and
+     * {@code jar} are possible. In general, {@code toUrl().openStream()} is expected to
+     * work.
+     *
+     * @return not null.
+     */
+    public abstract URI getUri();
+
+    /**
+     * Returns the absolute, normalized path of the resource if one is known.
+     *
+     * @return null if this resource is not a file system resource.
+     */
+    public abstract Path getPath();
+
+    /**
+     * Opens an input stream for reading the resource.
+     *
+     * @return a new input stream.
+     *
+     * @throws IOException if there's a problem opening the stream.
+     */
+    public abstract InputStream openStream()
+        throws IOException;
+
+
+    /**
+     * Returns the resource location as text.
+     */
+    public String toString()
+    {
+        return getUri().toString();
+    }
+
+
+    //=========================================================================
+    // Factory methods
+
+    /**
+     * Creates a {@link ResourceIdentifier} representing a file.
+     *
+     * @param path is converted to a normalized absolute path.
+     *
+     * @return a new {@link ResourceIdentifier}.
+     *
+     * @see #forFile(String)
+     */
+    public static ResourceIdentifier forFile(Path path)
+    {
+        return new FileResource(path);
+    }
+
+    /**
+     * Creates a {@link ResourceIdentifier} representing a file.
+     *
+     * @param file is converted to a normalized absolute path.
+     *
+     * @return a new {@link ResourceIdentifier}.
+     *
+     * @see #forFile(String)
+     */
+    public static ResourceIdentifier forFile(File file)
+    {
+        return new FileResource(file.toPath());
+    }
+
+    /**
+     * Creates a {@link ResourceIdentifier} representing a file at the given path.
+     *
+     * @param path is converted to a normalized absolute path.
+     *
+     * @return a new {@link ResourceIdentifier}.
+     *
+     * @see #forFile(File)
+     */
+    public static ResourceIdentifier forFile(String path)
+    {
+        return forFile(Paths.get(path));
+    }
+
+
+    /**
+     * Creates a {@link ResourceIdentifier} representing a URI.
+     *
+     * @param uri must be a valid URI.
+     *
+     * @return a new {@link ResourceIdentifier}.
+     */
+    public static ResourceIdentifier forUri(URI uri)
+    {
+        // We may want to handle jar: URLs specially, so we can distinguish
+        //  the Jar's file-system path and the internal resource path.
+
+        if (uri.getScheme().equals("file"))
+        {
+            return new FileResource(Paths.get(uri));
+        }
+
+        return new UriResource(uri);
+    }
+
+    /**
+     * Creates a {@link ResourceIdentifier} representing a URI.
+     *
+     * @param uri must be a valid URI.
+     *
+     * @return a new {@link ResourceIdentifier} instance.
+     *
+     * @throws IllegalArgumentException if the URI is not valid.
+     */
+    public static ResourceIdentifier forUri(String uri)
+    {
+        return forUri(URI.create(uri));
+    }
+
+
+    /**
+     * Creates a {@link ResourceIdentifier} representing a URL.
+     *
+     * @param url is converted to a URI; must not be null.
+     *
+     * @return a new {@link ResourceIdentifier}.
+     */
+    public static ResourceIdentifier forUrl(URL url)
+    {
+        try
+        {
+            return forUri(url.toURI());
+        }
+        catch (URISyntaxException e)
+        {
+            throw new AssertionError(e); // should not happen
+        }
+    }
+
+
+    //=========================================================================
+    // Implementations
+
+    private static class UriResource
+        extends ResourceIdentifier
+    {
+        private final URI myUri;
+
+        private UriResource(URI url)
+        {
+            myUri = url;
+        }
+
+        @Override
+        public URI getUri()
+        {
+            return myUri;
+        }
+
+        @Override
+        public Path getPath()
+        {
+            return null;
+        }
+
+        public InputStream openStream()
+            throws IOException
+        {
+            return myUri.toURL().openStream();
+        }
+    }
+
+
+    /**
+     * Specialization avoids Path/URI conversion and fast-tracks {@link #openStream()}.
+     */
+    private static class FileResource
+        extends UriResource
+    {
+        private final Path myPath;
+
+        // Awkward constructor to avoid normalizing twice.
+        FileResource(Path normalizedPath, Object dummy)
+        {
+            super(normalizedPath.toUri());
+            myPath = normalizedPath;
+        }
+
+        FileResource(Path path)
+        {
+            this(path.toAbsolutePath().normalize(), null);
+        }
+
+        @Override
+        public Path getPath() { return myPath; }
+
+
+        @Override
+        public InputStream openStream()
+            throws IOException
+        {
+            return Files.newInputStream(getPath());
+        }
+
+        @Override
+        public String toString()
+        {
+            return myPath.toString();
+        }
+    }
+}

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/ResourceIdentifierTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/ResourceIdentifierTest.java
@@ -1,0 +1,126 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+import static dev.ionfusion.testing.ProjectLayout.testDataDirectory;
+import static dev.ionfusion.testing.ProjectLayout.testDataFile;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.amazon.ion.IonReader;
+import com.amazon.ion.system.IonReaderBuilder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+
+public class ResourceIdentifierTest
+{
+    public static final Path HELLO_PATH = testDataFile("hello.ion");
+
+    private void checkPathResource(Path path, ResourceIdentifier rsrc)
+    {
+        assertEquals(path, rsrc.getPath());
+        assertEquals(path.toString(), rsrc.toString());
+        assertEquals("file://" + path, rsrc.getUri().toString());
+    }
+
+    private static void checkContent(ResourceIdentifier rsrc)
+        throws IOException
+    {
+        try (InputStream in = rsrc.openStream();
+             IonReader reader = IonReaderBuilder.standard().build(in))
+        {
+            reader.next();
+            assertEquals("hello", reader.stringValue());
+        }
+    }
+
+
+    @Test
+    void testPathResources()
+        throws Exception
+    {
+        Path path = testDataFile("hello.ion");
+
+        ResourceIdentifier rsrc = ResourceIdentifier.forFile(path);
+        checkPathResource(path, rsrc);
+
+        rsrc = ResourceIdentifier.forFile(path.toFile());
+        checkPathResource(path, rsrc);
+
+        rsrc = ResourceIdentifier.forFile(path.toString());
+        checkPathResource(path, rsrc);
+
+        rsrc = ResourceIdentifier.forUri(path.toUri());
+        checkPathResource(path, rsrc);
+
+        rsrc = ResourceIdentifier.forUri(path.toUri().toString());
+        checkPathResource(path, rsrc);
+
+        rsrc = ResourceIdentifier.forUrl(path.toUri().toURL());
+        checkPathResource(path, rsrc);
+    }
+
+    @Test
+    void testPathNormalization()
+    {
+        Path dir  = testDataDirectory();
+        Path path = testDataFile("hello.ion");
+        assertThat(path.toString(), startsWith(dir.toString()));
+
+        Path dotted = dir.resolve("../data/hello.ion");
+        assertThat(dotted.toString(), containsString("/../"));
+
+        ResourceIdentifier rsrc = ResourceIdentifier.forFile(dotted);
+        checkPathResource(path, rsrc);
+
+        Path cwd      = Paths.get("").toAbsolutePath();
+        Path relative = cwd.relativize(path);
+        assertFalse(relative.isAbsolute());
+
+        rsrc = ResourceIdentifier.forFile(relative);
+        checkPathResource(path, rsrc);
+
+        rsrc = ResourceIdentifier.forFile("");
+        // URI adds a slash if the path is a directory
+        assertEquals("file://" + cwd + "/", rsrc.getUri().toString());
+    }
+
+    @Test
+    void testPathReading()
+        throws Exception
+    {
+        ResourceIdentifier rsrc = ResourceIdentifier.forFile(HELLO_PATH);
+        checkContent(rsrc);
+    }
+
+
+    @Test
+    void testUriFactories()
+        throws Exception
+    {
+        URL url = new URL("https:/bar/baz");
+        URI uri = url.toURI();
+
+        ResourceIdentifier rsrc = ResourceIdentifier.forUrl(url);
+        assertEquals("https:/bar/baz", rsrc.toString());
+        assertNull(rsrc.getPath());
+
+        rsrc = ResourceIdentifier.forUri(uri);
+        assertEquals("https:/bar/baz", rsrc.toString());
+        assertNull(rsrc.getPath());
+
+        rsrc = ResourceIdentifier.forUri(url.toString());
+        assertEquals("https:/bar/baz", rsrc.toString());
+        assertNull(rsrc.getPath());
+    }
+}


### PR DESCRIPTION
## Description

Here's a new way to handle streamable resources.  This brings together custom Path-vs-URI handling that's currently scattered and replicated, notably in `SourceName` and `ModuleLocation`.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
