### PR TITLE
[tiny] Move `FUSION_SOURCE_EXTENSION` to `FusionRuntime`

### DIFF
--- a/fusioncli/src/main/java/dev/ionfusion/fusioncli/cover/CoverageReport.java
+++ b/fusioncli/src/main/java/dev/ionfusion/fusioncli/cover/CoverageReport.java
@@ -4,7 +4,7 @@
 package dev.ionfusion.fusioncli.cover;
 
 import static dev.ionfusion.fusion._Private_Trampoline.discoverModulesInRepository;
-import static dev.ionfusion.runtime.base.SourceName.FUSION_SOURCE_EXTENSION;
+import static dev.ionfusion.runtime.embed.FusionRuntime.FUSION_SOURCE_CODE_FILE_EXTENSION;
 import static java.nio.file.Files.walkFileTree;
 import static java.util.stream.Collectors.toList;
 
@@ -166,7 +166,8 @@ public class CoverageReport
             @Override
             public FileVisitResult visitFile(Path entry, BasicFileAttributes attrs)
             {
-                if (entry.getFileName().toString().endsWith(FUSION_SOURCE_EXTENSION))
+                if (entry.getFileName().toString().endsWith(
+                    FUSION_SOURCE_CODE_FILE_EXTENSION))
                 {
                     noteScript(entry);
                 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/ClassLoaderModuleRepository.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ClassLoaderModuleRepository.java
@@ -3,7 +3,7 @@
 
 package dev.ionfusion.fusion;
 
-import static dev.ionfusion.runtime.base.SourceName.FUSION_SOURCE_EXTENSION;
+import static dev.ionfusion.runtime.embed.FusionRuntime.FUSION_SOURCE_CODE_FILE_EXTENSION;
 
 import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ModuleIdentity;
@@ -40,7 +40,7 @@ final class ClassLoaderModuleRepository
         throws FusionException
     {
         final String resourceName =
-            myPathPrefix + id.absolutePath() + FUSION_SOURCE_EXTENSION;
+            myPathPrefix + id.absolutePath() + FUSION_SOURCE_CODE_FILE_EXTENSION;
 
         // The protocol could be a jar: or file: (at least!)
         URL url = myClassLoader.getResource(resourceName);

--- a/runtime/src/main/java/dev/ionfusion/fusion/FileSystemModuleRepository.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FileSystemModuleRepository.java
@@ -4,7 +4,7 @@
 package dev.ionfusion.fusion;
 
 import static dev.ionfusion.runtime.base.ModuleIdentity.isValidModuleName;
-import static dev.ionfusion.runtime.base.SourceName.FUSION_SOURCE_EXTENSION;
+import static dev.ionfusion.runtime.embed.FusionRuntime.FUSION_SOURCE_CODE_FILE_EXTENSION;
 import static java.nio.file.Files.isDirectory;
 
 import dev.ionfusion.runtime.base.FusionException;
@@ -46,7 +46,7 @@ final class FileSystemModuleRepository
         if (mySrcDir == null) return null;
 
         String path = id.absolutePath();
-        String fileName = path.substring(1) + FUSION_SOURCE_EXTENSION;
+        String fileName = path.substring(1) + FUSION_SOURCE_CODE_FILE_EXTENSION;
 
         final File libFile = new File(mySrcDir, fileName);
         if (libFile.exists())
@@ -74,11 +74,11 @@ final class FileSystemModuleRepository
         // First pass: build all "real" modules
         for (String fileName : fileNames)
         {
-            if (fileName.endsWith(FUSION_SOURCE_EXTENSION))
+            if (fileName.endsWith(FUSION_SOURCE_CODE_FILE_EXTENSION))
             {
                 // We assume that all .fusion files are modules.
                 int endIndex =
-                    fileName.length() - FUSION_SOURCE_EXTENSION.length();
+                    fileName.length() - FUSION_SOURCE_CODE_FILE_EXTENSION.length();
                 String moduleName = fileName.substring(0, endIndex);
                 if (isValidModuleName(moduleName))
                 {

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceName.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceName.java
@@ -20,12 +20,6 @@ public interface SourceName
     extends ResourceDescriptor
 {
     /**
-     * The standard extension for Fusion source code files.
-     */
-    String FUSION_SOURCE_EXTENSION = ".fusion";
-
-
-    /**
      * It is not guaranteed that the module declaration is the only content of
      * the file or URL.
      * The resource could be a script with several modules inside, and module

--- a/runtime/src/main/java/dev/ionfusion/runtime/embed/FusionRuntime.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/embed/FusionRuntime.java
@@ -36,6 +36,12 @@ import dev.ionfusion.runtime.base.FusionException;
 public interface FusionRuntime
 {
     /**
+     * The standard extension for Fusion source code files.
+     */
+    String FUSION_SOURCE_CODE_FILE_EXTENSION = ".fusion";
+
+
+    /**
      * Gets the identifier for this runtime's default language, which supplies
      * the initial bindings for its {@link TopLevel} namespaces.
      * Unless configured otherwise by the {@link FusionRuntimeBuilder}, this


### PR DESCRIPTION
Renamed it for clarity.

## Notes

`SourceName` is going away, so this needs to move.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
