### PR TITLE
Use `ResourceDescriptor` in `StandardReader` and `FusionIo.read()`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionIo.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionIo.java
@@ -19,6 +19,7 @@ import com.amazon.ion.IonValue;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.system.IonTextWriterBuilder;
 import dev.ionfusion.runtime.base.FusionException;
+import dev.ionfusion.runtime.base.ResourceDescriptor;
 import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -27,6 +28,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
+import java.util.Objects;
 
 /**
  * Utilities for input and output of Fusion data.
@@ -182,31 +184,32 @@ public final class FusionIo
 
 
     /**
-     * Reads a single Fusion value from an Ion stream.
-     * If the reader is positioned on a value, that value is read and returned.
-     * Otherwise, the reader's {@link IonReader#next()} method is called;
-     * if there's not another value then the result is {@code eof}.
+     * Reads a single Fusion value from an Ion stream. If the reader is positioned on a
+     * value, that value is read and returned. Otherwise, the reader's
+     * {@link IonReader#next()} method is called; if there's not another value, then the
+     * result is {@code eof}.
      * <p>
-     * After consuming the value, the reader is moved to the next
-     * value by calling {@link IonReader#next()}.
+     * After consuming the value, the reader is moved to the next value by calling
+     * {@link IonReader#next()}.
      *
      * @param top the {@link TopLevel} to use for evaluation
      * @param reader must be positioned on the value to read.
+     * @param desc describes the input; must not be null.
      *
      * @return an immutable Fusion value.
      *
      * @throws FusionException if an error occurs during evaluation
-     *
      * @see #isEof(TopLevel, Object)
      */
-    public static Object read(TopLevel top, IonReader reader)
+    public static Object read(TopLevel top, IonReader reader, ResourceDescriptor desc)
         throws FusionException
     {
+        Objects.requireNonNull(desc, "desc");
         Evaluator eval = StandardTopLevel.toEvaluator(top);
-        return read(eval, reader);
+        return read(eval, reader, desc);
     }
 
-    static Object read(Evaluator eval, IonReader reader)
+    static Object read(Evaluator eval, IonReader reader, ResourceDescriptor desc)
         throws FusionException
     {
         try
@@ -219,14 +222,13 @@ public final class FusionIo
                 }
             }
 
-            Object fv = StandardReader.read(eval, reader);
+            Object fv = StandardReader.read(eval, reader, desc);
             reader.next();
             return fv;
         }
         catch (IonException e)
         {
-            throw new FusionException("Error reading data: " + e.getMessage(),
-                                      e);
+            throw new FusionException("Error reading data: " + e.getMessage(), e);
         }
     }
 
@@ -650,7 +652,7 @@ public final class FusionIo
         {
             IonReader r = myCurrentIonReaderParam.currentValue(eval);
 
-            return FusionIo.read(eval, r);
+            return FusionIo.read(eval, r, ResourceDescriptor.unknown());
         }
     }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/StandardReader.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/StandardReader.java
@@ -30,9 +30,9 @@ import com.amazon.ion.Timestamp;
 import dev.ionfusion.fusion.FusionList.BaseList;
 import dev.ionfusion.fusion.FusionSexp.BaseSexp;
 import dev.ionfusion.runtime.base.FusionException;
+import dev.ionfusion.runtime.base.ResourceDescriptor;
 import dev.ionfusion.runtime.base.ResourceIdentifier;
 import dev.ionfusion.runtime.base.ResourcePosition;
-import dev.ionfusion.runtime.base.SourceName;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
@@ -78,43 +78,41 @@ class StandardReader
      *
      * @param source must be positioned on the value to be read.
      */
-    static Object read(Evaluator eval,
-                       IonReader source)
+    static Object read(Evaluator eval, IonReader source, ResourceDescriptor desc)
         throws FusionException
     {
         try
         {
-            return read(eval, source, null, false);
+            return read(eval, source, desc, false);
         }
         catch (IonException e)
         {
-            throw new FusionException("Error reading data: " + e.getMessage(),
-                                      e);
+            throw new FusionException("Error reading data: " + e.getMessage(), e);
         }
     }
 
 
     /**
-     * Reads a single Ion datum as source.
+     * Reads a single Ion datum as syntax.
      *
      * @param source must be positioned on the value to be read.
-     * @param name may be null.
+     * @param desc must not be null.
      */
-    static SyntaxValue readSyntax(Evaluator  eval,
-                                  IonReader  source,
-                                  SourceName name)
+    static SyntaxValue readSyntax(Evaluator eval,
+                                  IonReader source,
+                                  ResourceDescriptor desc)
         throws FusionException
     {
         try
         {
-            return (SyntaxValue) read(eval, source, name, true);
+            return (SyntaxValue) read(eval, source, desc, true);
         }
         catch (IonException e)
         {
             // We don't try to create a SourceLocation from the reader because
             // it usually doesn't have a current span when an error is thrown,
             // and since the IonException's message will contain it.
-            String nameStr = (name != null ? name.display() : "source");
+            String nameStr = (desc != null ? desc.display() : "source");
             String message =
                 "Error reading " + nameStr + ":\n" + e.getMessage();
             throw new FusionErrorException(message, e);
@@ -125,13 +123,13 @@ class StandardReader
     /**
      * Reads a single Ion datum, optionally as syntax objects.
      * @param source must be positioned on the value to be read.
-     * @param name may be null.
+     * @param desc can be null.
      *
      * @throws IonException if there's a problem reading the source data.
      */
     private static Object read(Evaluator  eval,
                                IonReader  source,
-                               SourceName name,
+                               ResourceDescriptor desc,
                                boolean    readingSyntax)
         throws FusionException, IonException
     {
@@ -139,7 +137,7 @@ class StandardReader
         assert type != null;
 
         String[] anns = source.getTypeAnnotations();
-        ResourcePosition pos = (readingSyntax ? forCurrentSpan(source, name) : null);
+        ResourcePosition pos = (readingSyntax ? forCurrentSpan(source, desc) : null);
 
         BaseValue datum;
         switch (type)
@@ -243,17 +241,17 @@ class StandardReader
             }
             case LIST:
             {
-                datum = readList(eval, source, name, readingSyntax, anns);
+                datum = readList(eval, source, desc, readingSyntax, anns);
                 break;
             }
             case SEXP:
             {
-                datum = readSexp(eval, source, name, readingSyntax, anns);
+                datum = readSexp(eval, source, desc, readingSyntax, anns);
                 break;
             }
             case STRUCT:
             {
-                datum = readStruct(eval, source, name, readingSyntax, anns);
+                datum = readStruct(eval, source, desc, readingSyntax, anns);
                 break;
             }
             default:
@@ -278,13 +276,13 @@ class StandardReader
     /**
      * @param source must be positioned on the value to be read, but not
      * stepped-in.  Must not be positioned on a null value.
-     * @param name may be null.
+     * @param desc can be null.
      *
      * @throws IonException if there's a problem reading the source data.
      */
     private static ArrayList<Object> readSequence(Evaluator  eval,
                                                   IonReader  source,
-                                                  SourceName name,
+                                                  ResourceDescriptor desc,
                                                   boolean    readingSyntax)
         throws FusionException, IonException
     {
@@ -295,7 +293,7 @@ class StandardReader
         source.stepIn();
         while (source.next() != null)
         {
-            Object child = read(eval, source, name, readingSyntax);
+            Object child = read(eval, source, desc, readingSyntax);
             children.add(child);
         }
         source.stepOut();
@@ -311,7 +309,7 @@ class StandardReader
      */
     private static BaseList readList(Evaluator  eval,
                                      IonReader  source,
-                                     SourceName name,
+                                     ResourceDescriptor desc,
                                      boolean    readingSyntax,
                                      String[]   annotations)
         throws FusionException, IonException
@@ -321,8 +319,7 @@ class StandardReader
             return nullList(eval, annotations);
         }
 
-        ArrayList<Object> elements =
-            readSequence(eval, source, name, readingSyntax);
+        ArrayList<Object> elements = readSequence(eval, source, desc, readingSyntax);
         return immutableList(eval, annotations, elements);
     }
 
@@ -332,7 +329,7 @@ class StandardReader
      */
     private static BaseSexp readSexp(Evaluator  eval,
                                      IonReader  source,
-                                     SourceName name,
+                                     ResourceDescriptor desc,
                                      boolean    readingSyntax,
                                      String[]   annotations)
         throws FusionException, IonException
@@ -342,8 +339,7 @@ class StandardReader
             return nullSexp(eval, annotations);
         }
 
-        List<Object> elements =
-            readSequence(eval, source, name, readingSyntax);
+        List<Object> elements = readSequence(eval, source, desc, readingSyntax);
         return immutableSexp(eval, annotations, elements);
     }
 
@@ -353,7 +349,7 @@ class StandardReader
      */
     private static BaseValue readStruct(Evaluator  eval,
                                         IonReader  source,
-                                        SourceName name,
+                                        ResourceDescriptor desc,
                                         boolean    readingSyntax,
                                         String[]   anns)
         throws FusionException, IonException
@@ -370,7 +366,7 @@ class StandardReader
             while (source.next() != null)
             {
                 String key   = source.getFieldName();
-                Object value = read(eval, source, name, readingSyntax);
+                Object value = read(eval, source, desc, readingSyntax);
                 builder.add(key, value);
             }
         }

--- a/runtime/src/test/java/dev/ionfusion/fusion/ClassLoaderModuleRepositoryTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/ClassLoaderModuleRepositoryTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.amazon.ion.IonReader;
 import dev.ionfusion.runtime.base.ModuleIdentity;
-import dev.ionfusion.runtime.base.SourceName;
+import dev.ionfusion.runtime.base.ResourceDescriptor;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
@@ -52,12 +52,12 @@ public class ClassLoaderModuleRepositoryTest
         assertNotNull(loc);
         assertNotNull(loc.toString());
 
-        SourceName name = loc.sourceName();
-        assertThat(name.display(), endsWith("/ftst/symbol.fusion"));
+        ResourceDescriptor desc = loc.sourceName();
+        assertThat(desc.display(), endsWith("/ftst/symbol.fusion"));
 
         Evaluator eval       = evaluator();
-        IonReader ionReader  = openIonReader(eval, name.getResourceId());
-        Object    moduleSexp = read(eval, ionReader);
+        IonReader ionReader  = openIonReader(eval, desc.getResourceId());
+        Object    moduleSexp = read(eval, ionReader, desc);
         assertTrue(isPair(eval, moduleSexp));
     }
 

--- a/runtime/src/test/java/dev/ionfusion/fusion/FusionIoTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/FusionIoTest.java
@@ -16,6 +16,7 @@ import com.amazon.ion.IonList;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.IonWriter;
+import dev.ionfusion.runtime.base.ResourceDescriptor;
 import dev.ionfusion.runtime.embed.TopLevel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -110,24 +111,25 @@ public class FusionIoTest
     {
         TopLevel  top  = topLevel();
         Evaluator eval = evaluator();
+        ResourceDescriptor desc = ResourceDescriptor.unknown();
 
         IonReader reader = system().newReader("{}");
-        Object fv = read(top, reader);
+        Object fv = read(top, reader, desc);
         assertTrue(isImmutableStruct(eval, fv));
         assertEquals(0, unsafeStructSize(eval, fv));
-        fv = read(top, reader);
+        fv = read(top, reader, desc);
         assertTrue(isEof(top, fv));
 
         reader = system().newReader("{f:9} 10");
         reader.next();
-        fv = FusionIo.read(top, reader);
+        fv = FusionIo.read(top, reader, desc);
         assertTrue(isImmutableStruct(eval, fv));
         assertEquals(1, unsafeStructSize(eval, fv));
-        fv = read(top, reader);
+        fv = read(top, reader, desc);
         checkLong(10, fv);
-        fv = read(top, reader);
+        fv = read(top, reader, desc);
         assertTrue(isEof(top, fv));
-        fv = read(top, reader);
+        fv = read(top, reader, desc);
         assertTrue(isEof(top, fv));  // EOF "sticks"
     }
 

--- a/runtime/src/test/java/dev/ionfusion/fusion/StandardReaderTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/StandardReaderTest.java
@@ -4,6 +4,7 @@
 package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionStruct.unsafeStructSize;
+import static dev.ionfusion.fusion.StandardReader.read;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -11,6 +12,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.amazon.ion.IonReader;
+import dev.ionfusion.runtime.base.ResourceDescriptor;
 import org.junit.jupiter.api.Test;
 
 public class StandardReaderTest
@@ -38,7 +40,7 @@ public class StandardReaderTest
     {
         IonReader reader = system().newReader("{f:1,f:2}");
         reader.next();
-        Object s = StandardReader.read(evaluator(), reader);
+        Object s = read(evaluator(), reader, ResourceDescriptor.unknown());
         assertEquals(2, unsafeStructSize(evaluator(), s));
     }
 }


### PR DESCRIPTION
One is now required throughout.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
