### PR TITLE
Use `ResourceDescriptor` in `FusionEval`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionEval.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionEval.java
@@ -12,11 +12,12 @@ import static dev.ionfusion.fusion.FusionVoid.voidValue;
 import static dev.ionfusion.fusion.GlobalState.MODULE;
 import static dev.ionfusion.fusion.StandardReader.readSyntax;
 import static dev.ionfusion.fusion.Syntax.datumToSyntax;
+import static java.util.Objects.requireNonNull;
 
 import com.amazon.ion.IonReader;
 import dev.ionfusion.runtime.base.FusionException;
+import dev.ionfusion.runtime.base.ResourceDescriptor;
 import dev.ionfusion.runtime.base.SourceLocation;
-import dev.ionfusion.runtime.base.SourceName;
 import dev.ionfusion.runtime.embed.TopLevel;
 import java.util.LinkedList;
 
@@ -247,28 +248,28 @@ final class FusionEval
 
 
     /**
-     * Parses the top-level syntax forms in Fusion source code, passing each
-     * resulting syntax object to a procedure.
-     * After all top-level forms are processed, the {@code receiver} is invoked
-     * one more time with {@linkplain FusionIo#eof(Evaluator) the canonical EOF
-     * value}.
+     * Parses the top-level syntax forms in Fusion source code, passing each resulting
+     * syntax object to a procedure. After all top-level forms are processed, the
+     * {@code receiver} is invoked one more time with
+     * {@linkplain FusionIo#eof(Evaluator) the canonical EOF value}.
      * <p>
-     * See http://docs.racket-lang.org/tools/drracket_eval.html#%28def._%28%28lib._drracket%2Ftool-lib..rkt%29._drracket~3aeval~3atraverse-program%2Fmultiple%29%29
-     * </p>
-     * @param receiver is a 1-argument procedure that accepts a syntax object
-     * or EOF.
+     * See
+     * http://docs.racket-lang.org/tools/drracket_eval.html#%28def._%28%28lib._drracket%2Ftool-lib..rkt%29._drracket~3aeval~3atraverse-program%2Fmultiple%29%29
+     *
+     * @param desc must not be null.
+     * @param receiver is a 1-argument procedure that accepts a syntax object or EOF.
      */
-    static void traverseProgram(Evaluator  eval,
-                                IonReader  source,
-                                SourceName name,
-                                Procedure  receiver)
+    static void traverseProgram(Evaluator eval,
+                                IonReader source,
+                                ResourceDescriptor desc,
+                                Procedure receiver)
         throws FusionException
     {
-        if (source.getType() == null) source.next();
+        if (source.getType() == null) { source.next(); }
 
         while (source.getType() != null)
         {
-            SyntaxValue sourceExpr = readSyntax(eval, source, name);
+            SyntaxValue sourceExpr = readSyntax(eval, source, desc);
 
             eval.callNonTail(receiver, sourceExpr);
 
@@ -280,17 +281,17 @@ final class FusionEval
 
 
     /**
-     * @param receiver is a 1-argument procedure that accepts a syntax object
-     * or EOF.
+     * @param desc must not be null.
+     * @param receiver is a 1-argument procedure that accepts a syntax object or EOF.
      */
-    static void traverseProgram(Evaluator  eval,
-                                String     source,
-                                SourceName name,
-                                Procedure  receiver)
+    static void traverseProgram(Evaluator eval,
+                                String source,
+                                ResourceDescriptor desc,
+                                Procedure receiver)
         throws FusionException
     {
         IonReader i = eval.getIonReaderBuilder().build(source);
-        traverseProgram(eval, i, name, receiver);
+        traverseProgram(eval, i, desc, receiver);
     }
 
 
@@ -336,16 +337,19 @@ final class FusionEval
      * value}.
      * <p>
      * See http://docs.racket-lang.org/tools/drracket_eval.html#%28def._%28%28lib._drracket%2Ftool-lib..rkt%29._drracket~3aeval~3aexpand-program%29%29
-     * </p>
-     * @param receiver is a 1-argument procedure that accepts a fully-expanded
+     *
+     * @param desc must not be null.
+     * @param receiver is a 1-argument procedure that accepts a fully expanded
      *   syntax object or EOF.
      */
     static void expandProgram(TopLevel        top,
                               String          source,
-                              SourceName      name,
-                              final Procedure receiver)
+                              ResourceDescriptor desc,
+                              Procedure receiver)
         throws FusionException
     {
+        requireNonNull(desc, "desc");
+
         final Evaluator eval = StandardTopLevel.toEvaluator(top);
 
         Procedure r2 = new Procedure1()
@@ -367,7 +371,7 @@ final class FusionEval
             }
         };
 
-        traverseProgram(eval, source, name, r2);
+        traverseProgram(eval, source, desc, r2);
     }
 
 

--- a/runtime/src/test/java/dev/ionfusion/fusion/ExpandProgramTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/ExpandProgramTest.java
@@ -3,6 +3,7 @@
 
 package dev.ionfusion.fusion;
 
+import static dev.ionfusion.fusion.FusionEval.expandProgram;
 import static dev.ionfusion.fusion.FusionIo.isEof;
 import static dev.ionfusion.fusion.FusionSexp.isSexp;
 import static dev.ionfusion.fusion.FusionSexp.unsafePairHead;
@@ -20,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import dev.ionfusion.runtime.base.FusionException;
+import dev.ionfusion.runtime.base.ResourceDescriptor;
 import org.junit.jupiter.api.Test;
 
 
@@ -111,7 +113,7 @@ public class ExpandProgramTest
             "(module M '/fusion' 1) " +
             "(define_values (s t) (values 1 2))";
 
-        FusionEval.expandProgram(topLevel(), source, null, collector);
+        expandProgram(topLevel(), source, ResourceDescriptor.unknown(), collector);
         assertTrue(collector.receivedEof);
 
         assertTrue(unsafeFreeIdentifierEqual(eval,

--- a/runtime/src/test/java/dev/ionfusion/fusion/IdentifierBindingTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/IdentifierBindingTest.java
@@ -3,6 +3,7 @@
 
 package dev.ionfusion.fusion;
 
+import static dev.ionfusion.fusion.FusionEval.expandProgram;
 import static dev.ionfusion.fusion.FusionIo.isEof;
 import static dev.ionfusion.fusion.FusionSymbol.unsafeSymbolToJavaString;
 import static dev.ionfusion.fusion.FusionSyntax.isIdentifier;
@@ -16,8 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import dev.ionfusion.runtime.base.FusionException;
+import dev.ionfusion.runtime.base.ResourceDescriptor;
 import dev.ionfusion.runtime.base.ResourcePosition;
-import dev.ionfusion.runtime.base.SourceName;
 import org.junit.jupiter.api.Test;
 
 
@@ -96,8 +97,8 @@ public class IdentifierBindingTest
             "foo";                          // <- moduleReference
 
         eval(topLevel(), module);
-        SourceName sourceName = SourceName.forDisplay("TestFile");
-        FusionEval.expandProgram(topLevel(), source, sourceName, traversal);
+        ResourceDescriptor desc = ResourceDescriptor.unknown();
+        expandProgram(topLevel(), source, desc, traversal);
 
 
         BindingSite topLevelSite =
@@ -106,7 +107,7 @@ public class IdentifierBindingTest
         assertBindingAt(3, 9, topLevelSite);
         assertTrue(topLevelSite.isDefinitionSite());
         assertNull(topLevelSite.nextSite());
-        assertSame(sourceName, topLevelSite.getPosition().getResourceDesc());
+        assertSame(desc, topLevelSite.getPosition().getResourceDesc());
 
 
         // We expect the BindingSite's SourceLocation to be null because
@@ -165,7 +166,7 @@ public class IdentifierBindingTest
 
         eval(topLevel(), onlyInModule);
         eval(topLevel(), enclosingModule);
-        FusionEval.expandProgram(topLevel(), source, null, traversal);
+        expandProgram(topLevel(), source, ResourceDescriptor.unknown(), traversal);
 
 
         BindingSite onlyInBinding =


### PR DESCRIPTION
# Notes

Hoisting to the new interface involves a rather specific order of operations, at least to avoid a massive PR.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
