### PR TITLE
Remove `ResourcePosition.getResourceId()`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageConfiguration.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageConfiguration.java
@@ -229,7 +229,7 @@ public final class CoverageConfiguration
         ModuleIdentity id = loc.getModuleIdentity();
         if (moduleIsSelected(id)) return true;
 
-        ResourceIdentifier rsrc = loc.getResourceId();
+        ResourceIdentifier rsrc = loc.getResourceDesc().getResourceId();
         if (rsrc == null) return false;
 
         return fileIsSelected(rsrc.getPath());

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/cover/CoverageDatabase.java
@@ -98,7 +98,7 @@ public class CoverageDatabase
     public boolean locationIsRecordable(CodePosition loc)
     {
         // We can record locations within identified resources.
-        return loc.getResourceId() != null;
+        return loc.getResourceDesc().getResourceId() != null;
     }
 
 
@@ -115,7 +115,7 @@ public class CoverageDatabase
     @Override
     public AtomicInteger locationInstrumented(CodePosition loc)
     {
-        URI uri = loc.getResourceId().getUri();
+        URI uri = loc.getResourceDesc().getResourceId().getUri();
         long offset = loc.getOffset();
         ModuleIdentity module = loc.getModuleIdentity();
 

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourcePosition.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourcePosition.java
@@ -21,15 +21,6 @@ public interface ResourcePosition
      */
     ResourceDescriptor getResourceDesc();
 
-    /**
-     * Identifies the resource containing this location if it's known.
-     *
-     * @return can be null.
-     */
-    default ResourceIdentifier getResourceId()
-    {
-        return getResourceDesc().getResourceId();
-    }
 
     /**
      * Gets the one-based line number.

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
@@ -22,11 +22,11 @@ public class SourceLocationTest
         assertSame(name, loc.getSourceName());
         if (name != null)
         {
-            assertSame(name.getResourceId(), loc.getResourceId());
+            assertSame(name.getResourceId(), loc.getResourceDesc().getResourceId());
         }
         else
         {
-            assertNull(loc.getResourceId());
+            assertNull(loc.getResourceDesc().getResourceId());
         }
     }
 


### PR DESCRIPTION
This eliminates redundancy and avoids potential inconsistency.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
