### PR TITLE
Use `ResourcePosition` in `FusionException`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/ContractException.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ContractException.java
@@ -4,7 +4,7 @@
 package dev.ionfusion.fusion;
 
 
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 
 /**
  * Indicates inappropriate run-time use of a procedure or syntactic form;
@@ -30,7 +30,7 @@ public class ContractException
     /**
      * @param location may be null.
      */
-    ContractException(String message, SourceLocation location)
+    ContractException(String message, ResourcePosition location)
     {
         super(message);
         addContext(location);
@@ -39,8 +39,7 @@ public class ContractException
     /**
      * @param location may be null.
      */
-    ContractException(String message, SourceLocation location,
-                      Throwable cause)
+    ContractException(String message, ResourcePosition location, Throwable cause)
     {
         super(message, cause);
         addContext(location);

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/FusionException.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/FusionException.java
@@ -36,7 +36,7 @@ public class FusionException
      * The Fusion stack trace, aggregated by {@code catch} clauses in the
      * interpreter as the Java stack unwinds.
      */
-    private List<SourceLocation> myContext;
+    private List<ResourcePosition> myContext;
 
 
     public FusionException(String message)
@@ -60,7 +60,7 @@ public class FusionException
      *
      * @param location can be null to indicate an unknown location.
      */
-    public void addContext(SourceLocation location)
+    public void addContext(ResourcePosition location)
     {
         if (myContext == null)
         {
@@ -70,7 +70,7 @@ public class FusionException
         else
         {
             // Collapse equal adjacent locations
-            SourceLocation prev = myContext.get(myContext.size() - 1);
+            ResourcePosition prev = myContext.get(myContext.size() - 1);
             if (! Objects.equals(prev, location))
             {
                 myContext.add(location);
@@ -90,7 +90,7 @@ public class FusionException
      *
      * @return an immutable list; not null.
      */
-    public List<SourceLocation> getContext()
+    public List<ResourcePosition> getContext()
     {
         return (myContext == null ? emptyList() : unmodifiableList(myContext));
     }
@@ -101,7 +101,7 @@ public class FusionException
     {
         if (myContext != null)
         {
-            for (SourceLocation loc : myContext)
+            for (ResourcePosition loc : myContext)
             {
                 if (loc == null)
                 {

--- a/runtime/src/test/java/dev/ionfusion/fusion/StackTraceTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/StackTraceTest.java
@@ -3,10 +3,12 @@
 
 package dev.ionfusion.fusion;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 import java.util.Iterator;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -14,27 +16,27 @@ import org.junit.jupiter.api.Test;
 public class StackTraceTest
     extends CoreTestCase
 {
-    private Iterator<SourceLocation> myStack;
+    private Iterator<ResourcePosition> myStack;
 
 
     private void evalForTrace(String code)
         throws Exception
     {
         FusionException e = assertEvalThrows(FusionException.class, code);
-        List<SourceLocation> locations = e.getContext();
+        List<ResourcePosition> locations = e.getContext();
         if (locations.isEmpty())
         {
             // This is probably a parsing error, since the evaluator will
-            // otherwise ensure a topmost locations.
+            // otherwise ensure a topmost frame.
             throw e;
         }
         myStack = locations.iterator();
     }
 
 
-    private SourceLocation popLocation()
+    private ResourcePosition popLocation()
     {
-        SourceLocation loc = myStack.next();
+        ResourcePosition loc = myStack.next();
 
         // Ignore library code from known resources; test code has an unknown resource.
         while (!loc.getResourceDesc().isUnknown())
@@ -47,7 +49,7 @@ public class StackTraceTest
 
     private void expectLocation(int line, int column)
     {
-        SourceLocation loc = popLocation();
+        ResourcePosition loc = popLocation();
         if (line != loc.getLine() || column != loc.getColumn())
         {
             fail("Expected L" + line +" C" + column
@@ -56,6 +58,19 @@ public class StackTraceTest
     }
 
 
+
+    //========================================================================
+
+    @Test
+    public void traceIncludesModuleIdentity()
+        throws Exception
+    {
+        useTstRepo();
+        String code = "(require '/module/bad_lang_symbol')";
+        FusionException e = assertEvalThrows(FusionException.class, code);
+        assertThat(e.getMessage(),
+                   containsString("of /module/bad_lang_symbol (at "));
+    }
 
     //========================================================================
 


### PR DESCRIPTION
Add a test case to ensure the module identity is in the printed stack trace.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
