### PR TITLE
Move `FusionInterruptedException` into `embed` package

### DIFF
--- a/runtime/.structural-baseline.xml
+++ b/runtime/.structural-baseline.xml
@@ -3,6 +3,5 @@
   <CurrentIssues>
     <ID>ForbiddenImport$FusionJarInfo$dev.ionfusion.runtime.base$dev.ionfusion.fusion._Private_Trampoline</ID>
     <ID>ForbiddenImport$FusionRuntimeBuilder$dev.ionfusion.runtime.embed$dev.ionfusion.fusion._Private_Trampoline</ID>
-    <ID>ForbiddenImport$TopLevel$dev.ionfusion.runtime.embed$dev.ionfusion.fusion.FusionInterruptedException</ID>
   </CurrentIssues>
 </StructuralBaseline>

--- a/runtime/src/main/java/dev/ionfusion/fusion/FusionInterrupt.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FusionInterrupt.java
@@ -5,6 +5,7 @@ package dev.ionfusion.fusion;
 
 
 import dev.ionfusion.runtime.base.FusionException;
+import dev.ionfusion.runtime.embed.FusionInterruptedException;
 
 /**
  * Internal exception thrown when a Fusion evaluation is interrupted via
@@ -14,10 +15,9 @@ import dev.ionfusion.runtime.base.FusionException;
  * careful to handle the interrupt exception everywhere we catch
  * {@link FusionException}, or else the interrupt could easily be swallowed.
  * <p>
- * Instead, we throw an {@link Error} that
- * is much less likely to be mis-handled. We catch it at entry points to the
- * evaluator and wrap it in the public sibling exception
- * {@link FusionInterruptedException}.
+ * Instead, we throw an {@link Error}, which is much less likely to be mishandled.
+ * We catch it at entry points to the evaluator and throw the public sibling
+ * exception {@link FusionInterruptedException}.
  */
 @SuppressWarnings("serial")
 final class FusionInterrupt

--- a/runtime/src/main/java/dev/ionfusion/fusion/StandardFusionRuntimeBuilder.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/StandardFusionRuntimeBuilder.java
@@ -15,6 +15,7 @@ import dev.ionfusion.runtime._private.cover.CoverageCollector;
 import dev.ionfusion.runtime._private.cover.CoverageCollectorImpl;
 import dev.ionfusion.runtime._private.cover.CoverageConfiguration;
 import dev.ionfusion.runtime.base.FusionException;
+import dev.ionfusion.runtime.embed.FusionInterruptedException;
 import dev.ionfusion.runtime.embed.FusionRuntime;
 import dev.ionfusion.runtime.embed.FusionRuntimeBuilder;
 import java.io.File;

--- a/runtime/src/main/java/dev/ionfusion/fusion/StandardRuntime.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/StandardRuntime.java
@@ -16,6 +16,7 @@ import com.amazon.ion.system.IonSystemBuilder;
 import dev.ionfusion.runtime._private.cover.CoverageCollector;
 import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ModuleIdentity;
+import dev.ionfusion.runtime.embed.FusionInterruptedException;
 import dev.ionfusion.runtime.embed.FusionRuntime;
 import dev.ionfusion.runtime.embed.ModuleBuilder;
 import dev.ionfusion.runtime.embed.SandboxBuilder;

--- a/runtime/src/main/java/dev/ionfusion/fusion/StandardTopLevel.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/StandardTopLevel.java
@@ -17,6 +17,7 @@ import dev.ionfusion.runtime._private.cover.CoverageCollector;
 import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ModuleIdentity;
 import dev.ionfusion.runtime.base.ResourceDescriptor;
+import dev.ionfusion.runtime.embed.FusionInterruptedException;
 import dev.ionfusion.runtime.embed.TopLevel;
 import java.io.File;
 import java.io.IOException;

--- a/runtime/src/main/java/dev/ionfusion/fusion/_Private_Trampoline.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/_Private_Trampoline.java
@@ -8,6 +8,7 @@ import dev.ionfusion.runtime._private.doc.BindingDoc;
 import dev.ionfusion.runtime._private.doc.ModuleDocs;
 import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ModuleIdentity;
+import dev.ionfusion.runtime.embed.FusionInterruptedException;
 import dev.ionfusion.runtime.embed.FusionRuntimeBuilder;
 import dev.ionfusion.runtime.embed.TopLevel;
 import java.nio.file.Path;

--- a/runtime/src/main/java/dev/ionfusion/runtime/embed/FusionInterruptedException.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/embed/FusionInterruptedException.java
@@ -1,7 +1,7 @@
 // Copyright Ion Fusion contributors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package dev.ionfusion.fusion;
+package dev.ionfusion.runtime.embed;
 
 import dev.ionfusion.runtime.base.FusionException;
 
@@ -19,7 +19,7 @@ import dev.ionfusion.runtime.base.FusionException;
 public final class FusionInterruptedException
     extends FusionException
 {
-    FusionInterruptedException(FusionInterrupt cause)
+    public FusionInterruptedException(Throwable cause)
     {
         super("The Fusion evaluation thread was interrupted.", cause);
         assert Thread.currentThread().isInterrupted();

--- a/runtime/src/main/java/dev/ionfusion/runtime/embed/TopLevel.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/embed/TopLevel.java
@@ -5,7 +5,6 @@ package dev.ionfusion.runtime.embed;
 
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonWriter;
-import dev.ionfusion.fusion.FusionInterruptedException;
 import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ResourceDescriptor;
 import java.io.File;

--- a/runtime/src/main/java/dev/ionfusion/runtime/embed/package-info.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/embed/package-info.java
@@ -58,7 +58,7 @@
  * can be canceled by calling {@link java.lang.Thread#interrupt()} on the evaluation
  * thread. The evaluator periodically checks the thread interrupt status and cancels the
  * computation when it is set. The evaluation API then throws
- * {@link dev.ionfusion.fusion.FusionInterruptedException}, leaving the thread interrupt
+ * {@link FusionInterruptedException}, leaving the thread interrupt
  * status set. Be aware that some activities, notably reading from an
  * {@link java.io.InputStream}, are uninterruptible and will block until control returns
  * to the evaluator.

--- a/runtime/src/test/java/dev/ionfusion/fusion/InterruptionTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/InterruptionTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.amazon.ion.IonReader;
+import dev.ionfusion.runtime.embed.FusionInterruptedException;
 import dev.ionfusion.runtime.embed.ModuleBuilder;
 import dev.ionfusion.runtime.embed.TopLevel;
 import java.util.concurrent.CountDownLatch;


### PR DESCRIPTION
This is a public feature used by the embedding API.

## Notes
I also got rid of a useless 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
