### PR TITLE
Add three new public interfaces

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
@@ -118,7 +118,7 @@ public class CoverageDatabase
     public AtomicInteger locationInstrumented(SourceLocation loc)
     {
         URI uri = loc.getResourceId().getUri();
-        long offset = loc.getStartOffset();
+        long offset = loc.getOffset();
         ModuleIdentity module = loc.getModuleIdentity();
 
         return resourceInstrumented(uri).containsModule(module)

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/CodePosition.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/CodePosition.java
@@ -1,0 +1,23 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+/**
+ * Captures information about a specific piece of Fusion code, adding semantic context
+ * a position.
+ */
+public interface CodePosition
+    extends ResourcePosition
+{
+    /**
+     * Returns the module containing this position, if any.
+     * <p>
+     * It is not guaranteed that the module declaration is the only content of the
+     * resource: it could be a script with several modules inside, and module
+     * declarations will eventually nest.
+     *
+     * @return the module associated with this position, if any. Can be null.
+     */
+    ModuleIdentity getModuleIdentity();
+}

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptor.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptor.java
@@ -1,0 +1,54 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+/**
+ * Provides access to metadata about a resource and optionally access to its content.
+ * <p>
+ * Long term, this is intended to surface things like the deployment unit containing the
+ * resource, perhaps checksums, etc. This enables passing context from the component
+ * providing the resource.
+ */
+public interface ResourceDescriptor
+{
+    /**
+     * Returns a human-readable description of the resource, for display in messages.
+     * This could be a file path, a URL, or an arbitrary string.
+     *
+     * @return the displayable name of this source, not null or empty.
+     */
+    String display();
+
+    /**
+     * Returns an identifier of the resource content, if possible.
+     *
+     * @return can be null.
+     */
+    ResourceIdentifier getResourceId();
+
+
+    /**
+     * Returns a descriptor that displays as "unknown resource" and has no
+     * {@link ResourceIdentifier}.
+     *
+     * @return not null.
+     */
+    static ResourceDescriptor unknown()
+    {
+        return new ResourceDescriptor()
+        {
+            @Override
+            public String display()
+            {
+                return "unknown resource";
+            }
+
+            @Override
+            public ResourceIdentifier getResourceId()
+            {
+                return null;
+            }
+        };
+    }
+}

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourcePosition.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourcePosition.java
@@ -1,0 +1,69 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+import java.io.IOException;
+
+/**
+ * A specific location within some resource.
+ * <p>
+ * Because Fusion is oriented around Ion data, these locations have semantics aligned
+ * with {@link com.amazon.ion.TextSpan} and {@link com.amazon.ion.OffsetSpan}.
+ */
+public interface ResourcePosition
+{
+    /**
+     * Describes the resource containing this location.
+     *
+     * @return not null.
+     */
+    ResourceDescriptor getResourceDesc();
+
+    /**
+     * Identifies the resource containing this location if it's known.
+     *
+     * @return can be null.
+     */
+    default ResourceIdentifier getResourceId()
+    {
+        return getResourceDesc().getResourceId();
+    }
+
+    /**
+     * Gets the one-based line number.
+     *
+     * @return zero if the line and column are unknown.
+     */
+    long getLine();
+
+    /**
+     * Gets the one-based column number.
+     * <p>
+     * Because it doesn't make sense to count columns without counting lines, this value
+     * is zero whenever the line number is zero.
+     * </p>
+     *
+     * @return zero if the line and column are unknown.
+     */
+    long getColumn();
+
+    /**
+     * Gets the zero-based offset.
+     *
+     * @return -1 if the offset is unknown.
+     */
+    long getOffset();
+
+
+    /**
+     * Displays this position in a human-readable form, in terms of line, column, and
+     * resource.  Additional semantic context may also be included.
+     *
+     * @param out the stream to write into.
+     *
+     * @throws IOException if thrown by the {@link Appendable}.
+     */
+    void display(Appendable out)
+        throws IOException;
+}

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceLocation.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceLocation.java
@@ -14,15 +14,14 @@ import java.util.Objects;
 
 
 /**
- * A specific location within some source of data.  In this library they are
- * generally used to reference Fusion source code, but they are equally useful
- * for other forms of serialized data.
+ * A specific location within some Fusion source code.
  * <p>
  * Because Fusion is oriented around Ion data, these locations have semantics
  * aligned with {@link com.amazon.ion.TextSpan} and
  * {@link com.amazon.ion.OffsetSpan}.
  */
 public class SourceLocation
+    implements CodePosition
 {
     /** May be null. */
     private final SourceName myName;
@@ -37,16 +36,11 @@ public class SourceLocation
     }
 
 
-    /**
-     * Identifies the resource containing this location if it's known.
-     *
-     * @return can be null.
-     */
-    public ResourceIdentifier getResourceId()
+    @Override
+    public ResourceDescriptor getResourceDesc()
     {
-        return myName != null ? myName.getResourceId() : null;
+        return myName != null ? myName : ResourceDescriptor.unknown();
     }
-
 
     /**
      * Gets the name of the source of this location.
@@ -61,6 +55,7 @@ public class SourceLocation
      * Gets the one-based line number.
      * @return zero if the line is unknown.
      */
+    @Override
     public long getLine()
     {
         return 0;
@@ -74,13 +69,13 @@ public class SourceLocation
      * </p>
      * @return zero if the column is unknown.
      */
+    @Override
     public long getColumn()
     {
         return 0;
     }
 
 
-    // TODO Define what this offset is counting.
     /**
      * Gets the zero-based starting offset.
      * @return -1 if the offset is unknown.
@@ -90,7 +85,14 @@ public class SourceLocation
         return -1;
     }
 
+    @Override
+    public long getOffset()
+    {
+        return getStartOffset();
+    }
 
+
+    @Override
     public ModuleIdentity getModuleIdentity()
     {
         return (myName == null) ? null : myName.getModuleIdentity();
@@ -398,6 +400,7 @@ public class SourceLocation
      *
      * @throws IOException if thrown by the {@link Appendable}.
      */
+    @Override
     public void display(Appendable out)
         throws IOException
     {

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceName.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceName.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
  * for error reporting to users.
  */
 public class SourceName
+    implements ResourceDescriptor
 {
     /**
      * The standard extension for Fusion source code files.
@@ -37,6 +38,7 @@ public class SourceName
      *
      * @return the displayable name of this source
      */
+    @Override
     public String display()
     {
         return myDisplay;
@@ -47,6 +49,7 @@ public class SourceName
      *
      * @return can be null.
      */
+    @Override
     public ResourceIdentifier getResourceId()
     {
         return null;

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
@@ -137,7 +137,7 @@ public class SourceLocationTest
 
         assertEquals(line,   loc.getLine(),   "line");
         assertEquals(column, loc.getColumn(), "column");
-        assertEquals(offset, loc.getStartOffset(), "offset");
+        assertEquals(offset, loc.getOffset(), "offset");
 
         SourceName name = loc.getSourceName();
         if (display == null)


### PR DESCRIPTION
These will replace `SourceName` and `SourceLocation` in public APIs. They have better separation of concerns between description, resource location, and module identity.

`ResourceDescriptor` and `ResourcePosition` generalize `SourceName` and `SourceLocation` respectively, without coupling to code-specific concerns like module identity.

`CodePosition` will replace `SourceLocation` in public APIs where that coupling is appropriate. It generally corresponds to a "stack frame" where we require a file+position but also want to display the module (and potentially other semantic context).

The "replaced" classes are likely to survive internally to optimize storage: the current design avoids having a ModuleId pointer in every source location.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
