### PR TITLE
Use `ResourcePosition` in `syntax_source`

### DIFF
--- a/runtime/src/main/fusion/modules/fusion/private/syntax.fusion
+++ b/runtime/src/main/fusion/modules/fusion/private/syntax.fusion
@@ -22,6 +22,7 @@ Intrinsic operators for working with syntax objects.
     syntax_line
     syntax_property
     syntax_size
+    syntax_source
     syntax_subseq
     syntax_to_datum
     syntax_track_origin

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSourceProc.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxSourceProc.java
@@ -8,8 +8,8 @@ import static dev.ionfusion.fusion.FusionSyntax.checkSyntaxArg;
 import static dev.ionfusion.fusion.FusionVoid.voidValue;
 
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
-import dev.ionfusion.runtime.base.SourceName;
+import dev.ionfusion.runtime.base.ResourceDescriptor;
+import dev.ionfusion.runtime.base.ResourcePosition;
 
 
 class SyntaxSourceProc
@@ -19,15 +19,12 @@ class SyntaxSourceProc
     Object doApply(Evaluator eval, Object arg)
         throws FusionException
     {
-        SyntaxValue stx = checkSyntaxArg(eval, this, 0, arg);
-        SourceLocation location = stx.getLocation();
-        if (location != null)
+        SyntaxValue      stx = checkSyntaxArg(eval, this, 0, arg);
+        ResourcePosition pos = stx.getPosition();
+        if (pos != null)
         {
-            SourceName name = location.getSourceName();
-            if (name != null)
-            {
-                return makeString(eval, name.display());
-            }
+            ResourceDescriptor rsrc = pos.getResourceDesc();
+            return makeString(eval, rsrc.display());
         }
         return voidValue(eval);
     }

--- a/runtime/src/test/fusion/scripts/syntax.test.fusion
+++ b/runtime/src/test/fusion/scripts/syntax.test.fusion
@@ -4,6 +4,7 @@
 (require
   "/fusion/experimental/check"
   "/fusion/experimental/syntax"
+  "/fusion/private/syntax"
   "/fusion/list"
   "/testutils"
   )
@@ -301,3 +302,11 @@
     (quote_syntax a::(true))
     (quote_syntax a::{f:true})
     ))
+
+
+//==========================================================================
+// syntax_source
+
+(check_pred
+  (|s| (string_ends_with s "/runtime/src/test/fusion/scripts/syntax.test.fusion"))
+  (syntax_source (quote_syntax here)))


### PR DESCRIPTION
Strangley, this feature was never exported, so fixed that.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
