### PR TITLE
`SourceNameImpl` extends `AbstractResourceDescriptor`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceName.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceName.java
@@ -54,11 +54,11 @@ public interface SourceName
      *
      * @param path must not be null or empty, and is converted to an absolute path.
      *
-     * @return a new {@link SourceName} instance
+     * @return a new descriptor.
      *
      * @see #forFile(File)
      */
-    static SourceName forFile(String path)
+    static ResourceDescriptor forFile(String path)
     {
         ResourceIdentifier rsrc = ResourceIdentifier.forFile(path);
         return new ResourceSourceName(rsrc);
@@ -70,11 +70,11 @@ public interface SourceName
      *
      * @param path is converted to an absolute path.
      *
-     * @return a new {@link SourceName} instance
+     * @return a new descriptor.
      *
      * @see #forFile(String)
      */
-    static SourceName forFile(File path)
+    static ResourceDescriptor forFile(File path)
     {
         ResourceIdentifier rsrc = ResourceIdentifier.forFile(path);
         return new ResourceSourceName(rsrc);
@@ -115,7 +115,7 @@ public interface SourceName
      *
      * @return a new {@link SourceName}.
      */
-    static SourceName forResource(ResourceIdentifier resource, ModuleIdentity id)
+    static ResourceDescriptor forResource(ResourceIdentifier resource, ModuleIdentity id)
     {
         requireNonNull(resource, "resource must not be null");
         if (id == null) return new ResourceSourceName(resource);

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceNameImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceNameImpl.java
@@ -3,7 +3,10 @@
 
 package dev.ionfusion.runtime.base;
 
+import dev.ionfusion.runtime.base.ResourceDescriptorImpl.AbstractResourceDescriptor;
+
 class SourceNameImpl
+    extends AbstractResourceDescriptor
     implements SourceName
 {
     private final String myDisplay;
@@ -37,29 +40,6 @@ class SourceNameImpl
     public String toString()
     {
         return myDisplay;
-    }
-
-
-    public boolean equals(SourceName other)
-    {
-        return (other != null && myDisplay.equals(other.display()));
-    }
-
-    @Override
-    public boolean equals(Object other)
-    {
-        return (other instanceof SourceName && equals((SourceName) other));
-    }
-
-
-    private static final int HASH_SEED = SourceNameImpl.class.hashCode();
-
-    @Override
-    public int hashCode()
-    {
-        int result = HASH_SEED + myDisplay.hashCode();
-        result ^= (result << 29) ^ (result >> 3);
-        return result;
     }
 
 

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/ResourceDescriptorTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/ResourceDescriptorTest.java
@@ -70,19 +70,19 @@ public class ResourceDescriptorTest
     //==================================================================================
     // SourceNames
 
-    /**
-     * Retain legacy equality of SourceName instances, for now at least. The design plan
-     * is for ResourceDescriptors to match on their ResourceIdentifier.
-     */
     @Test
-    void sourceNamesMatchOnDisplay()
+    void sourceNamesMatchOnResourceIdentifier()
     {
-        ResourceDescriptor foo1 = SourceName.forDisplay("foo");
-        ResourceDescriptor foo2 = SourceName.forDisplay("foo");
-        ResourceDescriptor bar  = SourceName.forDisplay("bar");
+        ResourceDescriptor foo1 = SourceName.forDisplay("/foo");
+        ResourceDescriptor foo2 = SourceName.forDisplay("/foo");
 
-        checkEquality(foo1, foo2);
-        checkInequality(foo1, bar);
+        checkInequality(foo1, foo2);
+
+        ResourceDescriptor fooFile1 = SourceName.forFile("/foo");
+        ResourceDescriptor fooFile2 = SourceName.forFile("/foo");
+
+        checkEquality(fooFile1, fooFile2);
+        checkInequality(foo1, fooFile1);
     }
 
     @Test


### PR DESCRIPTION
  * `SourceName.equals` now meets the `ResourceDescriptor` contract by matching on object identity else `ResourceIdentifier` (ie, URI).
  * Most `SourceName` factories return `ResourceDescriptor`


## Description

This allows us to hoist more uses of `SourceName` to `ResourceDescriptor`. The equality fix allows migrating more `SourceLocation` uses to `ResourcePosition` as well.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
