### PR TITLE
Migrate all `SourceName` factory calls to `ResourceDescriptor`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/ClassLoaderModuleRepository.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ClassLoaderModuleRepository.java
@@ -4,12 +4,12 @@
 package dev.ionfusion.fusion;
 
 import static dev.ionfusion.runtime.base.ResourceIdentifier.forUrl;
+import static dev.ionfusion.runtime.base._Private_Attributes.MODULE_IDENTITY_ATTRIBUTE;
 import static dev.ionfusion.runtime.embed.FusionRuntime.FUSION_SOURCE_CODE_FILE_EXTENSION;
 
 import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ModuleIdentity;
 import dev.ionfusion.runtime.base.ResourceDescriptor;
-import dev.ionfusion.runtime.base.SourceName;
 import java.net.URL;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -49,7 +49,9 @@ final class ClassLoaderModuleRepository
         URL url = myClassLoader.getResource(resourceName);
         if (url == null) return null;
 
-        return SourceName.forResource(forUrl(url), id);
+        ResourceDescriptor desc = ResourceDescriptor.identified(forUrl(url));
+        desc.addAttribute(MODULE_IDENTITY_ATTRIBUTE, id);
+        return desc;
     }
 
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/FileSystemModuleRepository.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/FileSystemModuleRepository.java
@@ -4,14 +4,14 @@
 package dev.ionfusion.fusion;
 
 import static dev.ionfusion.runtime.base.ModuleIdentity.isValidModuleName;
+import static dev.ionfusion.runtime.base.ResourceIdentifier.forFile;
+import static dev.ionfusion.runtime.base._Private_Attributes.MODULE_IDENTITY_ATTRIBUTE;
 import static dev.ionfusion.runtime.embed.FusionRuntime.FUSION_SOURCE_CODE_FILE_EXTENSION;
 import static java.nio.file.Files.isDirectory;
 
 import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ModuleIdentity;
 import dev.ionfusion.runtime.base.ResourceDescriptor;
-import dev.ionfusion.runtime.base.ResourceIdentifier;
-import dev.ionfusion.runtime.base.SourceName;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.function.Consumer;
@@ -54,7 +54,9 @@ final class FileSystemModuleRepository
         final File libFile = new File(mySrcDir, fileName);
         if (libFile.exists())
         {
-            return SourceName.forResource(ResourceIdentifier.forFile(libFile), id);
+            ResourceDescriptor desc = ResourceDescriptor.identified(forFile(libFile));
+            desc.addAttribute(MODULE_IDENTITY_ATTRIBUTE, id);
+            return desc;
         }
 
         return null;

--- a/runtime/src/main/java/dev/ionfusion/fusion/LoadHandler.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/LoadHandler.java
@@ -17,7 +17,6 @@ import dev.ionfusion.runtime.base.ModuleIdentity;
 import dev.ionfusion.runtime.base.ResourceDescriptor;
 import dev.ionfusion.runtime.base.ResourceIdentifier;
 import dev.ionfusion.runtime.base.SourceLocation;
-import dev.ionfusion.runtime.base.SourceName;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -67,7 +66,8 @@ final class LoadHandler
 
         try (InputStream in = myFileSystem.openInputFile(eval, "load", file))
         {
-            ResourceDescriptor name = SourceName.forFile(file);
+            ResourceIdentifier rsrc = ResourceIdentifier.forFile(file);
+            ResourceDescriptor desc = ResourceDescriptor.identified(rsrc);
             Object result = null;
 
             try (IonReader reader = eval.getIonReaderBuilder().build(in))
@@ -75,7 +75,7 @@ final class LoadHandler
                 while (reader.next() != null)
                 {
                     result = null;  // Don't hold onto garbage
-                    SyntaxValue fileExpr = readSyntax(eval, reader, name);
+                    SyntaxValue fileExpr = readSyntax(eval, reader, desc);
                     result = FusionEval.eval(eval, fileExpr, namespace);
                     // TODO TAIL
                 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/_private/util/IonCatalogLoader.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/_private/util/IonCatalogLoader.java
@@ -14,9 +14,9 @@ import com.amazon.ion.system.IonReaderBuilder;
 import com.amazon.ion.system.IonSystemBuilder;
 import com.amazon.ion.system.SimpleCatalog;
 import dev.ionfusion.runtime.base.ResourceDescriptor;
+import dev.ionfusion.runtime.base.ResourceIdentifier;
 import dev.ionfusion.runtime.base.ResourcePosition;
 import dev.ionfusion.runtime.base.SourceLocation;
-import dev.ionfusion.runtime.base.SourceName;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -109,14 +109,15 @@ public final class IonCatalogLoader
     private void loadFile(File file)
         throws IOException
     {
-        ResourceDescriptor name = SourceName.forFile(file.getPath());
+        ResourceIdentifier id = ResourceIdentifier.forFile(file.getPath());
+        ResourceDescriptor desc = ResourceDescriptor.identified(id);
 
         try (FileInputStream stream = new FileInputStream(file);
              IonReader reader = myReaderBuilder.build(stream))
         {
             while (reader.next() != null)
             {
-                loadSymtab(name, reader);
+                loadSymtab(desc, reader);
             }
         }
     }

--- a/runtime/src/test/java/dev/ionfusion/fusion/CoverageTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/CoverageTest.java
@@ -13,7 +13,6 @@ import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ResourceDescriptor;
 import dev.ionfusion.runtime.base.ResourcePosition;
 import dev.ionfusion.runtime.base.SourceLocation;
-import dev.ionfusion.runtime.base.SourceName;
 import dev.ionfusion.runtime.embed.TopLevel;
 import java.util.HashMap;
 import java.util.Map;
@@ -121,7 +120,7 @@ public class CoverageTest
         checkCovered   (desc, 2, 5);
         checkNotCovered(desc, 2, 7);
 
-        SourceName name1 = SourceName.forDisplay("define");
+        ResourceDescriptor name1 = ResourceDescriptor.named("define");
         //        1 3 5 7 9
         top.eval("(define (f t)\n" +
                  "  (if t      \n" +
@@ -140,7 +139,7 @@ public class CoverageTest
         checkCovered   (name1, 3, 7);
         checkNotCovered(name1, 4, 7);
 
-        SourceName name2 = SourceName.forDisplay("invoke");
+        ResourceDescriptor name2 = ResourceDescriptor.named("invoke");
         //        1 3 5 7 9
         top.eval("(f false)",
                  name2);

--- a/runtime/src/test/java/dev/ionfusion/fusion/RuntimeTest.java
+++ b/runtime/src/test/java/dev/ionfusion/fusion/RuntimeTest.java
@@ -28,7 +28,6 @@ import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.JarInfo;
 import dev.ionfusion.runtime.base.ModuleIdentity;
 import dev.ionfusion.runtime.base.ResourceDescriptor;
-import dev.ionfusion.runtime.base.SourceName;
 import dev.ionfusion.runtime.embed.FusionRuntime;
 import dev.ionfusion.runtime.embed.ModuleBuilder;
 import java.io.ByteArrayOutputStream;
@@ -220,7 +219,7 @@ public class RuntimeTest
     {
         topLevel().loadModule("/local/manual",
                               system().newReader(GOOD_MODULE),
-                              SourceName.forDisplay("manual source"));
+                              ResourceDescriptor.unknown());
 
         topLevel().requireModule("/local/manual");
         assertEval(1115, "x");
@@ -234,8 +233,7 @@ public class RuntimeTest
         reader.next();
 
         topLevel().loadModule("/local/manual",
-                              reader,
-                              SourceName.forDisplay("manual source"));
+                              reader, ResourceDescriptor.unknown());
 
         topLevel().requireModule("/local/manual");
         assertEval(1115, "x");
@@ -258,7 +256,7 @@ public class RuntimeTest
         assertThrows(IllegalArgumentException.class,
                      () -> topLevel().loadModule(null,
                                                  system().newReader(GOOD_MODULE),
-                                                 SourceName.forDisplay("manual source")));
+                                                 ResourceDescriptor.unknown()));
     }
 
     @Test
@@ -267,7 +265,7 @@ public class RuntimeTest
         assertThrows(IllegalArgumentException.class,
                      () -> topLevel().loadModule("/a bad path",
                                                  system().newReader(GOOD_MODULE),
-                                                 SourceName.forDisplay("manual source")));
+                                                 ResourceDescriptor.unknown()));
     }
 
     @Test
@@ -276,12 +274,12 @@ public class RuntimeTest
     {
         topLevel().loadModule("/local/manual",
                               system().newReader(GOOD_MODULE),
-                              SourceName.forDisplay("manual source"));
+                              ResourceDescriptor.unknown());
         try
         {
             topLevel().loadModule("/local/manual",
                                   system().newReader(GOOD_MODULE),
-                                  SourceName.forDisplay("manual source"));
+                                  ResourceDescriptor.unknown());
             fail("Expected exception");
         }
         catch (FusionException e) { }
@@ -292,18 +290,18 @@ public class RuntimeTest
         throws Exception
     {
         String modulePath = "/local/manual";
-        SourceName source = SourceName.forDisplay("/path/to/blah");
+        ResourceDescriptor desc = ResourceDescriptor.named("/path/to/blah");
         String moduleContent = "/* nothing */";
 
         Exception e =
             assertThrows(SyntaxException.class,
                          () -> topLevel().loadModule(modulePath,
                                                      system().newReader(moduleContent),
-                                                     source));
+                                                     desc));
 
         assertThat(e.getMessage(),
                    allOf(containsString("no top-level forms"),
-                         containsString(source.display())));
+                         containsString(desc.display())));
     }
 
     @Test
@@ -311,18 +309,18 @@ public class RuntimeTest
         throws Exception
     {
         String modulePath = "/local/manual";
-        SourceName source = SourceName.forDisplay("/path/to/blah");
+        ResourceDescriptor desc = ResourceDescriptor.named("/path/to/blah");
         String moduleContent = "(module m '/fusion' true) extra_data";
 
         Exception e =
             assertThrows(SyntaxException.class,
                          () -> topLevel().loadModule(modulePath,
                                                      system().newReader(moduleContent),
-                                                     source));
+                                                     desc));
 
         assertThat(e.getMessage(),
                    allOf(containsString("more than one top-level form"),
-                         containsString(source.display())));
+                         containsString(desc.display())));
     }
 
 
@@ -331,19 +329,19 @@ public class RuntimeTest
         throws Exception
     {
         String modulePath = "/local/manual";
-        SourceName source = SourceName.forDisplay("/path/to/blah");
+        ResourceDescriptor desc = ResourceDescriptor.named("/path/to/blah");
         String moduleContent = " (if true 1 2)";
 
         Exception e =
             assertThrows(SyntaxException.class,
                          () -> topLevel().loadModule(modulePath,
                                                      system().newReader(moduleContent),
-                                                     source));
+                                                     desc));
 
         assertThat(e.getMessage(),
                    allOf(containsString("Top-level form isn't (module ...)"),
                          containsString("1st line, 2nd column"),
-                         containsString(source.display())));
+                         containsString(desc.display())));
     }
 
 

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/ResourceDescriptorTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/ResourceDescriptorTest.java
@@ -87,7 +87,7 @@ public class ResourceDescriptorTest
         assertNull(desc.getResourceId());
 
 
-        desc = SourceName.forDisplay("name");
+        desc = ResourceDescriptor.named("name");
         assertEquals("name", desc.display());
         assertFalse(desc.isUnknown());
         assertNull(desc.getResourceId());
@@ -108,13 +108,15 @@ public class ResourceDescriptorTest
     @Test
     void sourceNamesMatchOnResourceIdentifier()
     {
-        ResourceDescriptor foo1 = SourceName.forDisplay("/foo");
-        ResourceDescriptor foo2 = SourceName.forDisplay("/foo");
+        ResourceDescriptor foo1 = ResourceDescriptor.named("/foo");
+        ResourceDescriptor foo2 = ResourceDescriptor.named("/foo");
 
         checkInequality(foo1, foo2);
 
-        ResourceDescriptor fooFile1 = SourceName.forFile("/foo");
-        ResourceDescriptor fooFile2 = SourceName.forFile("/foo");
+        ResourceDescriptor fooFile1 =
+            ResourceDescriptor.identified(ResourceIdentifier.forFile("/foo"));
+        ResourceDescriptor fooFile2 =
+            ResourceDescriptor.identified(ResourceIdentifier.forFile("/foo"));
 
         checkEquality(fooFile1, fooFile2);
         checkInequality(foo1, fooFile1);
@@ -124,7 +126,7 @@ public class ResourceDescriptorTest
     void sourceNamesDontMatchNewDescriptors()
     {
         ResourceDescriptor desc = ResourceDescriptor.named("name");
-        ResourceDescriptor name = SourceName.forDisplay("name");
+        ResourceDescriptor name = ResourceDescriptor.named("name");
 
         checkInequality(desc, name);
     }

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
@@ -3,6 +3,7 @@
 
 package dev.ionfusion.runtime.base;
 
+import static dev.ionfusion.runtime.base.ResourceIdentifier.forFile;
 import static dev.ionfusion.testing.Assertions.assertHashEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -34,12 +35,12 @@ public class SourceLocationTest
         SourceLocation loc = SourceLocation.forCurrentSpan(ir, null);
         assertNull(loc, "expected null SourceLocation");
 
-        ResourceDescriptor name = SourceName.forDisplay("test source");
+        ResourceDescriptor name = ResourceDescriptor.named("test source");
         loc = SourceLocation.forCurrentSpan(ir, name);
         assertHashEquals(name, loc.getResourceDesc());
         assertEquals("unknown location in test source", loc.display());
 
-        name = SourceName.forFile("/dummy/path");
+        name = ResourceDescriptor.identified(forFile("/dummy/path"));
         loc = SourceLocation.forCurrentSpan(ir, name);
         assertHashEquals(name, loc.getResourceDesc());
         checkPath("/dummy/path", loc);
@@ -52,12 +53,12 @@ public class SourceLocationTest
         assertEquals(expectedOffsets, loc.display());
         assertHashEquals(DEFAULT_DESCRIPTOR, loc.getResourceDesc());
 
-        ResourceDescriptor name = SourceName.forDisplay("test source");
+        ResourceDescriptor name = ResourceDescriptor.named("test source");
         loc = SourceLocation.forCurrentSpan(ir, name);
         assertHashEquals(name, loc.getResourceDesc());
         assertEquals(expectedOffsets + " of test source", loc.display());
 
-        name = SourceName.forFile("/dummy/path");
+        name = ResourceDescriptor.identified(forFile("/dummy/path"));
         loc = SourceLocation.forCurrentSpan(ir, name);
         assertHashEquals(name, loc.getResourceDesc());
         checkPath("/dummy/path", loc);
@@ -145,7 +146,7 @@ public class SourceLocationTest
         loc = SourceLocation.forLineColumn(line, column, null);
         assertNull(loc, "SourceLocation");
 
-        ResourceDescriptor name = SourceName.forDisplay("test source");
+        ResourceDescriptor name = ResourceDescriptor.named("test source");
         loc = SourceLocation.forLineColumn(line, column, name);
         assertHashEquals(name, loc.getResourceDesc());
         checkLocation(loc, null, 0, 0, -1);
@@ -161,7 +162,7 @@ public class SourceLocationTest
         assertHashEquals(DEFAULT_DESCRIPTOR, loc.getResourceDesc());
         checkLocation(loc, display, line, column, -1);
 
-        ResourceDescriptor name = SourceName.forDisplay("test source");
+        ResourceDescriptor name = ResourceDescriptor.named("test source");
         loc = SourceLocation.forLineColumn(line, column, name);
         assertHashEquals(name, loc.getResourceDesc());
         checkLocation(loc, display, line, column, -1);


### PR DESCRIPTION
## Description

These are the last remaining uses of `SourceName`!

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
