### PR TITLE
Lift `SourceLocation` impl into `ResourcePosition`

### DIFF
--- a/runtime/src/main/java/dev/ionfusion/runtime/base/BaseResourcePosition.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/BaseResourcePosition.java
@@ -1,0 +1,88 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+import java.util.Objects;
+
+class BaseResourcePosition
+    implements ResourcePosition
+{
+    private final ResourceDescriptor myDescriptor;
+
+    BaseResourcePosition(ResourceDescriptor desc)
+    {
+        Objects.requireNonNull(desc, "desc");
+        myDescriptor = desc;
+    }
+
+
+    @Override
+    public final ResourceDescriptor getResourceDesc()
+    {
+        return myDescriptor;
+    }
+
+    @Override
+    public long getLine()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getColumn()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getOffset()
+    {
+        return -1;
+    }
+
+
+    /**
+     * Returns a view of this object suitable for debugging. For displaying messages to
+     * users, use {@link #display()} instead.
+     */
+    @Override
+    public String toString()
+    {
+        return display();
+    }
+
+    public boolean equals(ResourcePosition that)
+    {
+        return (this == that ||
+                (that != null &&
+                 myDescriptor.equals(that.getResourceDesc()) &&
+                 this.getLine() == that.getLine() &&
+                 this.getColumn() == that.getColumn() &&
+                 this.getOffset() == that.getOffset()));
+    }
+
+    @Override
+    public boolean equals(Object that)
+    {
+        return that instanceof ResourcePosition && this.equals((ResourcePosition) that);
+    }
+
+
+    private static final int HASH_SEED = BaseResourcePosition.class.hashCode();
+
+    @Override
+    public int hashCode()
+    {
+        final int prime  = 8191;
+        int       result = HASH_SEED + myDescriptor.hashCode();
+        result ^= (result << 29) ^ (result >> 3);
+        result = prime * result + (int) getLine();
+        result ^= (result << 29) ^ (result >> 3);
+        result = prime * result + (int) getColumn();
+        result ^= (result << 29) ^ (result >> 3);
+        result = prime * result + (int) getOffset();
+        result ^= (result << 29) ^ (result >> 3);
+        return result;
+    }
+}

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/IntResourcePosition.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/IntResourcePosition.java
@@ -1,0 +1,38 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+final class IntResourcePosition
+    extends BaseResourcePosition
+{
+    private final int myLine;
+    private final int myColumn;
+    private final int myOffset;
+
+    IntResourcePosition(ResourceDescriptor desc, int line, int column, int offset)
+    {
+        super(desc);
+        myLine   = line;
+        myColumn = column;
+        myOffset = offset;
+    }
+
+    @Override
+    public long getLine()
+    {
+        return myLine;
+    }
+
+    @Override
+    public long getColumn()
+    {
+        return myColumn;
+    }
+
+    @Override
+    public long getOffset()
+    {
+        return myOffset;
+    }
+}

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/LongResourcePosition.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/LongResourcePosition.java
@@ -1,0 +1,38 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+final class LongResourcePosition
+    extends BaseResourcePosition
+{
+    private final long myLine;
+    private final long myColumn;
+    private final long myOffset;
+
+    LongResourcePosition(ResourceDescriptor desc, long line, long column, long offset)
+    {
+        super(desc);
+        myLine   = line;
+        myColumn = column;
+        myOffset = offset;
+    }
+
+    @Override
+    public long getLine()
+    {
+        return myLine;
+    }
+
+    @Override
+    public long getColumn()
+    {
+        return myColumn;
+    }
+
+    @Override
+    public long getOffset()
+    {
+        return myOffset;
+    }
+}

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ResourcePosition.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ResourcePosition.java
@@ -4,12 +4,17 @@
 package dev.ionfusion.runtime.base;
 
 import static dev.ionfusion.runtime._private.util.Ordinals.displayFriendlyPosition;
+import static java.util.Objects.requireNonNull;
 
+import com.amazon.ion.IonReader;
+import com.amazon.ion.OffsetSpan;
+import com.amazon.ion.TextSpan;
+import com.amazon.ion.util.Spans;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
 /**
- * A specific location within some resource.
+ * A specific offset and/or line and column within some resource.
  * <p>
  * Because Fusion is oriented around Ion data, these locations have semantics aligned
  * with {@link com.amazon.ion.TextSpan} and {@link com.amazon.ion.OffsetSpan}.
@@ -90,5 +95,122 @@ public interface ResourcePosition
             throw new UncheckedIOException(e);
         }
         return out.toString();
+    }
+
+
+    //==================================================================================
+    // Factories
+
+    /**
+     * Returns an instance representing an unknown position in the given resource.
+     *
+     * @param desc must not be null.
+     *
+     * @return an instance with the given descriptor and no position.
+     */
+    static ResourcePosition unknown(ResourceDescriptor desc)
+    {
+        requireNonNull(desc);
+
+        // TODO Consider reducing allocation by memoizing into a descriptor attribute.
+        //      These will be allocated frequently when "reading" a DOM.
+        return new BaseResourcePosition(desc);
+    }
+
+
+    /**
+     * Returns an instance representing the given position in the resource.
+     *
+     * @param desc must not be null.
+     * @param line one-based.
+     * Values less than 1 indicate that the line is unknown.
+     * @param column one-based.
+     * Values less than 1 indicate that the column is unknown.
+     * Ignored if the line is unknown.
+     * @param offset zero-based.
+     * Values less than 0 indicate that the offset is unknown.
+     *
+     * @return an instance with the given descriptor and position.
+     */
+    static ResourcePosition forPosition(ResourceDescriptor desc,
+                                        long line,
+                                        long column,
+                                        long offset)
+    {
+        requireNonNull(desc);
+
+        if (line < 1)
+        {
+            if (offset < 0)
+            {
+                return unknown(desc);
+            }
+
+            line = 0; // normalize
+            column = 0;
+        }
+        else if (column < 0)
+        {
+            column = 0;
+        }
+
+        if (line <= Short.MAX_VALUE &&
+            column <= Short.MAX_VALUE &&
+            offset <= Short.MAX_VALUE)
+        {
+            return new ShortResourcePosition(desc, (short) line, (short) column,
+                                             (short) offset);
+        }
+
+        if (line <= Integer.MAX_VALUE &&
+            column <= Integer.MAX_VALUE &&
+            offset <= Integer.MAX_VALUE)
+        {
+            return new IntResourcePosition(desc, (int) line, (int) column,
+                                           (int) offset);
+        }
+
+        return new LongResourcePosition(desc, line, column, offset);
+    }
+
+
+    /**
+     * Returns an instance representing the current span of the reader. This captures
+     * the span's start position, not the full span.
+     *
+     * @param desc must not be null.
+     * @param reader must not be null.
+     *
+     * @return an instance with the given descriptor and the reader's current position.
+     */
+    public static ResourcePosition forCurrentSpan(ResourceDescriptor desc,
+                                                  IonReader reader)
+    {
+        requireNonNull(desc);
+
+        // SpanProvider.currentSpan() crashes if not on a value.
+        if (reader.getType() == null)
+        {
+            return unknown(desc);
+        }
+
+        long line   = 0;
+        long column = 0;
+        long offset = -1;
+
+        TextSpan ts = Spans.currentSpan(TextSpan.class, reader);
+        if (ts != null)
+        {
+            line   = ts.getStartLine();
+            column = ts.getStartColumn();
+        }
+
+        OffsetSpan os = Spans.currentSpan(OffsetSpan.class, reader);
+        if (os != null)
+        {
+            offset = os.getStartOffset();
+        }
+
+        return forPosition(desc, line, column, offset);
     }
 }

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/ShortResourcePosition.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/ShortResourcePosition.java
@@ -1,0 +1,41 @@
+// Copyright Ion Fusion contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.ionfusion.runtime.base;
+
+final class ShortResourcePosition
+    extends BaseResourcePosition
+{
+    private final short myLine;
+    private final short myColumn;
+    private final short myOffset;
+
+    ShortResourcePosition(ResourceDescriptor desc,
+                          short line,
+                          short column,
+                          short offset)
+    {
+        super(desc);
+        myLine   = line;
+        myColumn = column;
+        myOffset = offset;
+    }
+
+    @Override
+    public long getLine()
+    {
+        return myLine;
+    }
+
+    @Override
+    public long getColumn()
+    {
+        return myColumn;
+    }
+
+    @Override
+    public long getOffset()
+    {
+        return myOffset;
+    }
+}

--- a/runtime/src/main/java/dev/ionfusion/runtime/base/SourceLocation.java
+++ b/runtime/src/main/java/dev/ionfusion/runtime/base/SourceLocation.java
@@ -3,13 +3,7 @@
 
 package dev.ionfusion.runtime.base;
 
-import static java.util.Objects.requireNonNull;
-
 import com.amazon.ion.IonReader;
-import com.amazon.ion.OffsetSpan;
-import com.amazon.ion.TextSpan;
-import com.amazon.ion.util.Spans;
-import java.util.Objects;
 
 
 /**
@@ -20,157 +14,8 @@ import java.util.Objects;
  * {@link com.amazon.ion.OffsetSpan}.
  */
 public class SourceLocation
-    implements ResourcePosition
 {
-    /** Not null. */
-    private final ResourceDescriptor myResource;
-
-
-    /**
-     * @param rsrc not null.
-     */
-    private SourceLocation(ResourceDescriptor rsrc)
-    {
-        assert rsrc != null;
-        myResource = rsrc;
-    }
-
-
-    @Override
-    public ResourceDescriptor getResourceDesc()
-    {
-        return myResource;
-    }
-
-
-    @Override
-    public long getLine()
-    {
-        return 0;
-    }
-
-    @Override
-    public long getColumn()
-    {
-        return 0;
-    }
-
-    @Override
-    public long getOffset()
-    {
-        return -1;
-    }
-
-
-    //==================================================================================
-    // Concrete implementations
-
-    private static final class Shorts
-        extends SourceLocation
-    {
-        private final short myLine;
-        private final short myColumn;
-        private final short myOffset;
-
-        private Shorts(ResourceDescriptor name, short line, short column, short offset)
-        {
-            super(name);
-            myLine = line;
-            myColumn = column;
-            myOffset = offset;
-        }
-
-        @Override
-        public long getLine()
-        {
-            return myLine;
-        }
-
-        @Override
-        public long getColumn()
-        {
-            return myColumn;
-        }
-
-        @Override
-        public long getOffset()
-        {
-            return myOffset;
-        }
-    }
-
-
-    private static final class Ints
-        extends SourceLocation
-    {
-        private final int myLine;
-        private final int myColumn;
-        private final int myOffset;
-
-        private Ints(ResourceDescriptor name, int line, int column, int offset)
-        {
-            super(name);
-            myLine   = line;
-            myColumn = column;
-            myOffset = offset;
-        }
-
-        @Override
-        public long getLine()
-        {
-            return myLine;
-        }
-
-        @Override
-        public long getColumn()
-        {
-            return myColumn;
-        }
-
-        @Override
-        public long getOffset()
-        {
-            return myOffset;
-        }
-    }
-
-
-    private static final class Longs
-        extends SourceLocation
-    {
-        private final long myLine;
-        private final long myColumn;
-        private final long myOffset;
-
-        private Longs(ResourceDescriptor name, long line, long column, long offset)
-        {
-            super(name);
-            myLine   = line;
-            myColumn = column;
-            myOffset = offset;
-        }
-
-        @Override
-        public long getLine()
-        {
-            return myLine;
-        }
-
-        @Override
-        public long getColumn()
-        {
-            return myColumn;
-        }
-
-        @Override
-        public long getOffset()
-        {
-            return myOffset;
-        }
-    }
-
-
-    //==================================================================================
+    private SourceLocation() {}
 
 
     /**
@@ -182,11 +27,7 @@ public class SourceLocation
      */
     public static ResourcePosition forName(ResourceDescriptor desc)
     {
-        requireNonNull(desc);
-
-        // TODO Can this allocation be eliminated?
-        //      We'll probably be creating lots of similar instances.
-        return new SourceLocation(desc);
+        return ResourcePosition.unknown(desc);
     }
 
 
@@ -205,29 +46,7 @@ public class SourceLocation
     public static ResourcePosition forLineColumn(long line, long column,
                                                  ResourceDescriptor desc)
     {
-        requireNonNull(desc);
-
-        if (line < 1)
-        {
-            return forName(desc);
-        }
-
-        if (column < 0)
-        {
-            column = 0;
-        }
-
-        if (line <= Short.MAX_VALUE && column <= Short.MAX_VALUE)
-        {
-            return new Shorts(desc, (short) line, (short) column, (short) -1);
-        }
-
-        if (line <= Integer.MAX_VALUE && column <= Integer.MAX_VALUE)
-        {
-            return new Ints(desc, (int) line, (int) column, -1);
-        }
-
-        return new Longs(desc, line, column, -1);
+        return ResourcePosition.forPosition(desc, line, column, -1);
     }
 
 
@@ -244,86 +63,6 @@ public class SourceLocation
     public static ResourcePosition forCurrentSpan(IonReader  source,
                                                   ResourceDescriptor desc)
     {
-        requireNonNull(desc);
-
-        // SpanProvider.currentSpan() crashes if not on a value.
-        if (source.getType() != null)
-        {
-            TextSpan   ts = Spans.currentSpan(TextSpan.class, source);
-            OffsetSpan os = Spans.currentSpan(OffsetSpan.class, source);
-
-            if (ts != null)
-            {
-                long line   = ts.getStartLine();
-                long column = ts.getStartColumn();
-                long offset = os.getStartOffset();
-
-                if (line <= Short.MAX_VALUE &&
-                    column <= Short.MAX_VALUE &&
-                    offset <= Short.MAX_VALUE)
-                {
-                    return new Shorts(desc, (short) line, (short) column,
-                                      (short) offset);
-                }
-
-                if (line <= Integer.MAX_VALUE &&
-                    column <= Integer.MAX_VALUE &&
-                    offset <= Integer.MAX_VALUE)
-                {
-                    return new Ints(desc, (int) line, (int) column, (int) offset);
-                }
-
-                return new Longs(desc, line, column, offset);
-            }
-        }
-
-        return forName(desc);
-    }
-
-
-    /**
-     * Returns a view of this object suitable for debugging.
-     * For displaying messages to users, use {@link #display()} instead.
-     */
-    @Override
-    public String toString()
-    {
-        return display();
-    }
-
-
-    public boolean equals(ResourcePosition that)
-    {
-        return (this == that
-                || (that != null
-                    && this.myResource.equals(that.getResourceDesc())
-                    && this.getLine()   == that.getLine()
-                    && this.getColumn() == that.getColumn()
-                    && this.getOffset() == that.getOffset()));
-    }
-
-    @Override
-    public boolean equals(Object that)
-    {
-        return that instanceof ResourcePosition &&
-               this.equals((ResourcePosition) that);
-    }
-
-
-    private static final int HASH_SEED = SourceLocation.class.hashCode();
-
-    @Override
-    public int hashCode()
-    {
-        final int prime = 8191;
-        int result = HASH_SEED + Objects.hashCode(myResource);
-        result ^= (result << 29) ^ (result >> 3);
-        result = prime * result + (int) getLine();
-        result ^= (result << 29) ^ (result >> 3);
-        result = prime * result + (int) getColumn();
-        result ^= (result << 29) ^ (result >> 3);
-        result = prime * result + (int) getOffset();
-        result ^= (result << 29) ^ (result >> 3);
-        return result;
+        return ResourcePosition.forCurrentSpan(desc, source);
     }
 }

--- a/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
+++ b/runtime/src/test/java/dev/ionfusion/runtime/base/SourceLocationTest.java
@@ -5,6 +5,8 @@ package dev.ionfusion.runtime.base;
 
 import static dev.ionfusion.runtime.base.ResourceIdentifier.forFile;
 import static dev.ionfusion.testing.Assertions.assertHashEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -37,6 +39,20 @@ public class SourceLocationTest
         assertSame(desc, loc.getResourceDesc());
         checkPath("/dummy/path", loc);
         assertEquals("unknown position of /dummy/path", loc.display());
+    }
+
+    private void assertNoLineColumn(IonReader ir)
+    {
+        ResourceDescriptor desc = ResourceDescriptor.named("test source");
+        ResourcePosition loc = SourceLocation.forCurrentSpan(ir, desc);
+        assertSame(desc, loc.getResourceDesc());
+        assertThat(loc.display(), matchesPattern("offset [0-9]+ of test source"));
+
+        desc = ResourceDescriptor.identified(forFile("/dummy/path"));
+        loc = SourceLocation.forCurrentSpan(ir, desc);
+        assertSame(desc, loc.getResourceDesc());
+        checkPath("/dummy/path", loc);
+        assertThat(loc.display(), matchesPattern("offset [0-9]+ of /dummy/path"));
     }
 
     private void assertLocation(String expectedOffsets, IonReader ir)
@@ -72,10 +88,13 @@ public class SourceLocationTest
         assertNoLocation(ir);  // Before first value
 
         ir.next();
-        assertNoLocation(ir);
+        assertNoLineColumn(ir); // On sexp
 
         ir.stepIn();
         assertNoLocation(ir);  // Before first child
+
+        ir.next();
+        assertNoLineColumn(ir); // On symbol
 
 
         // Text reader gives line/column locations


### PR DESCRIPTION
## Description

In contrast to `ResourceDescriptor` having its concrete classes nested inside `ResourceDescriptorImpl`, here we have individual files.  The former is a vestigial design from when I wasn't sure how this whole thing would work out, but this is cleaner and I'll migrate the other to match later.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
