### PR TITLE
Add a strongly typed `Attribute` micro-framework

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/base/Attribute.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/Attribute.java
@@ -1,0 +1,31 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+/**
+ * A key for storing attributes in an {@link Attributed} object.
+ * <p>
+ * Attributes are matched by their instance identity.
+ *
+ * @param <T> The type of the attribute's value.
+ */
+public class Attribute<T>
+{
+    private final Class<T> myType;
+
+    private Attribute(Class<T> type)
+    {
+        myType = type;
+    }
+
+    public T typecheck(Object value)
+    {
+        return myType.cast(value);
+    }
+
+    public static <T> Attribute<T> ofType(Class<T> type)
+    {
+        return new Attribute<>(type);
+    }
+}

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/AttributeSet.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/AttributeSet.java
@@ -1,0 +1,34 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A collection of {@link Attribute}s and their values.
+ * <p>
+ * This class is thread-safe.
+ */
+public class AttributeSet
+    implements Attributed
+{
+    private final Map<Attribute<?>, Object> myFacets = new IdentityHashMap<>();
+
+    public synchronized <T> void addAttribute(Attribute<T> facet, T value)
+    {
+        Objects.requireNonNull(value);
+
+        if (null != myFacets.putIfAbsent(facet, facet.typecheck(value)))
+        {
+            throw new IllegalStateException("Facet already exists for " + facet);
+        }
+    }
+
+    public synchronized <T> T getAttribute(Attribute<T> facet)
+    {
+        return facet.typecheck(myFacets.get(facet));
+    }
+}

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/Attributed.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/Attributed.java
@@ -1,0 +1,34 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+/**
+ * Provides strongly typed {@link Attribute}s attached to an object.
+ * <p>
+ * Attributes are matched by their instance identity.
+ */
+public interface Attributed
+{
+    /**
+     * Adds a new attribute to this object.
+     *
+     * @param attribute The attribute to add. Must not be null and must not be present
+     * on this object.
+     * @param value The value of the attribute. Must not be null.
+     * @param <T> The type of the attribute's value.
+     *
+     * @throws IllegalStateException if the attribute is present on this object.
+     */
+    <T> void addAttribute(Attribute<T> attribute, T value);
+
+    /**
+     * Retrieves the value of an attribute of this object.
+     *
+     * @param attribute The attribute to retrieve. Must not be null.
+     * @param <T> The type of the attribute's value.
+     *
+     * @return The value of the attribute, or null if the attribute is absent.
+     */
+    <T> T getAttribute(Attribute<T> attribute);
+}

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/AttributeSetTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/AttributeSetTest.java
@@ -1,0 +1,92 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class AttributeSetTest
+{
+    private final AttributeSet attribs = new AttributeSet();
+
+
+    @Test
+    void addAttributeRejectsNullArguments()
+    {
+        assertThrows(NullPointerException.class,
+                     () -> attribs.addAttribute(null, new Object()));
+        assertThrows(NullPointerException.class,
+                     () -> attribs.addAttribute(Attribute.ofType(Object.class), null));
+    }
+
+    @Test
+    void getReturnsAddedInstance()
+    {
+        Attribute<String> attr = Attribute.ofType(String.class);
+        assertNull(attribs.getAttribute(attr));
+
+        String stringValue = "foo";
+        attribs.addAttribute(attr, stringValue);
+        assertSame(stringValue, attribs.getAttribute(attr));
+    }
+
+    @Test
+    void cannotReplacePresentAttribute()
+    {
+        Attribute<String> attr = Attribute.ofType(String.class);
+        String value = "foo";
+        attribs.addAttribute(attr, value);
+
+        // Can't replace an attribute
+        assertThrows(IllegalStateException.class,
+                     () -> attribs.addAttribute(attr, "bar"));
+        assertSame(value, attribs.getAttribute(attr));
+
+        // Can't null one out either
+        assertThrows(NullPointerException.class,
+                     () -> attribs.addAttribute(attr, null));
+        assertSame(value, attribs.getAttribute(attr));
+    }
+
+    @Test
+    void attributesMatchByIdentity()
+    {
+        // Can't exfiltrate with another attribute of the same type
+        Attribute<String> attr = Attribute.ofType(String.class);
+        attribs.addAttribute(attr, "foo");
+
+        assertNull(attribs.getAttribute(Attribute.ofType(String.class)));
+    }
+
+    @Test
+    void testPrimitiveAttribute()
+    {
+        Attribute<Boolean> boolFacet = Attribute.ofType(Boolean.class);
+        assertNull(attribs.getAttribute(boolFacet));
+
+        attribs.addAttribute(boolFacet, true);
+        assertSame(true, attribs.getAttribute(boolFacet));
+    }
+
+    @Test
+    void valuesAreTypeChecked()
+    {
+        Attribute<Long> longFacet = Attribute.ofType(Long.class);
+        Attribute<String> notAString = recastAttribute(longFacet);
+        assertThrows(ClassCastException.class, () -> attribs.addAttribute(notAString, "42"));
+        assertNull(attribs.getAttribute(longFacet));
+    }
+
+    /**
+     * Forcibly recast an attribute to defeat compiler type checking.
+     */
+    @SuppressWarnings("unchecked")
+    static <T> Attribute<T> recastAttribute(Attribute<?> attribute)
+    {
+        return (Attribute<T>) attribute;
+    }
+}


### PR DESCRIPTION
## Description

This will be used for metadata on `ResourceDescriptor`, in particular to store the module identity without requiring a concrete subclass.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
