### PR TITLE
Add `AbstractResourceDescriptor`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptor.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptor.java
@@ -20,6 +20,9 @@ import java.nio.file.Path;
  *   string.</li>
  * </ul>
  * <p>
+ * Two descriptors are considered equal if they are the same instance or if they
+ * have equal non-null {@link ResourceIdentifier}s.
+ * <p>
  * Long term, this is intended to surface things like the deployment unit containing the
  * resource, perhaps checksums, etc. This enables passing context from the component
  * providing the resource.

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptorImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptorImpl.java
@@ -11,9 +11,63 @@ class ResourceDescriptorImpl
     //==================================================================================
     // Implementations
 
+    /**
+     * Satisfies the equals/hashCode contract for descriptors.
+     */
+    abstract static class AbstractResourceDescriptor
+        implements ResourceDescriptor
+    {
+        public final boolean equals(ResourceDescriptor that)
+        {
+            if (this == that) { return true; }
+            if (that == null) { return false; }
+
+            ResourceIdentifier thisId = this.getResourceId();
+            ResourceIdentifier thatId = that.getResourceId();
+            return thisId != null && thatId != null && thisId.equals(thatId);
+        }
+
+        @Override
+        public final boolean equals(Object that)
+        {
+            return (that instanceof ResourceDescriptor &&
+                    this.equals((ResourceDescriptor) that));
+        }
+
+
+        private static final int HASH_SEED = AbstractResourceDescriptor.class.hashCode();
+
+        @Override
+        public final int hashCode()
+        {
+            ResourceIdentifier id = getResourceId();
+            if (id == null)
+            {
+                return System.identityHashCode(this);
+            }
+            else
+            {
+                int result = HASH_SEED + id.hashCode();
+                result ^= (result << 29) ^ (result >> 3);
+                return result;
+            }
+        }
+    }
+
+
+    private abstract static class UnidentifiedResourceDescriptor
+        extends AbstractResourceDescriptor
+    {
+        @Override
+        public final ResourceIdentifier getResourceId()
+        {
+            return null;
+        }
+    }
+
 
     static final class NamedResourceDescriptor
-        implements ResourceDescriptor
+        extends UnidentifiedResourceDescriptor
     {
         private final String myName;
 
@@ -31,19 +85,11 @@ class ResourceDescriptorImpl
         {
             return myName;
         }
-
-        @Override
-        public ResourceIdentifier getResourceId()
-        {
-            return null;
-        }
-
-        // Default equals/hashCode are correct
     }
 
 
     static final class UnknownResourceDescriptor
-        implements ResourceDescriptor
+        extends UnidentifiedResourceDescriptor
     {
         @Override
         public String display()
@@ -52,17 +98,9 @@ class ResourceDescriptorImpl
         }
 
         @Override
-        public ResourceIdentifier getResourceId()
-        {
-            return null;
-        }
-
-        @Override
         public boolean isUnknown()
         {
             return true;
         }
-
-        // Default equals/hashCode are correct
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptorImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptorImpl.java
@@ -17,21 +17,15 @@ class ResourceDescriptorImpl
     abstract static class AbstractResourceDescriptor
         implements ResourceDescriptor
     {
-        public final boolean equals(ResourceDescriptor that)
-        {
-            if (this == that) { return true; }
-            if (that == null) { return false; }
-
-            ResourceIdentifier thisId = this.getResourceId();
-            ResourceIdentifier thatId = that.getResourceId();
-            return thisId != null && thatId != null && thisId.equals(thatId);
-        }
-
         @Override
         public final boolean equals(Object that)
         {
-            return (that instanceof ResourceDescriptor &&
-                    this.equals((ResourceDescriptor) that));
+            if (this == that) { return true; }
+            if (!(that instanceof ResourceDescriptor)) { return false; }
+
+            ResourceIdentifier thisId = this.getResourceId();
+            ResourceIdentifier thatId = ((ResourceDescriptor) that).getResourceId();
+            return thisId != null && thisId.equals(thatId);
         }
 
 

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceIdentifier.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceIdentifier.java
@@ -63,17 +63,13 @@ public abstract class ResourceIdentifier
         return getUri().toString();
     }
 
-
-    public boolean equals(ResourceIdentifier that)
-    {
-        return this.getUri().equals(that.getUri());
-    }
-
     @Override
     public boolean equals(Object that)
     {
+        if (this == that) { return true; }
+
         return that instanceof ResourceIdentifier &&
-               this.equals((ResourceIdentifier) that);
+               this.getUri().equals(((ResourceIdentifier) that).getUri());
     }
 
     @Override

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/ResourceDescriptorTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/ResourceDescriptorTest.java
@@ -15,14 +15,14 @@ import org.junit.jupiter.api.Test;
 
 public class ResourceDescriptorTest
 {
-    private static void checkEquality(ResourceDescriptor d1, ResourceDescriptor d2)
+    private static void checkEquality(Object d1, Object d2)
     {
         assertHashEquals(d1, d1);
         assertHashEquals(d2, d2);
         assertHashEquals(d1, d2);
     }
 
-    private static void checkInequality(ResourceDescriptor d1, ResourceDescriptor d2)
+    private static void checkInequality(Object d1, Object d2)
     {
         assertHashEquals(d1, d1);
         assertHashEquals(d2, d2);
@@ -77,9 +77,9 @@ public class ResourceDescriptorTest
     @Test
     void sourceNamesMatchOnDisplay()
     {
-        SourceName foo1 = SourceName.forDisplay("foo");
-        SourceName foo2 = SourceName.forDisplay("foo");
-        SourceName bar  = SourceName.forDisplay("bar");
+        ResourceDescriptor foo1 = SourceName.forDisplay("foo");
+        ResourceDescriptor foo2 = SourceName.forDisplay("foo");
+        ResourceDescriptor bar  = SourceName.forDisplay("bar");
 
         checkEquality(foo1, foo2);
         checkInequality(foo1, bar);
@@ -89,7 +89,7 @@ public class ResourceDescriptorTest
     void sourceNamesDontMatchNewDescriptors()
     {
         ResourceDescriptor desc = ResourceDescriptor.named("name");
-        SourceName name = SourceName.forDisplay("name");
+        ResourceDescriptor name = SourceName.forDisplay("name");
 
         checkInequality(desc, name);
     }


### PR DESCRIPTION
We define a strong equality contract for descriptors. `SourceName` does not yet satisfy it.

# Notes
SourceName will extend this, and get the new equality contract, in the next commit.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
