### PR TITLE
Remove `SourceLocation.display()`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/util/Ordinals.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/util/Ordinals.java
@@ -85,4 +85,40 @@ public class Ordinals
         String suffix = friendlySuffix(i);
         out.append(suffix);
     }
+
+
+    /**
+     * Displays the line and column, if known, otherwise the offset.
+     *
+     * @param out the stream to write into.
+     *
+     * @throws IOException if thrown by the {@link Appendable}.
+     */
+    public static void displayFriendlyPosition(Appendable out,
+                                               long line,
+                                               long column,
+                                               long offset)
+        throws IOException
+    {
+        if (line > 0)
+        {
+            writeFriendlyOrdinal(out, line);
+            out.append(" line");
+
+            if (column > 0)
+            {
+                out.append(", ");
+                writeFriendlyOrdinal(out, column);
+                out.append(" column");
+            }
+        }
+        else if (offset >= 0)
+        {
+            out.append("offset ").append(Long.toString(offset));
+        }
+        else
+        {
+            out.append("unknown position");
+        }
+    }
 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/FusionException.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/FusionException.java
@@ -3,6 +3,8 @@
 
 package dev.ionfusion.runtime.base;
 
+import static dev.ionfusion.runtime._private.util.Ordinals.displayFriendlyPosition;
+import static dev.ionfusion.runtime.base._Private_Attributes.MODULE_IDENTITY_ATTRIBUTE;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 
@@ -110,11 +112,37 @@ public class FusionException
                 else
                 {
                     out.append("\n  ...at ");
-                    loc.display(out);
+                    displayFrame(out, loc);
                 }
             }
         }
     }
+
+    /**
+     * Alternative to {@link ResourcePosition#display()} that adds the module identity.
+     */
+    private static void displayFrame(Appendable out, ResourcePosition loc)
+        throws IOException
+    {
+        displayFriendlyPosition(out, loc.getLine(), loc.getColumn(), loc.getOffset());
+
+        ResourceDescriptor rsrc = loc.getResourceDesc();
+
+        ModuleIdentity module = rsrc.getAttribute(MODULE_IDENTITY_ATTRIBUTE);
+        if (module != null)
+        {
+            out.append(" of ").append(module.absolutePath());
+            if (!rsrc.isUnknown())
+            {
+                out.append(" (at ").append(rsrc.display()).append(')');
+            }
+        }
+        else if (!rsrc.isUnknown())
+        {
+            out.append(" of ").append(rsrc.display());
+        }
+    }
+
 
     /**
      * Gets the value that was passed to Fusion's {@code raise} procedure.

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourcePosition.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourcePosition.java
@@ -3,6 +3,8 @@
 
 package dev.ionfusion.runtime.base;
 
+import static dev.ionfusion.runtime._private.util.Ordinals.displayFriendlyPosition;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
@@ -56,8 +58,17 @@ public interface ResourcePosition
      *
      * @throws IOException if thrown by the {@link Appendable}.
      */
-    void display(Appendable out)
-        throws IOException;
+    default void display(Appendable out)
+        throws IOException
+    {
+        displayFriendlyPosition(out, getLine(), getColumn(), getOffset());
+
+        ResourceDescriptor rsrc = getResourceDesc();
+        if (!rsrc.isUnknown())
+        {
+            out.append(" of ").append(rsrc.display());
+        }
+    }
 
 
     /**

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceLocation.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceLocation.java
@@ -3,14 +3,12 @@
 
 package dev.ionfusion.runtime.base;
 
-import static dev.ionfusion.runtime._private.util.Ordinals.writeFriendlyOrdinal;
 import static dev.ionfusion.runtime.base._Private_Attributes.MODULE_IDENTITY_ATTRIBUTE;
 
 import com.amazon.ion.IonReader;
 import com.amazon.ion.OffsetSpan;
 import com.amazon.ion.TextSpan;
 import com.amazon.ion.util.Spans;
-import java.io.IOException;
 import java.util.Objects;
 
 
@@ -309,61 +307,6 @@ public class SourceLocation
         }
 
         return forName(desc);
-    }
-
-
-    /**
-     * Displays this location in a human-readable form, in terms of line,
-     * column, and source name.
-     *
-     * @param out the stream to write
-     *
-     * @throws IOException if thrown by the {@link Appendable}.
-     */
-    @Override
-    public void display(Appendable out)
-        throws IOException
-    {
-        long line   = getLine();
-        long column = getColumn();
-
-        if (line < 1)
-        {
-            out.append("unknown location");
-            if (!myResource.isUnknown())
-            {
-                out.append(" in ").append(myResource.display());
-            }
-        }
-        else
-        {
-            writeFriendlyOrdinal(out, line);
-            out.append(" line");
-
-            if (column > 0)
-            {
-                out.append(", ");
-                writeFriendlyOrdinal(out, column);
-                out.append(" column");
-            }
-
-            if (!myResource.isUnknown())
-            {
-                out.append(" of ");
-                ModuleIdentity module = getModuleIdentity();
-                if (module != null)
-                {
-                    out.append(module.absolutePath())
-                       .append(" (at ")
-                       .append(myResource.display())
-                       .append(')');
-                }
-                else
-                {
-                    out.append(myResource.display());
-                }
-            }
-        }
     }
 
 

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
@@ -37,13 +37,13 @@ public class SourceLocationTest
         ResourceDescriptor name = SourceName.forDisplay("test source");
         loc = SourceLocation.forCurrentSpan(ir, name);
         assertHashEquals(name, loc.getResourceDesc());
-        assertEquals("unknown location in test source", loc.display());
+        assertEquals("unknown position of test source", loc.display());
 
         name = SourceName.forFile("/dummy/path");
         loc = SourceLocation.forCurrentSpan(ir, name);
         assertHashEquals(name, loc.getResourceDesc());
         checkPath("/dummy/path", loc);
-        assertEquals("unknown location in /dummy/path", loc.display());
+        assertEquals("unknown position of /dummy/path", loc.display());
     }
 
     private void assertLocation(String expectedOffsets, IonReader ir)
@@ -123,10 +123,10 @@ public class SourceLocationTest
         ResourceDescriptor name = loc.getResourceDesc();
         if (display == null)
         {
-            display = "unknown location";
-            if (name != null)
+            display = "unknown position";
+            if (!name.isUnknown())
             {
-                display += " in " + name.display();
+                display += " of " + name.display();
             }
         }
         else if (!name.isUnknown())


### PR DESCRIPTION
  * Provide a generic default `ResourcePosition.display`.
  * `FusionException` does its own thing to inject the module ID.

## Notes
This makes minor changes to the position output that were too complicated to avoid.  The stack rendering could use a refresh at some point.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
