### PR TITLE
Remove `SyntaxValue.getLocation()`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/fusion/Compiler.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Compiler.java
@@ -51,7 +51,7 @@ import dev.ionfusion.fusion.TopLevelNamespace.TopLevelDefinedBinding;
 import dev.ionfusion.runtime._private.doc.BindingDoc;
 import dev.ionfusion.runtime._private.doc.BindingDoc.Kind;
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 
 /**
  * "Registers" used during compilation.
@@ -275,27 +275,26 @@ class Compiler
                  throw makeSyntaxError(myEval, "procedure application", message, stx);
             }
 
-            SourceLocation[] argLocs = extractArgLocations(stx,
-                                                           argForms.length);
+            ResourcePosition[] argLocs = extractArgPositions(stx, argForms.length);
             return compilePlainLet(argForms, argLocs, lambda.myBody);
         }
 
         // Look for syntax property forcing argument location tracking.
         if (isVoid(myEval, stx.findProperty(myEval, myStxPropRetainArgLocs)))
         {
-            return new CompiledPlainApp(stx.getLocation(), procForm, argForms);
+            return new CompiledPlainApp(stx.getPosition(), procForm, argForms);
         }
 
-        SourceLocation[] argLocs = extractArgLocations(stx, argForms.length);
+        ResourcePosition[] argLocs = extractArgPositions(stx, argForms.length);
 
-        return new CompiledPlainAppWithLocations(stx.getLocation(), procForm,
+        return new CompiledPlainAppWithLocations(stx.getPosition(), procForm,
                                                  argForms, argLocs);
     }
 
-    private SourceLocation[] extractArgLocations(SyntaxSexp stx, int argCount)
+    private ResourcePosition[] extractArgPositions(SyntaxSexp stx, int argCount)
         throws FusionException
     {
-        SourceLocation[] argLocs = new SourceLocation[argCount];
+        ResourcePosition[] argLocs = new ResourcePosition[argCount];
         Object argSexp = stx.unwrap(myEval);
         for (int i = 0; i < argCount; i++)
         {
@@ -303,7 +302,7 @@ class Compiler
             SyntaxValue argExpr = (SyntaxValue)
                 unsafePairHead(myEval, argSexp);
 
-            argLocs[i] = argExpr.getLocation();
+            argLocs[i] = argExpr.getPosition();
         }
         return argLocs;
     }
@@ -480,8 +479,8 @@ class Compiler
                                                                  b.myAddress);
                 }
 
-                SourceLocation locn = identifier.getLocation();
-                return new CompiledModuleVariableReference(b.myAddress, locn);
+                ResourcePosition posn = identifier.getPosition();
+                return new CompiledModuleVariableReference(b.myAddress, posn);
             }
 
             @Override
@@ -758,15 +757,15 @@ class Compiler
     private static class CompiledPlainApp
         implements CompiledForm
     {
-        private final SourceLocation myLocation;
-        private final CompiledForm   myProcForm;
-        private final CompiledForm[] myArgForms;
+        private final ResourcePosition myPosition;
+        private final CompiledForm     myProcForm;
+        private final CompiledForm[]   myArgForms;
 
-        CompiledPlainApp(SourceLocation location,
-                         CompiledForm   procForm,
-                         CompiledForm[] argForms)
+        CompiledPlainApp(ResourcePosition position,
+                         CompiledForm     procForm,
+                         CompiledForm[]   argForms)
         {
-            myLocation = location;
+            myPosition = position;
             myProcForm = procForm;
             myArgForms = argForms;
         }
@@ -774,14 +773,14 @@ class Compiler
         Object evalArg(Evaluator eval, Store store, int i, CompiledForm arg)
             throws FusionException
         {
-            return eval.eval(store, arg, myLocation);
+            return eval.eval(store, arg, myPosition);
         }
 
         @Override
         public Object doEval(Evaluator eval, Store store)
             throws FusionException
         {
-            Object proc = eval.eval(store, myProcForm, myLocation);
+            Object proc = eval.eval(store, myProcForm, myPosition);
 
             int argCount = myArgForms.length;
 
@@ -824,11 +823,11 @@ class Compiler
                 }
 
                 FusionException fe = new FusionException(b.toString());
-                fe.addContext(myLocation);
+                fe.addContext(myPosition);
                 throw fe;
             }
 
-            return eval.bounceTailCall(myLocation, p, args);
+            return eval.bounceTailCall(myPosition, p, args);
         }
     }
 
@@ -836,22 +835,22 @@ class Compiler
     private static final class CompiledPlainAppWithLocations
         extends CompiledPlainApp
     {
-        private final SourceLocation[] myArgLocs;
+        private final ResourcePosition[] myArgPosns;
 
-        CompiledPlainAppWithLocations(SourceLocation   location,
-                                      CompiledForm     procForm,
-                                      CompiledForm[]   argForms,
-                                      SourceLocation[] argLocs)
+        CompiledPlainAppWithLocations(ResourcePosition   callPosn,
+                                      CompiledForm       procForm,
+                                      CompiledForm[]     argForms,
+                                      ResourcePosition[] argPosns)
         {
-            super(location, procForm, argForms);
-            myArgLocs = argLocs;
+            super(callPosn, procForm, argForms);
+            myArgPosns = argPosns;
         }
 
         @Override
         Object evalArg(Evaluator eval, Store store, int i, CompiledForm arg)
             throws FusionException
         {
-            return eval.eval(store, arg, myArgLocs[i]);
+            return eval.eval(store, arg, myArgPosns[i]);
         }
     }
 

--- a/runtime/src/main/java/dev/ionfusion/fusion/Evaluator.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/Evaluator.java
@@ -37,7 +37,7 @@ import com.amazon.ion.IonValue;
 import com.amazon.ion.Timestamp;
 import com.amazon.ion.system.IonReaderBuilder;
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 import dev.ionfusion.runtime.embed.FusionRuntime;
 import dev.ionfusion.runtime.embed.TopLevel;
 import java.math.BigDecimal;
@@ -508,7 +508,7 @@ class Evaluator
                     }
                     catch (FusionException e)
                     {
-                        e.addContext(tail.myLoc);
+                        e.addContext(tail.myPos);
                         throw e;
                     }
 
@@ -527,7 +527,7 @@ class Evaluator
     }
 
 
-    Object eval(Store store, CompiledForm form, SourceLocation loc)
+    Object eval(Store store, CompiledForm form, ResourcePosition pos)
         throws FusionException
     {
         try
@@ -536,7 +536,7 @@ class Evaluator
         }
         catch (FusionException e)
         {
-            e.addContext(loc);
+            e.addContext(pos);
             throw e;
         }
     }
@@ -553,7 +553,7 @@ class Evaluator
     Object callNonTail(Procedure proc, Object... args)
         throws FusionException
     {
-        SourceLocation callLocation = null;
+        ResourcePosition callPosition = null;
 
         calling: while (true) // GOTO target
         {
@@ -565,7 +565,7 @@ class Evaluator
             }
             catch (FusionException e)
             {
-                e.addContext(callLocation);
+                e.addContext(callPosition);
                 throw e;
             }
 
@@ -587,7 +587,7 @@ class Evaluator
                 {
                     // Imitate a tail-recursive call via GOTO
                     TailCall tail = (TailCall) result;
-                    callLocation = tail.myLoc;
+                    callPosition = tail.myPos;
                     proc = tail.myProc;
                     args = tail.myArgs;
                     continue calling;
@@ -682,13 +682,13 @@ class Evaluator
      */
     private static final class TailCall
     {
-        final SourceLocation myLoc;
-        final Procedure myProc;
+        final ResourcePosition myPos;
+        final Procedure        myProc;
         final Object[]  myArgs;
 
-        TailCall(SourceLocation loc, Procedure proc, Object... args)
+        TailCall(ResourcePosition pos, Procedure proc, Object... args)
         {
-            myLoc  = loc;
+            myPos  = pos;
             myProc = proc;
             myArgs = args;
         }
@@ -716,9 +716,9 @@ class Evaluator
      *
      * @return not null
      */
-    Object bounceTailCall(SourceLocation loc, Procedure proc, Object... args)
+    Object bounceTailCall(ResourcePosition pos, Procedure proc, Object... args)
         throws FusionException
     {
-        return new TailCall(loc, proc, args);
+        return new TailCall(pos, proc, args);
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/LetValuesForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/LetValuesForm.java
@@ -7,7 +7,7 @@ import static dev.ionfusion.fusion.ResultFailure.makeResultError;
 import static dev.ionfusion.fusion.SyntaxSymbol.ensureUniqueIdentifiers;
 
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 import java.util.ArrayList;
 
 final class LetValuesForm
@@ -137,8 +137,8 @@ final class LetValuesForm
         final int numBindingForms = bindingForms.size(eval);
 
         int[] valueCounts = new int[numBindingForms];
-        CompiledForm[]   valueForms = new CompiledForm  [numBindingForms];
-        SourceLocation[] valueLocs  = new SourceLocation[numBindingForms];
+        CompiledForm[]     valueForms = new CompiledForm    [numBindingForms];
+        ResourcePosition[] valuePosns = new ResourcePosition[numBindingForms];
 
         int bindingCount = 0;
         boolean allSingles = true;
@@ -155,7 +155,7 @@ final class LetValuesForm
 
             SyntaxValue boundExpr = binding.get(eval, 1);
             valueForms[i] = comp.compileExpression(env, boundExpr);
-            valueLocs [i] = boundExpr.getLocation();
+            valuePosns[i] = boundExpr.getPosition();
         }
 
         if (bindingCount != 0)
@@ -168,16 +168,16 @@ final class LetValuesForm
 
         if (allSingles)
         {
-            return compilePlainLet(valueForms, valueLocs, body);
+            return compilePlainLet(valueForms, valuePosns, body);
         }
 
         return new CompiledLetValues(bindingCount, valueCounts, valueForms,
-                                     valueLocs, body);
+                                     valuePosns, body);
     }
 
 
-    static CompiledForm compilePlainLet(CompiledForm[]   valueForms,
-                                        SourceLocation[] valueLocs,
+    static CompiledForm compilePlainLet(CompiledForm[]     valueForms,
+                                        ResourcePosition[] valuePosns,
                                         CompiledForm body)
     {
         switch (valueForms.length)
@@ -188,11 +188,11 @@ final class LetValuesForm
                 // let_values are compiled without a local environment.
                 return body;
             case 1:
-                return new CompiledPlainLet1(valueForms, valueLocs, body);
+                return new CompiledPlainLet1(valueForms, valuePosns, body);
             case 2:
-                return new CompiledPlainLet2(valueForms, valueLocs, body);
+                return new CompiledPlainLet2(valueForms, valuePosns, body);
             default:
-                return new CompiledPlainLet (valueForms, valueLocs, body);
+                return new CompiledPlainLet (valueForms, valuePosns, body);
         }
     }
 
@@ -206,16 +206,16 @@ final class LetValuesForm
     private static final class CompiledPlainLet
         implements CompiledForm
     {
-        private final CompiledForm[]   myValueForms;
-        private final SourceLocation[] myValueLocs;
-        private final CompiledForm     myBody;
+        private final CompiledForm[]     myValueForms;
+        private final ResourcePosition[] myValuePosns;
+        private final CompiledForm       myBody;
 
-        CompiledPlainLet(CompiledForm  [] valueForms,
-                         SourceLocation[] valueLocs,
-                         CompiledForm     body)
+        CompiledPlainLet(CompiledForm[]     valueForms,
+                         ResourcePosition[] valuePosns,
+                         CompiledForm       body)
         {
             myValueForms = valueForms;
-            myValueLocs  = valueLocs;
+            myValuePosns = valuePosns;
             myBody       = body;
         }
 
@@ -229,9 +229,9 @@ final class LetValuesForm
 
             for (int i = 0; i < numBindings; i++)
             {
-                CompiledForm   form = myValueForms[i];
-                SourceLocation loc  = myValueLocs [i];
-                Object values = eval.eval(store, form, loc);
+                CompiledForm     form = myValueForms[i];
+                ResourcePosition pos  = myValuePosns[i];
+                Object values = eval.eval(store, form, pos);
                 eval.checkSingleResult(values, "local-binding form");
                 boundValues[i] = values;
             }
@@ -245,16 +245,16 @@ final class LetValuesForm
     private static final class CompiledPlainLet1
         implements CompiledForm
     {
-        private final CompiledForm   myValueForm0;
-        private final SourceLocation myValueLoc0;
-        private final CompiledForm   myBody;
+        private final CompiledForm     myValueForm0;
+        private final ResourcePosition myValuePos0;
+        private final CompiledForm     myBody;
 
-        CompiledPlainLet1(CompiledForm  [] valueForms,
-                          SourceLocation[] valueLocs,
+        CompiledPlainLet1(CompiledForm    [] valueForms,
+                          ResourcePosition[] valuePosns,
                           CompiledForm body)
         {
             myValueForm0 = valueForms[0];
-            myValueLoc0  = valueLocs [0];
+            myValuePos0  = valuePosns[0];
             myBody       = body;
         }
 
@@ -262,7 +262,7 @@ final class LetValuesForm
         public Object doEval(Evaluator eval, Store store)
             throws FusionException
         {
-            Object value = eval.eval(store, myValueForm0, myValueLoc0);
+            Object value = eval.eval(store, myValueForm0, myValuePos0);
             eval.checkSingleResult(value, "local-binding form");
 
             Store localStore = new LocalStore1(store, value);
@@ -274,20 +274,20 @@ final class LetValuesForm
     private static final class CompiledPlainLet2
         implements CompiledForm
     {
-        private final CompiledForm myValueForm0;
-        private final CompiledForm myValueForm1;
-        private final SourceLocation myValueLoc0;
-        private final SourceLocation myValueLoc1;
-        private final CompiledForm myBody;
+        private final CompiledForm     myValueForm0;
+        private final CompiledForm     myValueForm1;
+        private final ResourcePosition myValuePos0;
+        private final ResourcePosition myValuePos1;
+        private final CompiledForm     myBody;
 
-        CompiledPlainLet2(CompiledForm  [] valueForms,
-                          SourceLocation[] valueLocs,
+        CompiledPlainLet2(CompiledForm    [] valueForms,
+                          ResourcePosition[] valuePosns,
                           CompiledForm     body)
         {
             myValueForm0 = valueForms[0];
             myValueForm1 = valueForms[1];
-            myValueLoc0  = valueLocs [0];
-            myValueLoc1  = valueLocs [1];
+            myValuePos0  = valuePosns[0];
+            myValuePos1  = valuePosns[1];
             myBody       = body;
         }
 
@@ -295,10 +295,10 @@ final class LetValuesForm
         public Object doEval(Evaluator eval, Store store)
             throws FusionException
         {
-            Object value0 = eval.eval(store, myValueForm0, myValueLoc0);
+            Object value0 = eval.eval(store, myValueForm0, myValuePos0);
             eval.checkSingleResult(value0, "local-binding form");
 
-            Object value1 = eval.eval(store, myValueForm1, myValueLoc1);
+            Object value1 = eval.eval(store, myValueForm1, myValuePos1);
             eval.checkSingleResult(value1, "local-binding form");
 
             Store localStore = new LocalStore2(store, value0, value1);
@@ -313,24 +313,24 @@ final class LetValuesForm
     private static final class CompiledLetValues
         implements CompiledForm
     {
-        private final int              myBindingCount;
-        private final int[]            myValueCounts;
-        private final CompiledForm[]   myValueForms;
-        private final SourceLocation[] myValueLocns;
-        private final CompiledForm     myBody;
+        private final int                myBindingCount;
+        private final int[]              myValueCounts;
+        private final CompiledForm[]     myValueForms;
+        private final ResourcePosition[] myValuePosns;
+        private final CompiledForm       myBody;
 
-        CompiledLetValues(int              bindingCount,
-                          int[]            valueCounts,
-                          CompiledForm[]   valueForms,
-                          SourceLocation[] valueLocns,
-                          CompiledForm     body)
+        CompiledLetValues(int                bindingCount,
+                          int[]              valueCounts,
+                          CompiledForm[]     valueForms,
+                          ResourcePosition[] valuePosns,
+                          CompiledForm       body)
         {
             assert valueCounts.length == valueForms.length;
 
             myBindingCount = bindingCount;
             myValueCounts  = valueCounts;
             myValueForms   = valueForms;
-            myValueLocns   = valueLocns;
+            myValuePosns   = valuePosns;
             myBody         = body;
         }
 
@@ -345,9 +345,9 @@ final class LetValuesForm
             int bindingPos = 0;
             for (int i = 0; i < numBindingForms; i++)
             {
-                CompiledForm   form = myValueForms[i];
-                SourceLocation locn = myValueLocns[i];
-                Object values = eval.eval(store, form, locn);
+                CompiledForm     form = myValueForms[i];
+                ResourcePosition posn = myValuePosns[i];
+                Object values = eval.eval(store, form, posn);
 
                 int expectedCount = myValueCounts[i];
                 if (expectedCount == 1)

--- a/runtime/src/main/java/dev/ionfusion/fusion/LetrecForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/LetrecForm.java
@@ -7,7 +7,7 @@ import static dev.ionfusion.fusion.FusionValue.UNDEF;
 import static dev.ionfusion.fusion.SyntaxSymbol.ensureUniqueIdentifiers;
 
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 import java.util.Arrays;
 
 final class LetrecForm
@@ -92,15 +92,15 @@ final class LetrecForm
 
         final int numBindings = bindingForms.size(eval);
 
-        CompiledForm  [] valueForms = new CompiledForm  [numBindings];
-        SourceLocation[] valueLocns = new SourceLocation[numBindings];
+        CompiledForm    [] valueForms = new CompiledForm  [numBindings];
+        ResourcePosition[] valuePosns = new ResourcePosition[numBindings];
 
         for (int i = 0; i < numBindings; i++)
         {
             SyntaxSexp binding = (SyntaxSexp) bindingForms.get(eval, i);
             SyntaxValue boundExpr = binding.get(eval, 1);
             valueForms[i] = comp.compileExpression(env, boundExpr);
-            valueLocns[i] = boundExpr.getLocation();
+            valuePosns[i] = boundExpr.getPosition();
         }
 
         CompiledForm body = comp.compileBegin(env, stx, 2);
@@ -110,11 +110,11 @@ final class LetrecForm
             case 0:
                 return body;
             case 1:
-                return new CompiledLetrec1(valueForms, valueLocns, body);
+                return new CompiledLetrec1(valueForms, valuePosns, body);
             case 2:
-                return new CompiledLetrec2(valueForms, valueLocns, body);
+                return new CompiledLetrec2(valueForms, valuePosns, body);
             default:
-                return new CompiledLetrec(valueForms, valueLocns, body);
+                return new CompiledLetrec(valueForms, valuePosns, body);
         }
     }
 
@@ -125,16 +125,16 @@ final class LetrecForm
     private static final class CompiledLetrec
         implements CompiledForm
     {
-        private final CompiledForm[]   myValueForms;
-        private final SourceLocation[] myValueLocns;
-        private final CompiledForm     myBody;
+        private final CompiledForm[]     myValueForms;
+        private final ResourcePosition[] myValuePosns;
+        private final CompiledForm       myBody;
 
-        CompiledLetrec(CompiledForm[]   valueForms,
-                       SourceLocation[] valueLocns,
-                       CompiledForm     body)
+        CompiledLetrec(CompiledForm[]     valueForms,
+                       ResourcePosition[] valuePosns,
+                       CompiledForm       body)
         {
             myValueForms = valueForms;
-            myValueLocns = valueLocns;
+            myValuePosns = valuePosns;
             myBody       = body;
         }
 
@@ -151,9 +151,9 @@ final class LetrecForm
 
             for (int i = 0; i < numBindings; i++)
             {
-                CompiledForm   form = myValueForms[i];
-                SourceLocation locn = myValueLocns[i];
-                boundValues[i] = eval.eval(localStore, form, locn);
+                CompiledForm     form = myValueForms[i];
+                ResourcePosition posn = myValuePosns[i];
+                boundValues[i] = eval.eval(localStore, form, posn);
             }
 
             return eval.bounceTailForm(localStore, myBody);
@@ -164,16 +164,16 @@ final class LetrecForm
     private static final class CompiledLetrec1
         implements CompiledForm
     {
-        private final CompiledForm   myValueForm0;
-        private final SourceLocation myValueLocn0;
-        private final CompiledForm   myBody;
+        private final CompiledForm     myValueForm0;
+        private final ResourcePosition myValuePosn0;
+        private final CompiledForm     myBody;
 
-        CompiledLetrec1(CompiledForm[]   valueForms,
-                        SourceLocation[] valueLocns,
-                        CompiledForm     body)
+        CompiledLetrec1(CompiledForm[]     valueForms,
+                        ResourcePosition[] valuePosns,
+                        CompiledForm       body)
         {
             myValueForm0 = valueForms[0];
-            myValueLocn0 = valueLocns[0];
+            myValuePosn0 = valuePosns[0];
             myBody       = body;
         }
 
@@ -183,7 +183,7 @@ final class LetrecForm
         {
             Store localStore = new LocalStore1(store, UNDEF);
 
-            Object value = eval.eval(localStore, myValueForm0, myValueLocn0);
+            Object value = eval.eval(localStore, myValueForm0, myValuePosn0);
             localStore.set(0, value);
 
             return eval.bounceTailForm(localStore, myBody);
@@ -194,20 +194,20 @@ final class LetrecForm
     private static final class CompiledLetrec2
         implements CompiledForm
     {
-        private final CompiledForm   myValueForm0;
-        private final CompiledForm   myValueForm1;
-        private final SourceLocation myValueLocn0;
-        private final SourceLocation myValueLocn1;
-        private final CompiledForm   myBody;
+        private final CompiledForm     myValueForm0;
+        private final CompiledForm     myValueForm1;
+        private final ResourcePosition myValuePosn0;
+        private final ResourcePosition myValuePosn1;
+        private final CompiledForm     myBody;
 
-        CompiledLetrec2(CompiledForm[]   valueForms,
-                        SourceLocation[] valueLocns,
-                        CompiledForm     body)
+        CompiledLetrec2(CompiledForm[]     valueForms,
+                        ResourcePosition[] valuePosns,
+                        CompiledForm       body)
         {
             myValueForm0 = valueForms[0];
             myValueForm1 = valueForms[1];
-            myValueLocn0 = valueLocns[0];
-            myValueLocn1 = valueLocns[1];
+            myValuePosn0 = valuePosns[0];
+            myValuePosn1 = valuePosns[1];
             myBody       = body;
         }
 
@@ -217,10 +217,10 @@ final class LetrecForm
         {
             Store localStore = new LocalStore2(store, UNDEF, UNDEF);
 
-            Object value = eval.eval(localStore, myValueForm0, myValueLocn0);
+            Object value = eval.eval(localStore, myValueForm0, myValuePosn0);
             localStore.set(0, value);
 
-            value = eval.eval(localStore, myValueForm1, myValueLocn1);
+            value = eval.eval(localStore, myValueForm1, myValuePosn1);
             localStore.set(1, value);
 
             return eval.bounceTailForm(localStore, myBody);

--- a/runtime/src/main/java/dev/ionfusion/fusion/ModuleNamespace.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/ModuleNamespace.java
@@ -13,7 +13,6 @@ import dev.ionfusion.runtime._private.doc.BindingDoc;
 import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ModuleIdentity;
 import dev.ionfusion.runtime.base.ResourcePosition;
-import dev.ionfusion.runtime.base.SourceLocation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -593,13 +592,13 @@ final class ModuleNamespace
     static final class CompiledModuleVariableReference
         implements CompiledForm
     {
-        private final int            myAddress;
-        private final SourceLocation myLocation;
+        private final int              myAddress;
+        private final ResourcePosition myPosition;
 
-        CompiledModuleVariableReference(int address, SourceLocation location)
+        CompiledModuleVariableReference(int address, ResourcePosition position)
         {
             myAddress  = address;
-            myLocation = location;
+            myPosition = position;
         }
 
         @Override
@@ -614,7 +613,7 @@ final class ModuleNamespace
 
             // Synthesize an identifier for stack traces.
             BaseSymbol name = ns.getDefinedName(myAddress);
-            SyntaxSymbol id = SyntaxSymbol.make(myLocation, name);
+            SyntaxSymbol id = SyntaxSymbol.make(myPosition, name);
 
             throw makeUnboundError(id);
         }

--- a/runtime/src/main/java/dev/ionfusion/fusion/QuasiSyntaxForm.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/QuasiSyntaxForm.java
@@ -5,11 +5,12 @@ package dev.ionfusion.fusion;
 
 import static dev.ionfusion.fusion.FusionIo.safeWriteToString;
 import static dev.ionfusion.fusion.FusionList.immutableList;
+
 import dev.ionfusion.fusion.FusionList.BaseList;
 import dev.ionfusion.fusion.FusionSexp.BaseSexp;
 import dev.ionfusion.fusion.FusionSymbol.BaseSymbol;
 import dev.ionfusion.runtime.base.FusionException;
-import dev.ionfusion.runtime.base.SourceLocation;
+import dev.ionfusion.runtime.base.ResourcePosition;
 
 final class QuasiSyntaxForm
     extends QuasiBaseForm
@@ -38,9 +39,9 @@ final class QuasiSyntaxForm
                          CompiledForm unquotedForm)
         throws FusionException
     {
-        SourceLocation location = unquotedStx.getLocation();
+        ResourcePosition position = unquotedStx.getPosition();
         String expression = safeWriteToString(eval, unquotedStx);
-        return new CompiledUnsyntax(unquotedForm, location, expression);
+        return new CompiledUnsyntax(unquotedForm, position, expression);
     }
 
 
@@ -50,10 +51,10 @@ final class QuasiSyntaxForm
                            CompiledForm[] children)
         throws FusionException
     {
-        SourceLocation location    = originalStx.getLocation();
+        ResourcePosition position    = originalStx.getPosition();
         BaseSexp sexp = (BaseSexp) originalStx.unwrap(eval);
         BaseSymbol[] annotations = sexp.getAnnotations();
-        return new CompiledQuasiSyntaxSexp(location, annotations, children);
+        return new CompiledQuasiSyntaxSexp(position, annotations, children);
     }
 
 
@@ -63,10 +64,10 @@ final class QuasiSyntaxForm
                            CompiledForm[] children)
         throws FusionException
     {
-        SourceLocation location    = originalStx.getLocation();
+        ResourcePosition position    = originalStx.getPosition();
         BaseList list = (BaseList) originalStx.unwrap(eval);
         BaseSymbol[] annotations = list.getAnnotations();
-        return new CompiledQuasiSyntaxList(location, annotations, children);
+        return new CompiledQuasiSyntaxList(position, annotations, children);
     }
 
 
@@ -76,16 +77,16 @@ final class QuasiSyntaxForm
     private static final class CompiledQuasiSyntaxSexp
         implements CompiledForm
     {
-        private final SourceLocation myLocation;
-        private final BaseSymbol[]   myAnnotations;
-        private final CompiledForm[] myChildForms;
+        private final ResourcePosition myPosition;
+        private final BaseSymbol[]     myAnnotations;
+        private final CompiledForm[]   myChildForms;
 
-        CompiledQuasiSyntaxSexp(SourceLocation location,
-                                BaseSymbol[]   annotations,
-                                CompiledForm[] childForms)
+        CompiledQuasiSyntaxSexp(ResourcePosition position,
+                                BaseSymbol[]     annotations,
+                                CompiledForm[]   childForms)
         {
             assert childForms.length != 0;
-            myLocation    = location;
+            myPosition    = position;
             myAnnotations = annotations;
             myChildForms  = childForms;
         }
@@ -107,7 +108,7 @@ final class QuasiSyntaxForm
 
             // We don't use copyReplacingChildren because we don't want the
             // properties to come over.
-            return SyntaxSexp.make(eval, myLocation, myAnnotations, children);
+            return SyntaxSexp.make(eval, myPosition, myAnnotations, children);
         }
     }
 
@@ -115,15 +116,15 @@ final class QuasiSyntaxForm
     private static final class CompiledQuasiSyntaxList
         implements CompiledForm
     {
-        private final SourceLocation myLocation;
-        private final BaseSymbol[]   myAnnotations;
-        private final CompiledForm[] myChildForms;
+        private final ResourcePosition myPosition;
+        private final BaseSymbol[]     myAnnotations;
+        private final CompiledForm[]   myChildForms;
 
-        CompiledQuasiSyntaxList(SourceLocation location,
-                                BaseSymbol[]   annotations,
-                                CompiledForm[] childForms)
+        CompiledQuasiSyntaxList(ResourcePosition position,
+                                BaseSymbol[]     annotations,
+                                CompiledForm[]   childForms)
         {
-            myLocation    = location;
+            myPosition    = position;
             myAnnotations = annotations;
             myChildForms  = childForms;
         }
@@ -142,7 +143,7 @@ final class QuasiSyntaxForm
             // We don't use copyReplacingChildren because we don't want the
             // properties to come over.
             Object list = immutableList(eval, myAnnotations, children);
-            return SyntaxList.make(eval, myLocation, list);
+            return SyntaxList.make(eval, myPosition, list);
         }
     }
 
@@ -150,17 +151,17 @@ final class QuasiSyntaxForm
     private static final class CompiledUnsyntax
         implements CompiledForm
     {
-        private final CompiledForm myUnquotedForm;
-        private final SourceLocation myLocation;
-        private final String         myExpression;
+        private final CompiledForm     myUnquotedForm;
+        private final ResourcePosition myPosition;
+        private final String           myExpression;
 
-        CompiledUnsyntax(CompiledForm unquotedForm,
-                         SourceLocation location,
-                         String expression)
+        CompiledUnsyntax(CompiledForm     unquotedForm,
+                         ResourcePosition position,
+                         String           expression)
         {
-            myUnquotedForm   = unquotedForm;
-            myLocation       = location;
-            myExpression     = expression;
+            myUnquotedForm = unquotedForm;
+            myPosition     = position;
+            myExpression   = expression;
         }
 
         @Override
@@ -178,7 +179,7 @@ final class QuasiSyntaxForm
                 "Result of (unsyntax " + myExpression +
                 ") isn't a syntax value: " +
                 safeWriteToString(eval, unquoted);
-            throw new ContractException(message, myLocation);
+            throw new ContractException(message, myPosition);
         }
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/fusion/SyntaxValue.java
+++ b/runtime/src/main/java/dev/ionfusion/fusion/SyntaxValue.java
@@ -12,7 +12,6 @@ import static java.lang.Boolean.TRUE;
 import com.amazon.ion.IonValue;
 import dev.ionfusion.runtime.base.FusionException;
 import dev.ionfusion.runtime.base.ResourcePosition;
-import dev.ionfusion.runtime.base.SourceLocation;
 import java.util.Arrays;
 
 /**
@@ -67,17 +66,6 @@ abstract class SyntaxValue
         return false;
     }
 
-
-    /**
-     * Gets the location associated with this syntax node, if it exists.
-     * @return can be null.
-     */
-    SourceLocation getLocation()
-    {
-        return (myPosition instanceof SourceLocation
-                ? (SourceLocation) myPosition
-                : null);
-    }
 
     /**
      * Gets the resource and position associated with this syntax node, if it exists.


### PR DESCRIPTION
## Description

A bit bulky, but effectively replacing use of `SourceLocation` with `ResourcePosition` by using the `SyntaxValue.getPosition()`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
