### PR TITLE
Remove `SourceName.getPath()` and `getUri()`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/LoadHandler.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/LoadHandler.java
@@ -14,6 +14,7 @@ import com.amazon.ion.IonReader;
 import dev.ionfusion.fusion.Evaluator.Thunk;
 import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ModuleIdentity;
+import dev.ionfusion.runtime.base.ResourceIdentifier;
 import dev.ionfusion.runtime.base.SourceLocation;
 import dev.ionfusion.runtime.base.SourceName;
 import java.io.File;
@@ -201,7 +202,8 @@ final class LoadHandler
         //      relative paths won't be able to access sibling resources.
         if (sourceName != null)
         {
-            Path srcPath = sourceName.getPath();
+            ResourceIdentifier rsrcId = sourceName.getResourceId();
+            Path srcPath = (rsrcId == null ? null : rsrcId.getPath());
             if (srcPath != null)
             {
                 String dirPath = srcPath.getParent().toAbsolutePath().toString();

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceName.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceName.java
@@ -8,9 +8,7 @@ import static java.util.Objects.requireNonNull;
 import dev.ionfusion.runtime.base.SourceNameImpl.ModuleSourceName;
 import dev.ionfusion.runtime.base.SourceNameImpl.ResourceSourceName;
 import java.io.File;
-import java.net.URI;
 import java.net.URL;
-import java.nio.file.Path;
 
 /**
  * Identifies a source of Fusion code or other data: a file, URL, <em>etc.</em>
@@ -25,25 +23,6 @@ public interface SourceName
      * The standard extension for Fusion source code files.
      */
     String FUSION_SOURCE_EXTENSION = ".fusion";
-
-
-    /**
-     * Returns the absolute path of the source file if one is known.
-     * This is the case for instances created by {@link #forFile(File)} or
-     * {@link #forFile(String)}.
-     *
-     * @return null if this source is not an actual file.
-     */
-    Path getPath();
-
-    /**
-     * Returns a URI for the source. The protocol can vary; at least {@code file}
-     * and {@code jar} are possible. In general, {@code toUrl().openStream()} is
-     * expected to work.
-     *
-     * @return null if this source cannot be identified as a URI.
-     */
-    URI getUri();
 
 
     /**

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceNameImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceNameImpl.java
@@ -3,9 +3,6 @@
 
 package dev.ionfusion.runtime.base;
 
-import java.net.URI;
-import java.nio.file.Path;
-
 class SourceNameImpl
     implements SourceName
 {
@@ -26,18 +23,6 @@ class SourceNameImpl
 
     @Override
     public ResourceIdentifier getResourceId()
-    {
-        return null;
-    }
-
-    @Override
-    public Path getPath()
-    {
-        return null;
-    }
-
-    @Override
-    public URI getUri()
     {
         return null;
     }
@@ -102,18 +87,6 @@ class SourceNameImpl
         public ResourceIdentifier getResourceId()
         {
             return myResource;
-        }
-
-        @Override
-        public Path getPath()
-        {
-            return myResource.getPath();
-        }
-
-        @Override
-        public URI getUri()
-        {
-            return myResource.getUri();
         }
     }
 

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
@@ -3,6 +3,7 @@
 
 package dev.ionfusion.runtime.base;
 
+import static dev.ionfusion.testing.Assertions.assertHashEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -30,15 +31,10 @@ public class SourceLocationTest
     }
 
 
-    private void checkPath(String path, SourceLocation loc)
+    private void checkPath(String path, ResourcePosition pos)
     {
-        ResourceIdentifier rsrc = loc.getResourceId();
-
-        assertEquals("file://" + path, rsrc.getUri().toString());
-        assertEquals(path, rsrc.getPath().toString());
-
-        assertSame(rsrc.getUri(), loc.getSourceName().getUri());
-        assertSame(rsrc.getPath(), loc.getSourceName().getPath());
+        assertHashEquals(ResourceIdentifier.forFile(path),
+                         pos.getResourceDesc().getResourceId());
     }
 
     private void assertNoLocation(IonReader ir)


### PR DESCRIPTION
This eliminates redundancy and avoids potential inconsistency.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
