### PR TITLE
Test hash-equals of `ResourceDescriptor` and `ResourceIdentifier`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptor.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptor.java
@@ -49,6 +49,8 @@ public interface ResourceDescriptor
             {
                 return null;
             }
+
+            // Default equals/hashCode are correct
         };
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceIdentifier.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceIdentifier.java
@@ -17,6 +17,8 @@ import java.nio.file.Paths;
  * Identifies a persistent, external resource, such as a file or a JAR entry.
  * <p>
  * On the whole, this offers a Fusion-oriented alternative to {@link URI}.
+ * <p>
+ * Two identifiers are equal if they have equal URIs.
  */
 public abstract class ResourceIdentifier
 {
@@ -59,6 +61,25 @@ public abstract class ResourceIdentifier
     public String toString()
     {
         return getUri().toString();
+    }
+
+
+    public boolean equals(ResourceIdentifier that)
+    {
+        return this.getUri().equals(that.getUri());
+    }
+
+    @Override
+    public boolean equals(Object that)
+    {
+        return that instanceof ResourceIdentifier &&
+               this.equals((ResourceIdentifier) that);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getUri().hashCode();
     }
 
 

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/ResourceDescriptorTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/ResourceDescriptorTest.java
@@ -1,0 +1,42 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+import static dev.ionfusion.testing.Assertions.assertHashEquals;
+import static dev.ionfusion.testing.Assertions.assertNotHashEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class ResourceDescriptorTest
+{
+    @Test
+    void unknownDescriptorsNotEqual()
+    {
+        ResourceDescriptor unknown1 = ResourceDescriptor.unknown();
+        ResourceDescriptor unknown2 = ResourceDescriptor.unknown();
+
+        assertHashEquals(unknown1, unknown1);
+        assertHashEquals(unknown2, unknown2);
+
+        assertNotHashEquals(unknown1, unknown2);
+    }
+
+
+    /**
+     * Retain legacy equality of SourceName instances, for now at least. The design plan
+     * is for ResourceDescriptors to match on their ResourceIdentifier.
+     */
+    @Test
+    void sourceNamesMatchOnDisplay()
+    {
+        SourceName foo1 = SourceName.forDisplay("foo");
+        SourceName foo2 = SourceName.forDisplay("foo");
+        SourceName bar  = SourceName.forDisplay("bar");
+
+        assertHashEquals(foo1, foo1);
+        assertHashEquals(foo1, foo2);
+
+        assertNotHashEquals(foo1, bar);
+    }
+}

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/ResourceIdentifierTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/ResourceIdentifierTest.java
@@ -3,6 +3,7 @@
 
 package dev.ionfusion.runtime.base;
 
+import static dev.ionfusion.testing.Assertions.assertHashEquals;
 import static dev.ionfusion.testing.ProjectLayout.testDataDirectory;
 import static dev.ionfusion.testing.ProjectLayout.testDataFile;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -54,8 +55,11 @@ public class ResourceIdentifierTest
         ResourceIdentifier rsrc = ResourceIdentifier.forFile(path);
         checkPathResource(path, rsrc);
 
+        ResourceIdentifier orig = rsrc;
+
         rsrc = ResourceIdentifier.forFile(path.toFile());
         checkPathResource(path, rsrc);
+        assertHashEquals(orig, rsrc);
 
         rsrc = ResourceIdentifier.forFile(path.toString());
         checkPathResource(path, rsrc);

--- a/testing/src/main/java/dev/ionfusion/testing/Assertions.java
+++ b/testing/src/main/java/dev/ionfusion/testing/Assertions.java
@@ -1,0 +1,40 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.testing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+public class Assertions
+{
+    private Assertions() {}
+
+
+    /**
+     * Asserts that the given objects are {@link #equals} and have the same
+     * {@link #hashCode()}s.
+     */
+    public static void assertHashEquals(Object a, Object b)
+    {
+        assertEquals(a, b); // Check symmetry of equals()
+        assertEquals(b, a);
+
+        assertEquals(a.hashCode(), b.hashCode(), "hashCode");
+    }
+
+    /**
+     * Asserts that the given objects are not {@link #equals} and have different
+     * {@link #hashCode}s.
+     */
+    public static void assertNotHashEquals(Object a, Object b)
+    {
+        assertNotSame(a, b);
+
+        assertNotEquals(a, b); // Check symmetry of equals()
+        assertNotEquals(b, a);
+
+        assertNotEquals(a.hashCode(), b.hashCode(), "hashCode");
+    }
+}


### PR DESCRIPTION
## Description

Strengthening the contract and tests before deeper refactoring.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
