### PR TITLE
Replace `SourceName.getModuleIdentity`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptor.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptor.java
@@ -7,7 +7,7 @@ import java.net.URI;
 import java.nio.file.Path;
 
 /**
- * Provides access to metadata about a resource and optionally access to its content.
+ * Describes a resource and optionally provides access to its content.
  * <p>
  * There are three varieties of resource descriptors:
  * <ul>
@@ -23,11 +23,13 @@ import java.nio.file.Path;
  * Two descriptors are considered equal if they are the same instance or if they
  * have equal non-null {@link ResourceIdentifier}s.
  * <p>
+ * Descriptors are {@link Attributed} to support extensible metadata about the resource.
  * Long term, this is intended to surface things like the deployment unit containing the
  * resource, perhaps checksums, etc. This enables passing context from the component
  * providing the resource.
  */
 public interface ResourceDescriptor
+    extends Attributed
 {
     /**
      * Returns a human-readable description of the resource, for display in messages.

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptorImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourceDescriptorImpl.java
@@ -12,9 +12,10 @@ class ResourceDescriptorImpl
     // Implementations
 
     /**
-     * Satisfies the equals/hashCode contract for descriptors.
+     * Satisfies the facet and equals/hashCode contracts for descriptors.
      */
     abstract static class AbstractResourceDescriptor
+        extends AttributeSet
         implements ResourceDescriptor
     {
         @Override

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceLocation.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceLocation.java
@@ -4,6 +4,7 @@
 package dev.ionfusion.runtime.base;
 
 import static dev.ionfusion.runtime._private.util.Ordinals.writeFriendlyOrdinal;
+import static dev.ionfusion.runtime.base._Private_Attributes.MODULE_IDENTITY_ATTRIBUTE;
 
 import com.amazon.ion.IonReader;
 import com.amazon.ion.OffsetSpan;
@@ -72,11 +73,7 @@ public class SourceLocation
     @Override
     public ModuleIdentity getModuleIdentity()
     {
-        if (myResource instanceof SourceName)
-        {
-            return ((SourceName) myResource).getModuleIdentity();
-        }
-        return null;
+        return myResource.getAttribute(MODULE_IDENTITY_ATTRIBUTE);
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceName.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceName.java
@@ -3,9 +3,9 @@
 
 package dev.ionfusion.runtime.base;
 
+import static dev.ionfusion.runtime.base._Private_Attributes.MODULE_IDENTITY_ATTRIBUTE;
 import static java.util.Objects.requireNonNull;
 
-import dev.ionfusion.runtime.base.SourceNameImpl.ModuleSourceName;
 import dev.ionfusion.runtime.base.SourceNameImpl.ResourceSourceName;
 import java.io.File;
 
@@ -18,17 +18,6 @@ import java.io.File;
 public interface SourceName
     extends ResourceDescriptor
 {
-    /**
-     * It is not guaranteed that the module declaration is the only content of
-     * the file or URL.
-     * The resource could be a script with several modules inside, and module
-     * declarations will eventually nest.
-     *
-     * @return the module associated with this source, if any.
-     */
-    ModuleIdentity getModuleIdentity();
-
-
     //=========================================================================
     // Factory methods
 
@@ -92,6 +81,8 @@ public interface SourceName
     {
         requireNonNull(resource, "resource must not be null");
         if (id == null) return new ResourceSourceName(resource);
-        return new ModuleSourceName(resource, id);
+        SourceName name = new ResourceSourceName(resource);
+        name.addAttribute(MODULE_IDENTITY_ATTRIBUTE, id);
+        return name;
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceNameImpl.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceNameImpl.java
@@ -31,12 +31,6 @@ class SourceNameImpl
     }
 
     @Override
-    public ModuleIdentity getModuleIdentity()
-    {
-        return null;
-    }
-
-    @Override
     public String toString()
     {
         return myDisplay;
@@ -68,21 +62,5 @@ class SourceNameImpl
         {
             return myResource;
         }
-    }
-
-
-    static class ModuleSourceName
-        extends ResourceSourceName
-    {
-        private final ModuleIdentity myId;
-
-        ModuleSourceName(ResourceIdentifier rsrc, ModuleIdentity id)
-        {
-            super(rsrc);
-            myId   = id;
-        }
-
-        @Override
-        public ModuleIdentity getModuleIdentity() { return myId; }
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/_Private_Attributes.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/_Private_Attributes.java
@@ -1,0 +1,17 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+public final class _Private_Attributes
+{
+    private _Private_Attributes() {}
+
+
+    /**
+     * {@link ResourceDescriptor} attribute holding the module contained by a resource.
+     * It is not guaranteed that the module declaration is the only content present.
+     */
+    public static final Attribute<ModuleIdentity> MODULE_IDENTITY_ATTRIBUTE =
+        Attribute.ofType(ModuleIdentity.class);
+}


### PR DESCRIPTION
Instead, have `ResourceDescriptor` extend `Attributed` and add a `ModuleIdentity` attribute as needed. 

This isn't a long-term solution: to support nested modules, we'll need a map between source positions and modules.

## Description

This was one of the big problems plaguing the old design.  After this, we can migrate all uses of `SourceName` to `ResourceDescription` and then delete the thing.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
