### PR TITLE
Add named `ResourceDescriptor`s.

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptor.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptor.java
@@ -3,8 +3,22 @@
 
 package dev.ionfusion.runtime.base;
 
+import java.net.URI;
+import java.nio.file.Path;
+
 /**
  * Provides access to metadata about a resource and optionally access to its content.
+ * <p>
+ * There are three varieties of resource descriptors:
+ * <ul>
+ *   <li><em>Identified</em> descriptors have a {@link ResourceIdentifier}, so their
+ *   content can be accessed from the descriptor.  Their {@link #display} form is that
+ *   of their identifier's {@link Path} or {@link URI}.</li>
+ *   <li><em>Named</em> descriptors have no identifier, only a custom {@link #display}
+ *   string.</li>
+ *   <li><em>Unknown</em> descriptors have no identifier, only a generic {@link #display}
+ *   string.</li>
+ * </ul>
  * <p>
  * Long term, this is intended to surface things like the deployment unit containing the
  * resource, perhaps checksums, etc. This enables passing context from the component
@@ -39,35 +53,35 @@ public interface ResourceDescriptor
     }
 
 
+    //==================================================================================
+    // Factories
+
+    /**
+     * Returns a descriptor that displays as the given name and has no
+     * {@link ResourceIdentifier}.
+     * <p>
+     * Named descriptors are only {@link Object#equals} to themselves.
+     *
+     * @param name must not be null or empty.
+     *
+     * @return a new descriptor.
+     */
+    static ResourceDescriptor named(String name)
+    {
+        return new ResourceDescriptorImpl.NamedResourceDescriptor(name);
+    }
+
+
     /**
      * Returns a descriptor that displays as "unknown resource" and has no
      * {@link ResourceIdentifier}.
+     * <p>
+     * Unknown descriptors are only {@link Object#equals} to themselves.
      *
      * @return not null.
      */
     static ResourceDescriptor unknown()
     {
-        return new ResourceDescriptor()
-        {
-            @Override
-            public String display()
-            {
-                return "unknown resource";
-            }
-
-            @Override
-            public ResourceIdentifier getResourceId()
-            {
-                return null;
-            }
-
-            @Override
-            public boolean isUnknown()
-            {
-                return true;
-            }
-
-            // Default equals/hashCode are correct
-        };
+        return new ResourceDescriptorImpl.UnknownResourceDescriptor();
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptorImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptorImpl.java
@@ -1,0 +1,68 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+class ResourceDescriptorImpl
+{
+    private ResourceDescriptorImpl() {}
+
+
+    //==================================================================================
+    // Implementations
+
+
+    static final class NamedResourceDescriptor
+        implements ResourceDescriptor
+    {
+        private final String myName;
+
+        NamedResourceDescriptor(String name)
+        {
+            if (name.isEmpty())
+            {
+                throw new IllegalArgumentException("name must not be empty");
+            }
+            myName = name;
+        }
+
+        @Override
+        public String display()
+        {
+            return myName;
+        }
+
+        @Override
+        public ResourceIdentifier getResourceId()
+        {
+            return null;
+        }
+
+        // Default equals/hashCode are correct
+    }
+
+
+    static final class UnknownResourceDescriptor
+        implements ResourceDescriptor
+    {
+        @Override
+        public String display()
+        {
+            return "unknown resource";
+        }
+
+        @Override
+        public ResourceIdentifier getResourceId()
+        {
+            return null;
+        }
+
+        @Override
+        public boolean isUnknown()
+        {
+            return true;
+        }
+
+        // Default equals/hashCode are correct
+    }
+}

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/ResourceDescriptorTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/ResourceDescriptorTest.java
@@ -5,26 +5,70 @@ package dev.ionfusion.runtime.base;
 
 import static dev.ionfusion.testing.Assertions.assertHashEquals;
 import static dev.ionfusion.testing.Assertions.assertNotHashEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
 public class ResourceDescriptorTest
 {
-    @Test
-    void unknownDescriptorsNotEqual()
+    private static void checkEquality(ResourceDescriptor d1, ResourceDescriptor d2)
     {
-        ResourceDescriptor unknown1 = ResourceDescriptor.unknown();
-        ResourceDescriptor unknown2 = ResourceDescriptor.unknown();
-
-        assertHashEquals(unknown1, unknown1);
-        assertHashEquals(unknown2, unknown2);
-
-        assertNotHashEquals(unknown1, unknown2);
+        assertHashEquals(d1, d1);
+        assertHashEquals(d2, d2);
+        assertHashEquals(d1, d2);
     }
 
+    private static void checkInequality(ResourceDescriptor d1, ResourceDescriptor d2)
+    {
+        assertHashEquals(d1, d1);
+        assertHashEquals(d2, d2);
+
+        assertNotHashEquals(d1, d2);
+    }
+
+
+    //==================================================================================
+    // Named descriptors
+
+    @Test
+    void sameNamedDescriptorsNotEqual()
+    {
+        ResourceDescriptor desc1 = ResourceDescriptor.named("name");
+        ResourceDescriptor desc2 = ResourceDescriptor.named("name");
+
+        checkInequality(desc1, desc2);
+    }
+
+    @Test
+    void testNamedDescriptor()
+    {
+        ResourceDescriptor desc = ResourceDescriptor.named("name");
+        assertEquals("name", desc.display());
+        assertFalse(desc.isUnknown());
+        assertNull(desc.getResourceId());
+
+
+        desc = SourceName.forDisplay("name");
+        assertEquals("name", desc.display());
+        assertFalse(desc.isUnknown());
+        assertNull(desc.getResourceId());
+    }
+
+    @Test
+    void namedDescriptorMustHaveName()
+    {
+        assertThrows(NullPointerException.class,
+                     () -> ResourceDescriptor.named(null));
+        assertThrows(IllegalArgumentException.class,
+                     () -> ResourceDescriptor.named(""));
+    }
+
+    //==================================================================================
+    // SourceNames
 
     /**
      * Retain legacy equality of SourceName instances, for now at least. The design plan
@@ -37,20 +81,38 @@ public class ResourceDescriptorTest
         SourceName foo2 = SourceName.forDisplay("foo");
         SourceName bar  = SourceName.forDisplay("bar");
 
-        assertHashEquals(foo1, foo1);
-        assertHashEquals(foo1, foo2);
+        checkEquality(foo1, foo2);
+        checkInequality(foo1, bar);
+    }
 
-        assertNotHashEquals(foo1, bar);
+    @Test
+    void sourceNamesDontMatchNewDescriptors()
+    {
+        ResourceDescriptor desc = ResourceDescriptor.named("name");
+        SourceName name = SourceName.forDisplay("name");
+
+        checkInequality(desc, name);
+    }
+
+
+    //==================================================================================
+    // Unknown descriptors
+
+    @Test
+    void unknownDescriptorsNotEqual()
+    {
+        ResourceDescriptor unknown1 = ResourceDescriptor.unknown();
+        ResourceDescriptor unknown2 = ResourceDescriptor.unknown();
+
+        checkInequality(unknown1, unknown2);
     }
 
     @Test
     void testUnknownDescriptor()
     {
         ResourceDescriptor unknown = ResourceDescriptor.unknown();
+        assertEquals("unknown resource", unknown.display());
         assertTrue(unknown.isUnknown());
         assertNull(unknown.getResourceId());
-
-        SourceName foo = SourceName.forDisplay("foo");
-        assertFalse(foo.isUnknown());
     }
 }


### PR DESCRIPTION
This will replace `SourceName.forDisplay()`.

# Notes

Similar factories for identified descriptors will come later, they are not as straightforward.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
