### PR TITLE
Update `SourceLocation` factory contract

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceLocation.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceLocation.java
@@ -3,6 +3,8 @@
 
 package dev.ionfusion.runtime.base;
 
+import static java.util.Objects.requireNonNull;
+
 import com.amazon.ion.IonReader;
 import com.amazon.ion.OffsetSpan;
 import com.amazon.ion.TextSpan;
@@ -20,23 +22,17 @@ import java.util.Objects;
 public class SourceLocation
     implements ResourcePosition
 {
-    /**
-     * This descriptor is used by all instances constructed with a null SourceName,
-     * preserving the legacy behavior of this class WRT equals and hashCode.
-     */
-    private static final ResourceDescriptor DISTINCT_UNKNOWN_RESOURCE =
-        ResourceDescriptor.unknown();
-
     /** Not null. */
     private final ResourceDescriptor myResource;
 
 
     /**
-     * @param rsrc null will be replaced by {@link #DISTINCT_UNKNOWN_RESOURCE}.
+     * @param rsrc not null.
      */
     private SourceLocation(ResourceDescriptor rsrc)
     {
-        myResource = (rsrc != null ? rsrc : DISTINCT_UNKNOWN_RESOURCE);
+        assert rsrc != null;
+        myResource = rsrc;
     }
 
 
@@ -178,16 +174,15 @@ public class SourceLocation
 
 
     /**
-     * Returns an instance that represents an unknown location in the given
-     * source.
+     * Returns an instance that represents an unknown location in the given resource.
      *
-     * @param desc can be null.
+     * @param desc must not be null.
      *
-     * @return null when all parameters are unknown.
+     * @return a location with no offsets and the given descriptor.
      */
-    public static SourceLocation forName(ResourceDescriptor desc)
+    public static ResourcePosition forName(ResourceDescriptor desc)
     {
-        if (desc == null) return null;
+        requireNonNull(desc);
 
         // TODO Can this allocation be eliminated?
         //      We'll probably be creating lots of similar instances.
@@ -203,13 +198,15 @@ public class SourceLocation
      * @param column one-based.
      * Values less than 1 indicate that the column is unknown.
      * Ignored if the line is unknown.
-     * @param desc can be null.
+     * @param desc must not be null.
      *
-     * @return null when all parameters are unknown.
+     * @return a location with no offsets and the given descriptor.
      */
-    public static SourceLocation forLineColumn(long line, long column,
-                                               ResourceDescriptor desc)
+    public static ResourcePosition forLineColumn(long line, long column,
+                                                 ResourceDescriptor desc)
     {
+        requireNonNull(desc);
+
         if (line < 1)
         {
             return forName(desc);
@@ -235,37 +232,20 @@ public class SourceLocation
 
 
     /**
-     * Returns an instance that represents the given text location.
-     *
-     * @param line one-based.
-     * Values less than 1 indicate that the line is unknown.
-     * @param column one-based.
-     * Values less than 1 indicate that the column is unknown.
-     * Ignored if the line is unknown.
-     *
-     * @return null when all parameters are unknown.
-     */
-    public static SourceLocation forLineColumn(long line, long column)
-    {
-        return forLineColumn(line, column, null);
-    }
-
-
-    /**
      * Returns an instance that represents the current span of the reader.
      * This currently only supports Ion text sources and only captures the
      * start position.
      *
      * @param source must not be null.
-     * @param desc can be null.
+     * @param desc must not be null.
      *
-     *
-     * @return null if no descriptor is given and no location could be determined from
-     * the source.
+     * @return a location with current span's offsets and the given descriptor.
      */
-    public static SourceLocation forCurrentSpan(IonReader  source,
-                                                ResourceDescriptor desc)
+    public static ResourcePosition forCurrentSpan(IonReader  source,
+                                                  ResourceDescriptor desc)
     {
+        requireNonNull(desc);
+
         // SpanProvider.currentSpan() crashes if not on a value.
         if (source.getType() != null)
         {

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
@@ -6,24 +6,19 @@ package dev.ionfusion.runtime.base;
 import static dev.ionfusion.runtime.base.ResourceIdentifier.forFile;
 import static dev.ionfusion.testing.Assertions.assertHashEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.amazon.ion.IonDatagram;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonSystem;
+import com.amazon.ion.system.IonReaderBuilder;
 import com.amazon.ion.system.IonSystemBuilder;
 import org.junit.jupiter.api.Test;
 
 
 public class SourceLocationTest
 {
-    /**
-     * SourceLocation uses a distinct descriptor when one isn't given.
-     */
-    private static final ResourceDescriptor DEFAULT_DESCRIPTOR =
-        SourceLocation.forLineColumn(1, 1).getResourceDesc();
-
-
     private void checkPath(String path, ResourcePosition pos)
     {
         assertHashEquals(ResourceIdentifier.forFile(path),
@@ -32,36 +27,33 @@ public class SourceLocationTest
 
     private void assertNoLocation(IonReader ir)
     {
-        SourceLocation loc = SourceLocation.forCurrentSpan(ir, null);
-        assertNull(loc, "expected null SourceLocation");
-
-        ResourceDescriptor name = ResourceDescriptor.named("test source");
-        loc = SourceLocation.forCurrentSpan(ir, name);
-        assertHashEquals(name, loc.getResourceDesc());
+        ResourceDescriptor desc = ResourceDescriptor.named("test source");
+        ResourcePosition loc = SourceLocation.forCurrentSpan(ir, desc);
+        assertSame(desc, loc.getResourceDesc());
         assertEquals("unknown position of test source", loc.display());
 
-        name = ResourceDescriptor.identified(forFile("/dummy/path"));
-        loc = SourceLocation.forCurrentSpan(ir, name);
-        assertHashEquals(name, loc.getResourceDesc());
+        desc = ResourceDescriptor.identified(forFile("/dummy/path"));
+        loc = SourceLocation.forCurrentSpan(ir, desc);
+        assertSame(desc, loc.getResourceDesc());
         checkPath("/dummy/path", loc);
         assertEquals("unknown position of /dummy/path", loc.display());
     }
 
     private void assertLocation(String expectedOffsets, IonReader ir)
     {
-        SourceLocation loc = SourceLocation.forCurrentSpan(ir, null);
+        ResourceDescriptor desc = ResourceDescriptor.unknown();
+        ResourcePosition loc = SourceLocation.forCurrentSpan(ir, desc);
+        assertSame(desc, loc.getResourceDesc());
         assertEquals(expectedOffsets, loc.display());
-        assertHashEquals(DEFAULT_DESCRIPTOR, loc.getResourceDesc());
 
-        ResourceDescriptor name = ResourceDescriptor.named("test source");
-        loc = SourceLocation.forCurrentSpan(ir, name);
-        assertHashEquals(name, loc.getResourceDesc());
+        desc = ResourceDescriptor.named("test source");
+        loc = SourceLocation.forCurrentSpan(ir, desc);
+        assertSame(desc, loc.getResourceDesc());
         assertEquals(expectedOffsets + " of test source", loc.display());
 
-        name = ResourceDescriptor.identified(forFile("/dummy/path"));
-        loc = SourceLocation.forCurrentSpan(ir, name);
-        assertHashEquals(name, loc.getResourceDesc());
-        checkPath("/dummy/path", loc);
+        desc = ResourceDescriptor.identified(forFile("/dummy/path"));
+        loc = SourceLocation.forCurrentSpan(ir, desc);
+        assertSame(desc, loc.getResourceDesc());
         assertEquals(expectedOffsets + " of /dummy/path", loc.display());
     }
 
@@ -140,31 +132,27 @@ public class SourceLocationTest
 
     private void assertNoLineColumn(long line, long column)
     {
-        SourceLocation loc = SourceLocation.forLineColumn(line, column);
-        assertNull(loc, "SourceLocation");
+        ResourceDescriptor desc = ResourceDescriptor.unknown();
+        ResourcePosition loc = SourceLocation.forLineColumn(line, column, desc);
+        assertSame(desc, loc.getResourceDesc());
+        checkLocation(loc, null, 0, 0, -1);
 
-        loc = SourceLocation.forLineColumn(line, column, null);
-        assertNull(loc, "SourceLocation");
-
-        ResourceDescriptor name = ResourceDescriptor.named("test source");
-        loc = SourceLocation.forLineColumn(line, column, name);
-        assertHashEquals(name, loc.getResourceDesc());
+        desc = ResourceDescriptor.named("test source");
+        loc = SourceLocation.forLineColumn(line, column, desc);
+        assertSame(desc, loc.getResourceDesc());
         checkLocation(loc, null, 0, 0, -1);
     }
 
     private void assertLineColumn(String display, long line, long column)
     {
-        SourceLocation loc = SourceLocation.forLineColumn(line, column);
-        assertHashEquals(DEFAULT_DESCRIPTOR, loc.getResourceDesc());
+        ResourceDescriptor desc = ResourceDescriptor.unknown();
+        ResourcePosition loc = SourceLocation.forLineColumn(line, column, desc);
+        assertSame(desc, loc.getResourceDesc());
         checkLocation(loc, display, line, column, -1);
 
-        loc = SourceLocation.forLineColumn(line, column, null);
-        assertHashEquals(DEFAULT_DESCRIPTOR, loc.getResourceDesc());
-        checkLocation(loc, display, line, column, -1);
-
-        ResourceDescriptor name = ResourceDescriptor.named("test source");
-        loc = SourceLocation.forLineColumn(line, column, name);
-        assertHashEquals(name, loc.getResourceDesc());
+        desc = ResourceDescriptor.named("test source");
+        loc = SourceLocation.forLineColumn(line, column, desc);
+        assertSame(desc, loc.getResourceDesc());
         checkLocation(loc, display, line, column, -1);
     }
 
@@ -184,5 +172,34 @@ public class SourceLocationTest
         assertLineColumn("1st line",  1,  0);
         assertLineColumn("2nd line",  2, -1);
         assertLineColumn("3rd line, 4th column",  3, 4);
+    }
+
+
+    @Test
+    void forNameRequiresDescriptor()
+        throws Exception
+    {
+        assertThrows(NullPointerException.class,
+                     () -> SourceLocation.forName(null));
+    }
+
+    @Test
+    void forLineColumnRequiresDescriptor()
+        throws Exception
+    {
+        assertThrows(NullPointerException.class,
+                     () -> SourceLocation.forLineColumn(1, 2, null));
+    }
+
+    @Test
+    void forCurrentSpanRequiresDescriptor()
+        throws Exception
+    {
+        IonReaderBuilder builder = IonReaderBuilder.standard();
+        try (IonReader reader = builder.build("{}"))
+        {
+            assertThrows(NullPointerException.class,
+                         () -> SourceLocation.forCurrentSpan(reader, null));
+        }
     }
 }


### PR DESCRIPTION
All factory methods require a `ResourceDescriptor` and return a non-null `ResourcePosition`.

## Description

This unblocks migration to the new types.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
