### PR TITLE
️Use `ResourcePosition` in `SyntaxValue` constructors

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/SimpleSyntaxValue.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SimpleSyntaxValue.java
@@ -8,7 +8,7 @@ import static dev.ionfusion.runtime._private.util.Empties.EMPTY_OBJECT_ARRAY;
 import com.amazon.ion.IonException;
 import com.amazon.ion.IonWriter;
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 import java.io.IOException;
 
 /**
@@ -22,58 +22,58 @@ class SimpleSyntaxValue
 
 
     /**
-     * @param loc may be null.
+     * @param pos can be null.
      * @param properties must not be null.
      * @param datum must not be null and must not be a {@link SyntaxValue}.
      */
-    SimpleSyntaxValue(SourceLocation loc, Object[] properties, BaseValue datum)
+    SimpleSyntaxValue(ResourcePosition pos, Object[] properties, BaseValue datum)
     {
-        super(loc, properties);
+        super(pos, properties);
         assert ! (datum instanceof SyntaxValue);
         myDatum = datum;
     }
 
     /**
-     * @param loc may be null.
+     * @param pos may be null.
      * @param datum must not be null and must not be a {@link SyntaxValue}.
      */
-    SimpleSyntaxValue(SourceLocation loc, BaseValue datum)
+    SimpleSyntaxValue(ResourcePosition pos, BaseValue datum)
     {
-        this(loc, EMPTY_OBJECT_ARRAY, datum);
+        this(pos, EMPTY_OBJECT_ARRAY, datum);
     }
 
 
     /**
-     * @param loc may be null.
+     * @param pos may be null.
      * @param datum must not be null and must not be a {@link SyntaxValue}.
      */
     static SyntaxValue makeOriginalSyntax(Evaluator      eval,
-                                          SourceLocation loc,
+                                          ResourcePosition pos,
                                           BaseValue      datum)
     {
-        return new SimpleSyntaxValue(loc, ORIGINAL_STX_PROPS, datum);
+        return new SimpleSyntaxValue(pos, ORIGINAL_STX_PROPS, datum);
     }
 
     /**
-     * @param loc may be null.
+     * @param pos may be null.
      * @param datum must not be null and must not be a {@link SyntaxValue}.
      */
     static SyntaxValue makeSyntax(Evaluator      eval,
-                                  SourceLocation loc,
+                                  ResourcePosition pos,
                                   BaseValue      datum)
     {
-        return new SimpleSyntaxValue(loc, datum);
+        return new SimpleSyntaxValue(pos, datum);
     }
 
     /**
-     * @param loc may be null.
+     * @param pos may be null.
      * @param datum must be a Fusion value but not a {@link SyntaxValue}.
      */
     static SyntaxValue makeSyntax(Evaluator      eval,
-                                  SourceLocation loc,
+                                  ResourcePosition pos,
                                   Object         datum)
     {
-        return new SimpleSyntaxValue(loc, (BaseValue) datum);
+        return new SimpleSyntaxValue(pos, (BaseValue) datum);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxContainer.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxContainer.java
@@ -6,7 +6,7 @@ package dev.ionfusion.fusion;
 import static dev.ionfusion.runtime._private.util.Empties.EMPTY_OBJECT_ARRAY;
 
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 
 abstract class SyntaxContainer
     extends SyntaxValue
@@ -20,15 +20,15 @@ abstract class SyntaxContainer
      */
     SyntaxWraps myWraps;
 
-    SyntaxContainer(SourceLocation loc, Object[] properties, SyntaxWraps wraps)
+    SyntaxContainer(ResourcePosition pos, Object[] properties, SyntaxWraps wraps)
     {
-        super(loc, properties);
+        super(pos, properties);
         myWraps = wraps;
     }
 
-    SyntaxContainer(SourceLocation loc)
+    SyntaxContainer(ResourcePosition pos)
     {
-        super(loc, EMPTY_OBJECT_ARRAY);
+        super(pos, EMPTY_OBJECT_ARRAY);
         myWraps = null;
     }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxKeyword.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxKeyword.java
@@ -10,7 +10,7 @@ import com.amazon.ion.IonException;
 import com.amazon.ion.IonWriter;
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 import java.io.IOException;
 
 final class SyntaxKeyword
@@ -20,38 +20,36 @@ final class SyntaxKeyword
     /**
      * @param datum must not be null.
      */
-    private SyntaxKeyword(SyntaxWraps    wraps,
-                          SourceLocation loc,
-                          Object[]       properties,
-                          BaseSymbol     datum)
+    private SyntaxKeyword(SyntaxWraps      wraps,
+                          ResourcePosition pos,
+                          Object[]         properties,
+                          BaseSymbol       datum)
     {
-        super(wraps, loc, properties, datum);
+        super(wraps, pos, properties, datum);
     }
 
     /**
      * @param datum must not be null.
      */
-    private SyntaxKeyword(SourceLocation loc,
-                          Object[]       properties,
-                          BaseSymbol     datum)
+    private SyntaxKeyword(ResourcePosition pos,
+                          Object[]         properties,
+                          BaseSymbol       datum)
     {
-        super(null, loc, properties, datum);
+        super(null, pos, properties, datum);
     }
 
 
-    static SyntaxKeyword makeOriginal(Evaluator      eval,
-                                      SourceLocation loc,
-                                      BaseSymbol     symbol)
+    static SyntaxKeyword makeOriginal(Evaluator        eval,
+                                      ResourcePosition pos,
+                                      BaseSymbol       symbol)
     {
-        return new SyntaxKeyword(loc, ORIGINAL_STX_PROPS, symbol);
+        return new SyntaxKeyword(pos, ORIGINAL_STX_PROPS, symbol);
     }
 
 
-    static SyntaxKeyword make(Evaluator      eval,
-                              SourceLocation loc,
-                              BaseSymbol     symbol)
+    static SyntaxKeyword make(Evaluator eval, ResourcePosition pos, BaseSymbol symbol)
     {
-        return new SyntaxKeyword(loc, EMPTY_OBJECT_ARRAY, symbol);
+        return new SyntaxKeyword(pos, EMPTY_OBJECT_ARRAY, symbol);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxList.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxList.java
@@ -14,7 +14,7 @@ import com.amazon.ion.IonWriter;
 import dev.ionfusion.fusion.FusionList.BaseList;
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 import java.io.IOException;
 
 final class SyntaxList
@@ -32,12 +32,12 @@ final class SyntaxList
     /**
      * @param datum an immutable list of {@link SyntaxValue}s.
      */
-    private SyntaxList(SourceLocation loc,
-                       Object[]       properties,
-                       SyntaxWraps    wraps,
-                       BaseList       datum)
+    private SyntaxList(ResourcePosition pos,
+                       Object[]         properties,
+                       SyntaxWraps      wraps,
+                       BaseList         datum)
     {
-        super(loc, properties, wraps);
+        super(pos, properties, wraps);
         myImmutableList = datum;
     }
 
@@ -45,10 +45,10 @@ final class SyntaxList
      * @param datum an immutable list of {@link SyntaxValue}s.
      */
     private SyntaxList(Evaluator eval,
-                       SourceLocation loc,
+                       ResourcePosition pos,
                        BaseList datum)
     {
-        super(loc);
+        super(pos);
         assert isImmutableList(eval, datum);
         myImmutableList = datum;
     }
@@ -64,21 +64,17 @@ final class SyntaxList
     /**
      * @param datum an immutable list of {@link SyntaxValue}s.
      */
-    static SyntaxList makeOriginal(Evaluator      eval,
-                                   SourceLocation loc,
-                                   BaseList       datum)
+    static SyntaxList makeOriginal(Evaluator eval, ResourcePosition pos, BaseList datum)
     {
-        return new SyntaxList(loc, ORIGINAL_STX_PROPS, null, datum);
+        return new SyntaxList(pos, ORIGINAL_STX_PROPS, null, datum);
     }
 
     /**
      * @param datum an immutable list of {@link SyntaxValue}s.
      */
-    static SyntaxList make(Evaluator      eval,
-                           SourceLocation loc,
-                           Object         datum)
+    static SyntaxList make(Evaluator eval, ResourcePosition pos, Object datum)
     {
-        return new SyntaxList(eval, loc, (BaseList) datum);
+        return new SyntaxList(eval, pos, (BaseList) datum);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSequence.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSequence.java
@@ -5,19 +5,19 @@ package dev.ionfusion.fusion;
 
 
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 
 abstract class SyntaxSequence
     extends SyntaxContainer
 {
-    SyntaxSequence(SourceLocation loc, Object[] properties, SyntaxWraps wraps)
+    SyntaxSequence(ResourcePosition pos, Object[] properties, SyntaxWraps wraps)
     {
-        super(loc, properties, wraps);
+        super(pos, properties, wraps);
     }
 
-    SyntaxSequence(SourceLocation loc)
+    SyntaxSequence(ResourcePosition pos)
     {
-        super(loc);
+        super(pos);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSexp.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSexp.java
@@ -22,7 +22,7 @@ import dev.ionfusion.fusion.FusionSexp.BaseSexp;
 import dev.ionfusion.fusion.FusionSexp.ImmutablePair;
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.util.IdentityHashMap;
@@ -37,12 +37,12 @@ final class SyntaxSexp
     /**
      * @param sexp must not be null.
      */
-    private SyntaxSexp(SourceLocation loc,
-                       Object[]       properties,
-                       SyntaxWraps    wraps,
-                       BaseSexp       sexp)
+    private SyntaxSexp(ResourcePosition pos,
+                       Object[]         properties,
+                       SyntaxWraps      wraps,
+                       BaseSexp         sexp)
     {
-        super(loc, properties, wraps);
+        super(pos, properties, wraps);
         assert sexp != null;
         mySexp = sexp;
     }
@@ -51,9 +51,9 @@ final class SyntaxSexp
     /**
      * @param sexp must not be null.
      */
-    private SyntaxSexp(SourceLocation loc, BaseSexp sexp)
+    private SyntaxSexp(ResourcePosition pos, BaseSexp sexp)
     {
-        super(loc);
+        super(pos);
         assert sexp != null;
         mySexp = sexp;
     }
@@ -66,45 +66,43 @@ final class SyntaxSexp
     }
 
 
-    static SyntaxSexp makeOriginal(Evaluator      eval,
-                                   SourceLocation loc,
-                                   BaseSexp       sexp)
+    static SyntaxSexp makeOriginal(Evaluator eval, ResourcePosition pos, BaseSexp sexp)
     {
-        return new SyntaxSexp(loc, ORIGINAL_STX_PROPS, null, sexp);
+        return new SyntaxSexp(pos, ORIGINAL_STX_PROPS, null, sexp);
     }
 
-    static SyntaxSexp make(Evaluator eval, SourceLocation loc, BaseSexp sexp)
+    static SyntaxSexp make(Evaluator eval, ResourcePosition pos, BaseSexp sexp)
     {
-        return new SyntaxSexp(loc, sexp);
+        return new SyntaxSexp(pos, sexp);
     }
 
     /**
-     * Instance will be {@link #isAnyNull()} if children is null.
+     * Instance will be {@link #isAnyNull()} if {@code children} is null.
      *
      * @param anns must not be null.
      * This method takes ownership of the array; the array and its elements
-     * must not be changed by calling code afterwards!
+     * must not be changed by calling code afterward!
      * @param children the children of the new sexp.
      * This method takes ownership of the array; the array and its elements
-     * must not be changed by calling code afterwards!
+     * must not be changed by calling code afterward!
      */
     static SyntaxSexp make(Evaluator eval,
-                           SourceLocation loc,
+                           ResourcePosition pos,
                            BaseSymbol[] anns,
                            SyntaxValue[] children)
     {
         BaseSexp datum = (children == null
                               ? nullSexp(eval, anns)
                               : immutableSexp(eval, anns, children));
-        return new SyntaxSexp(loc, datum);
+        return new SyntaxSexp(pos, datum);
     }
 
     /**
-     * Instance will be {@link #isAnyNull()} if children is null.
+     * Instance will be {@link #isAnyNull()} if {@code children} is null.
 
      * @param children the children of the new sexp.
      * This method takes ownership of the array; the array and its elements
-     * must not be changed by calling code afterwards!
+     * must not be changed by calling code afterward!
      */
     static SyntaxSexp make(Evaluator eval, SyntaxValue... children)
     {
@@ -112,16 +110,16 @@ final class SyntaxSexp
     }
 
     /**
-     * Instance will be {@link #isAnyNull()} if children is null.
+     * Instance will be {@link #isAnyNull()} if {@code children} is null.
 
      * @param children the children of the new sexp.
      * This method takes ownership of the array; the array and its elements
-     * must not be changed by calling code afterwards!
+     * must not be changed by calling code afterward!
      */
-    static SyntaxSexp make(Evaluator eval, SourceLocation loc,
+    static SyntaxSexp make(Evaluator eval, ResourcePosition pos,
                            SyntaxValue... children)
     {
-        return make(eval, loc, BaseSymbol.EMPTY_ARRAY, children);
+        return make(eval, pos, BaseSymbol.EMPTY_ARRAY, children);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxString.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxString.java
@@ -6,7 +6,7 @@ package dev.ionfusion.fusion;
 import static dev.ionfusion.runtime._private.util.Empties.EMPTY_OBJECT_ARRAY;
 
 import dev.ionfusion.fusion.FusionString.BaseString;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 
 final class SyntaxString
     extends SyntaxText<SyntaxString>
@@ -14,26 +14,26 @@ final class SyntaxString
     /**
      * @param datum must not be null.
      */
-    private SyntaxString(SyntaxWraps    wraps,
-                         SourceLocation loc,
-                         Object[]       properties,
-                         BaseString     datum)
+    private SyntaxString(SyntaxWraps      wraps,
+                         ResourcePosition pos,
+                         Object[]         properties,
+                         BaseString       datum)
     {
-        super(wraps, loc, properties, datum);
+        super(wraps, pos, properties, datum);
     }
 
-    static SyntaxString makeOriginal(Evaluator      eval,
-                                     SourceLocation loc,
-                                     BaseString     datum)
+    static SyntaxString makeOriginal(Evaluator        eval,
+                                     ResourcePosition pos,
+                                     BaseString       datum)
     {
-        return new SyntaxString(null, loc, ORIGINAL_STX_PROPS, datum);
+        return new SyntaxString(null, pos, ORIGINAL_STX_PROPS, datum);
     }
 
-    static SyntaxString make(Evaluator      eval,
-                             SourceLocation loc,
-                             BaseString     datum)
+    static SyntaxString make(Evaluator        eval,
+                             ResourcePosition pos,
+                             BaseString       datum)
     {
-        return new SyntaxString(null, loc, EMPTY_OBJECT_ARRAY, datum);
+        return new SyntaxString(null, pos, EMPTY_OBJECT_ARRAY, datum);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxStruct.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxStruct.java
@@ -8,7 +8,7 @@ import com.amazon.ion.IonWriter;
 import dev.ionfusion.fusion.FusionStruct.ImmutableStruct;
 import dev.ionfusion.fusion.FusionStruct.StructFieldVisitor;
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 import java.io.IOException;
 
 final class SyntaxStruct
@@ -20,43 +20,39 @@ final class SyntaxStruct
     /**
      * @param struct must not be null.
      */
-    private SyntaxStruct(SourceLocation  loc,
+    private SyntaxStruct(ResourcePosition pos,
                          Object[] properties,
                          SyntaxWraps wraps,
                          ImmutableStruct struct)
     {
-        super(loc, properties, wraps);
+        super(pos, properties, wraps);
         myStruct = struct;
     }
 
     /**
      * @param struct must not be null.
      */
-    private SyntaxStruct(SourceLocation  loc,
-                         ImmutableStruct struct)
+    private SyntaxStruct(ResourcePosition pos, ImmutableStruct struct)
     {
-        super(loc);
+        super(pos);
         myStruct = struct;
     }
 
 
-
-    static SyntaxStruct makeOriginal(Evaluator       eval,
-                                     SourceLocation  loc,
+    static SyntaxStruct makeOriginal(Evaluator eval,
+                                     ResourcePosition pos,
                                      ImmutableStruct struct)
     {
-        return new SyntaxStruct(loc, ORIGINAL_STX_PROPS, null, struct);
+        return new SyntaxStruct(pos, ORIGINAL_STX_PROPS, null, struct);
     }
 
 
     /**
      * @param datum must be an immutable struct
      */
-    static SyntaxStruct make(Evaluator eval,
-                             SourceLocation loc,
-                             Object datum)
+    static SyntaxStruct make(Evaluator eval, ResourcePosition pos, Object datum)
     {
-        return new SyntaxStruct(loc, (ImmutableStruct) datum);
+        return new SyntaxStruct(pos, (ImmutableStruct) datum);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSymbol.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSymbol.java
@@ -14,7 +14,7 @@ import static dev.ionfusion.runtime._private.util.Empties.EMPTY_STRING_ARRAY;
 
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 import java.util.Collections;
 import java.util.Set;
 
@@ -47,39 +47,37 @@ final class SyntaxSymbol
     private BoundIdentifier myBoundId;
 
     /**
-     * @param wraps may be null.
-     * @param loc may be null.
+     * @param wraps can be null.
+     * @param pos can be null.
      * @param properties must not be null.
      * @param datum must not be null.
      */
     private SyntaxSymbol(SyntaxWraps    wraps,
-                         SourceLocation loc,
+                         ResourcePosition pos,
                          Object[]       properties,
                          BaseSymbol     datum)
     {
-        super(wraps, loc, properties, datum);
+        super(wraps, pos, properties, datum);
     }
 
 
 
     /**
-     * @param loc may be null.
+     * @param pos can be null.
      * @param symbol must not be null.
      */
-    static SyntaxSymbol makeOriginal(SourceLocation loc,
-                                     BaseSymbol     symbol)
+    static SyntaxSymbol makeOriginal(ResourcePosition pos, BaseSymbol symbol)
     {
-        return new SyntaxSymbol(null, loc, ORIGINAL_STX_PROPS, symbol);
+        return new SyntaxSymbol(null, pos, ORIGINAL_STX_PROPS, symbol);
     }
 
     /**
-     * @param loc may be null.
+     * @param pos can be null.
      * @param symbol must not be null.
      */
-    static SyntaxSymbol make(SourceLocation loc,
-                             BaseSymbol     symbol)
+    static SyntaxSymbol make(ResourcePosition pos, BaseSymbol symbol)
     {
-        return new SyntaxSymbol(null, loc, EMPTY_OBJECT_ARRAY, symbol);
+        return new SyntaxSymbol(null, pos, EMPTY_OBJECT_ARRAY, symbol);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxText.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxText.java
@@ -5,7 +5,7 @@ package dev.ionfusion.fusion;
 
 import dev.ionfusion.fusion.FusionText.BaseText;
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 
 abstract class SyntaxText<Sub extends SyntaxText>
     extends SimpleSyntaxValue
@@ -13,17 +13,17 @@ abstract class SyntaxText<Sub extends SyntaxText>
     final SyntaxWraps myWraps;   // TODO make non-null to streamline logic.
 
     /**
-     * @param wraps may be null.
-     * @param loc may be null.
+     * @param wraps can be null.
+     * @param pos can be null.
      * @param properties must not be null.
      * @param datum must not be null.
      */
     SyntaxText(SyntaxWraps    wraps,
-               SourceLocation loc,
+               ResourcePosition pos,
                Object[]       properties,
                BaseText       datum)
     {
-        super(loc, properties, datum);
+        super(pos, properties, datum);
         myWraps = wraps;
     }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxValue.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxValue.java
@@ -28,7 +28,7 @@ abstract class SyntaxValue
 
     /**
      * Private key used to identify syntax objects constructed by the reader.
-     * We don't use a normal symbol here, because the property key must be
+     * We don't use a normal symbol here because the property key must be
      * kept private: a symbol would be interned and therefore reproducible.
      */
     static final Object STX_PROPERTY_ORIGINAL = new String("is_original");
@@ -41,20 +41,20 @@ abstract class SyntaxValue
         new Object[] { STX_PROPERTY_ORIGINAL, Boolean.TRUE };
 
 
-    private final SourceLocation mySrcLoc;
+    private final ResourcePosition myPosition;
 
     /** Not null, to streamline things. */
     private final Object[] myProperties;
 
 
     /**
-     * @param loc may be null.
+     * @param pos can be null.
      * @param properties must not be null.
      */
-    SyntaxValue(SourceLocation loc, Object[] properties)
+    SyntaxValue(ResourcePosition pos, Object[] properties)
     {
         assert properties != null;
-        mySrcLoc = loc;
+        myPosition = pos;
         myProperties = properties;
     }
 
@@ -70,11 +70,13 @@ abstract class SyntaxValue
 
     /**
      * Gets the location associated with this syntax node, if it exists.
-     * @return may be null.
+     * @return can be null.
      */
     SourceLocation getLocation()
     {
-        return mySrcLoc;
+        return (myPosition instanceof SourceLocation
+                ? (SourceLocation) myPosition
+                : null);
     }
 
     /**
@@ -83,7 +85,7 @@ abstract class SyntaxValue
      */
     ResourcePosition getPosition()
     {
-        return mySrcLoc;
+        return myPosition;
     }
 
 


### PR DESCRIPTION
## Description

This is the primary spot where `SourceLocation` is stored; hoisting to the new interface here unblocks a lot of similar hoisting in other places.

A lot will be touched, so I'll try to take things in reasonable steps so the review is easy.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
