### PR TITLE
Remove an overload of `SourceLocation.forCurrentSpan()`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceLocation.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceLocation.java
@@ -322,21 +322,6 @@ public class SourceLocation
 
 
     /**
-     * Returns an instance that represents the current span of the reader.
-     * This currently only supports Ion text sources, and only captures the
-     * start position.
-     *
-     * @param source must not be null.
-     *
-     * @return null if no location could be determined from the source.
-     */
-    public static SourceLocation forCurrentSpan(IonReader source)
-    {
-        return forCurrentSpan(source, null);
-    }
-
-
-    /**
      * Displays this location in a human-readable form, in terms of line,
      * column, and source name.
      *

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
@@ -43,10 +43,7 @@ public class SourceLocationTest
 
     private void assertNoLocation(IonReader ir)
     {
-        SourceLocation loc = SourceLocation.forCurrentSpan(ir);
-        assertNull(loc, "expected null SourceLocation");
-
-        loc = SourceLocation.forCurrentSpan(ir, null);
+        SourceLocation loc = SourceLocation.forCurrentSpan(ir, null);
         assertNull(loc, "expected null SourceLocation");
 
         SourceName name = SourceName.forDisplay("test source");
@@ -63,11 +60,7 @@ public class SourceLocationTest
 
     private void assertLocation(String expectedOffsets, IonReader ir)
     {
-        SourceLocation loc = SourceLocation.forCurrentSpan(ir);
-        assertEquals(expectedOffsets, loc.display());
-        checkConsistency(null, loc);
-
-        loc = SourceLocation.forCurrentSpan(ir, null);
+        SourceLocation loc = SourceLocation.forCurrentSpan(ir, null);
         assertEquals(expectedOffsets, loc.display());
         checkConsistency(null, loc);
 


### PR DESCRIPTION
The no-descriptor variant was only used by tests, and is not desired long-term; I want all `ResourcePosition`s to have user-supplied descriptors.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
